### PR TITLE
errorpage: 404 page's stars should extend to the max width (case 3294539)

### DIFF
--- a/public/styles/pages/error.styl
+++ b/public/styles/pages/error.styl
@@ -8,7 +8,8 @@
   font-size: 80%
   position: relative
   height: 100vh
-
+  max-width: 100%
+  
   .container
     margin-top: calc(20%)
     text-align: center

--- a/src/templates/pages/error.jade
+++ b/src/templates/pages/error.jade
@@ -1,4 +1,4 @@
-- logo = "https://cdn.gomix.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2Fcarp.svg"
+- logo = "https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2Fcarp.svg"
 
 .content.error-page
   .container
@@ -10,7 +10,5 @@
       a(href="https://glitch.com")
         img(src=logo width=80)
 
-    .beta beta
-
     canvas#stars
-    script(src="https://gomix.com/error-page.js")
+    script(src="https://glitch.com/edit/error-page.js")


### PR DESCRIPTION
This should fix up the starfield not extending to the entire width of the page (https://our.manuscript.com/f/cases/3294539/full-screen-the-black-stars-on-our-404-page).

It also updates a couple gomix.com links to glitch.com and removes the beta tag