### PR TITLE
Use watchers to drastically speed up the community site build. case 3280332

### DIFF
--- a/.config/configstore/update-notifier-nodemon.json
+++ b/.config/configstore/update-notifier-nodemon.json
@@ -1,0 +1,4 @@
+{
+	"optOut": false,
+	"lastUpdateCheck": 1516042836054
+}

--- a/models/user.coffee
+++ b/models/user.coffee
@@ -6,8 +6,10 @@ field it will be cached based on the id. If the id already
 exists in the cache the same reference to that model will be
 returned.
 
-If the id property is not given the model is not cached.hi
+If the id property is not given the model is not cached.
 ###
+
+console.log "hi"
 
 isuuid = require 'isuuid'
 _ = require 'underscore'

--- a/models/user.coffee
+++ b/models/user.coffee
@@ -6,7 +6,7 @@ field it will be cached based on the id. If the id already
 exists in the cache the same reference to that model will be
 returned.
 
-If the id property is not given the model is not cached.
+If the id property is not given the model is not cached.hi
 ###
 
 isuuid = require 'isuuid'

--- a/models/user.coffee
+++ b/models/user.coffee
@@ -9,8 +9,6 @@ returned.
 If the id property is not given the model is not cached.
 ###
 
-console.log "hi"
-
 isuuid = require 'isuuid'
 _ = require 'underscore'
 axios = require 'axios'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "babel-polyfill": "^6.26.0",
     "coffeescript": "2.0.0",
     "request": "^2.83.0",
-    "request-promise": "^4.2.2"
+    "request-promise": "^4.2.2",
+    "watchify": "^3.9.0",
+    "nodemon": "^1.14.11"
   },
   "engines": {
     "node": "8.x"

--- a/sh/compile-jade.sh
+++ b/sh/compile-jade.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jadelet -d templates -r "require('jadelet')"

--- a/sh/compile-jade.sh
+++ b/sh/compile-jade.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jadelet -d templates -r "require('jadelet')"
+jadelet -d templates -r "require('jadelet')" | grep -v "\(no changes\)"

--- a/sh/rebuild-client.sh
+++ b/sh/rebuild-client.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
 set -e
 
-browserify client.js > public/client.js
-
-uglifyjs public/client.js \
-  --compress \
-  --mangle \
-  --screw-ie8 \
-  > public/client.min.js.tmp
-
-mv -f public/client.min.js.tmp public/client.min.js
+touch client.js

--- a/sh/start.sh
+++ b/sh/start.sh
@@ -4,17 +4,6 @@ set -e
 # json file cache:
 mkdir -p cache
 
-coffee --watch --transpile --compile . &
-nodemon --exec "bash sh/compile-jade.sh" --ext jade &
-watchify client.js -o public/client.js -v &
-nodemon --exec "bash sh/uglify.sh" --watch public/client.js
-stylus \
-  --watch \
-  --use autoprefixer-stylus \
-  --sourcemap \
-  --compress public/styles.styl \
-  --out public/styles.css \
-  &
-
+bash sh/watchers.sh &  
 
 nodemon --exec "coffee server.coffee" --watch server.coffee --watch routes.coffee

--- a/sh/start.sh
+++ b/sh/start.sh
@@ -1,30 +1,20 @@
 #!/bin/bash
 set -e
 
-# jadelet cache:
+# json file cache:
 mkdir -p cache
 
-if [[ $ENVIRONMENT = 'production' ]]; then
-  (
-    echo "💟 environment is in production mode"
-    jadelet -d templates -r "require('jadelet')"
-    coffee  --transpile --compile .
-    browserify client.js -o public/client.js
-    uglifyjs public/client.js \
-      --compress \
-      --mangle \
-      --screw-ie8 \
-      > public/client.min.js
+coffee --watch --transpile --compile . &
+nodemon --exec "bash sh/compile-jade.sh" --ext jade &
+watchify client.js -o public/client.js -v &
+nodemon --exec "bash sh/uglify.sh" --watch public/client.js
+stylus \
+  --watch \
+  --use autoprefixer-stylus \
+  --sourcemap \
+  --compress public/styles.styl \
+  --out public/styles.css \
+  &
 
-    stylus \
-      --use autoprefixer-stylus \
-      --sourcemap \
-      --compress public/styles.styl \
-      --out public/styles.css
-  )
-else
-  echo "🚒 environment is in development mode"
-  bash sh/watchers.sh &  
-fi
 
 nodemon --exec "coffee server.coffee" --watch server.coffee --watch routes.coffee

--- a/sh/uglify.sh
+++ b/sh/uglify.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+uglifyjs public/client.js \
+      --compress \
+      --mangle \
+      --screw-ie8 \
+      > public/client.min.js

--- a/sh/uglify.sh
+++ b/sh/uglify.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+echo "uglification underway"
 uglifyjs public/client.js \
       --compress \
       --mangle \

--- a/sh/uglify.sh
+++ b/sh/uglify.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-echo "uglification underway"
 uglifyjs public/client.js \
       --compress \
       --mangle \

--- a/sh/watchers.sh
+++ b/sh/watchers.sh
@@ -3,7 +3,7 @@ set -e
 
 coffee --watch --transpile --compile . &
 nodemon --exec "bash sh/compile-jade.sh" --ext jade &
-nodemon --exec "bash sh/uglify.sh"
+nodemon --exec "bash sh/uglify.sh" --watch public/client.js
 watchify client.js -o public/client.js &
 stylus \
   --watch \

--- a/sh/watchers.sh
+++ b/sh/watchers.sh
@@ -3,7 +3,7 @@ set -e
 
 coffee --watch --transpile --compile . &
 nodemon --exec "bash sh/compile-jade.sh" --ext jade &
-watchify client.js -o public/client.js &
+watchify client.js -o public/client.js -v &
 nodemon --exec "bash sh/uglify.sh" --watch public/client.js
 stylus \
   --watch \

--- a/sh/watchers.sh
+++ b/sh/watchers.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+coffee --watch --transpile --compile . &
+nodemon --exec "bash sh/compile-jade.sh" --ext jade &
+nodemon --exec "bash sh/uglify.sh"
+watchify client.js -o public/client.js &
+stylus \
+  --watch \
+  --use autoprefixer-stylus \
+  --sourcemap \
+  --compress public/styles.styl \
+  --out public/styles.css \
+  &
+
+wait

--- a/sh/watchers.sh
+++ b/sh/watchers.sh
@@ -3,8 +3,8 @@ set -e
 
 coffee --watch --transpile --compile . &
 nodemon --exec "bash sh/compile-jade.sh" --ext jade &
-nodemon --exec "bash sh/uglify.sh" --watch public/client.js
 watchify client.js -o public/client.js &
+nodemon --exec "bash sh/uglify.sh" --watch public/client.js
 stylus \
   --watch \
   --use autoprefixer-stylus \

--- a/sh/watchers.sh
+++ b/sh/watchers.sh
@@ -4,7 +4,7 @@ set -e
 coffee --watch --transpile --compile . &
 nodemon --exec "bash sh/compile-jade.sh" --ext jade &
 watchify client.js -o public/client.js -v &
-nodemon --exec "bash sh/uglify.sh" --watch public/client.js
+nodemon --delay 2.5 --exec "bash sh/uglify.sh" --watch public/client.js
 stylus \
   --watch \
   --use autoprefixer-stylus \
@@ -12,5 +12,5 @@ stylus \
   --compress public/styles.styl \
   --out public/styles.css \
   &
-
+  
 wait

--- a/watch.json
+++ b/watch.json
@@ -12,10 +12,7 @@
     ],
     "include": [
       "^sh/start.sh$",
-      "\\.coffee$",
-      "\\.jade",
-      "\\.json",
-      "\\.styl"
+      "\\.json"
     ]
   },
   "throttle": 100


### PR DESCRIPTION
We're able to use watchers everywhere, which not only speeds up the build substantially but also makes the 'dev' and 'production' environments share the same build pipeline.

play with it at https://glitch.com/~curvy-harbor