### PR TITLE
Future riddle -- popover-container.jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "webpack-cli": "^2.0.15",
     "lodash-webpack-plugin": "^0.11.5",
     "babel-plugin-lodash": "^3.3.2",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "react-onclickoutside": "^6.7.1"
   },
   "engines": {
     "node": "8.x"

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -31,6 +31,7 @@ dependencies:
   randomcolor: 0.5.3
   react: 16.3.2
   react-dom: 16.3.2
+  react-onclickoutside: 6.7.1
   stylus: 0.54.5
   uglifyjs-webpack-plugin: 1.2.5
   webpack: 4.6.0
@@ -5403,6 +5404,13 @@ packages:
       react: ^16.0.0
     resolution:
       integrity: sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==
+  /react-onclickoutside/6.7.1:
+    dev: false
+    peerDependencies:
+      react: ^15.5.x || ^16.x
+      react-dom: ^15.5.x || ^16.x
+    resolution:
+      integrity: sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
   /react/16.3.2:
     dependencies:
       fbjs: 0.8.16
@@ -6975,6 +6983,7 @@ specifiers:
   randomcolor: ^0.5.3
   react: ^16.3.2
   react-dom: ^16.3.2
+  react-onclickoutside: ^6.7.1
   stylus: ^0.54.5
   uglifyjs-webpack-plugin: ^1.2.5
   webpack: ^4.6.0

--- a/src/application.js
+++ b/src/application.js
@@ -110,36 +110,17 @@ var self = Model({
     
   },
 
-  // Call this function to close all active popovers and overlays.
-  // Pass a callback to this function to register a callback
-  // to be invoked when this function is called (e.g., so you can close yourself.);
-  // Callbacks are only invoked once.
-  closeAllPopOvers: (() => {
-    const callbacks = [];
-    
-    return (cb) => {
-      if(cb) {
-        callbacks.push(cb);
-        return;
-      }
-      
-      callbacks.forEach(cb => cb());
-      
-      //delete all the callbacks
-      callbacks.length = 0;
-      
-      $(".pop-over.disposable, .overlay-background.disposable").remove();
-      self.signInPopVisibleOnHeader(false);
-      self.signInPopVisibleOnRecentProjects(false);
-      self.userOptionsPopVisible(false);
-      self.addTeamUserPopVisible(false);
-      self.addTeamProjectPopVisible(false);
-      self.overlayProjectVisible(false);
-      self.overlayVideoVisible(false);
-      return self.overlayNewStuffVisible(false);
-    };
-  
-  })(),
+  closeAllPopOvers() {
+    $(".pop-over.disposable, .overlay-background.disposable").remove();
+    self.signInPopVisibleOnHeader(false);
+    self.signInPopVisibleOnRecentProjects(false);
+    self.userOptionsPopVisible(false);
+    self.addTeamUserPopVisible(false);
+    self.addTeamProjectPopVisible(false);
+    self.overlayProjectVisible(false);
+    self.overlayVideoVisible(false);
+    return self.overlayNewStuffVisible(false);
+  },
 
   searchProjects(query) {
     self.searchResultsProjects([]);

--- a/src/models/category.js
+++ b/src/models/category.js
@@ -34,6 +34,7 @@ export default Category = function(I, self) {
   });
   
   self.asProps = () => ({
+    id: self.id(),
     avatarUrl: self.avatarUrl(),
     backgroundColor: self.backgroundColor(),
     color: self.color(),

--- a/src/presenters/pop-overs/popover-container.jsx
+++ b/src/presenters/pop-overs/popover-container.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import onClickOutside from 'react-onclickoutside';
+
+/*
+A popover is a light, hollow roll made from an egg batter similar to
+that of Yorkshire pudding, typically baked in muffin tins or dedicated
+popover pans, which have straight-walled sides rather than angled.
+
+...also it's a [Bootstrap UI pattern](https://www.w3schools.com/bootstrap/bootstrap_popover.asp)
+*/
+export default class PopoverContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { visible: false };
+
+    this.toggle = this.toggle.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+  
+  handleClickOutside(event) {
+    // On keyup events, only hide the popup if it was the 'esc' key (27).
+    if(event.type === "keyup" && event.keyCode !== 27) {
+      return;
+    }
+    
+    this.setState({visible: false});
+  }
+  
+  toggle(event) {
+    this.setState({visible: !this.state.visible});
+  }
+
+  render() {
+    // Invoke the children as a react component, passing them the toggle visibility controls.
+    // The <span> is needed because onClickOutside doesn't support React.Fragment
+    const Children = () => (
+      <span>
+        <this.props.children togglePopover={this.toggle} visible={this.state.visible}/>
+      </span>
+    );
+    
+    const clickOutsideConfig = {
+      handleClickOutside: () => this.handleClickOutside,
+      excludeScrollbar: true,
+    };
+    const MonitoredComponent = onClickOutside(Children, clickOutsideConfig);
+    
+    return (
+      <MonitoredComponent disableOnClickOutside={!this.state.visible}  eventTypes={["mousedown", "touchstart", "keyup"]}/>
+    );
+  }
+}
+
+PopoverContainer.propTypes = {
+  children: PropTypes.func.isRequired,
+};
+

--- a/src/presenters/pop-overs/popover-container.jsx
+++ b/src/presenters/pop-overs/popover-container.jsx
@@ -27,7 +27,7 @@ export default class PopoverContainer extends React.Component {
     this.setState({visible: false});
   }
   
-  toggle(event) {
+  toggle() {
     this.setState({visible: !this.state.visible});
   }
 
@@ -40,10 +40,15 @@ export default class PopoverContainer extends React.Component {
       </span>
     );
     
+    // The rest of this logic sets up and configures the onClickOutside wrapper
+    // https://github.com/Pomax/react-onclickoutside
+
+    // We do extra work with disableOnClickOutside and handleClickOutside
+    // to prevent event bindings frto occur until the popover is visible.
     const clickOutsideConfig = {
-      handleClickOutside: () => this.handleClickOutside,
-      excludeScrollbar: true,
-    };
+       handleClickOutside: () => this.handleClickOutside,
+       excludeScrollbar: true,
+    }
     const MonitoredComponent = onClickOutside(Children, clickOutsideConfig);
     
     return (

--- a/src/presenters/pop-overs/project-options-pop.jsx
+++ b/src/presenters/pop-overs/project-options-pop.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Popover from './pop-over.jsx';
 
 const PopoverButton = ({onClick, text, emoji}) => (
   <button className="button-small has-emoji button-tertiary" onClick={onClick}>
@@ -78,56 +79,6 @@ ProjectOptionsPop.propTypes = {
   removeProjectFromTeam: PropTypes.func,
 };
 
-/*
-A popover is a light, hollow roll made from an egg batter similar to
-that of Yorkshire pudding, typically baked in muffin tins or dedicated
-popover pans, which have straight-walled sides rather than angled.
-
-..
-*/
-export class PopoverContainer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { visible: false };
-    this._ismounted = false;
-  }
-  
-  componentDidMount() { 
-    this._ismounted = true;
-  }
-
-  componentWillUnmount() {
-    this._ismounted = false;
-  }
-
-  render() {
-    const toggle = (event) => {
-      const wasVisible = this.state.visible;
-      
-      //closeAllPopovers();
-      event.stopPropagation();
-      
-      if(wasVisible) {
-        // In this circumstance, they clicked the down-arrow in order to
-        // close the popup, since it was already open.
-        // ..so leave it closed.
-        return;
-      }
-      
-      this.setState({visible: true});
-      //this.props.closeAllPopovers(() => {
-      //  this._ismounted && this.setState({visible: false});
-      //});
-    };
-    
-    let Children = this.props.children;
-    
-    return (
-      <Children togglePopover={toggle} visible={this.state.visible}/>
-    );
-  }
-}
-
 export default function ProjectOptions({projectOptions={}, project}) {
   if(Object.keys(projectOptions).length === 0) {
     return null;
@@ -140,15 +91,15 @@ export default function ProjectOptions({projectOptions={}, project}) {
   };
   
   return (
-    <PopoverContainer>
-      { ({togglePopover, visible}) => (
+    <Popover>
+      {({togglePopover, visible}) => (
         <React.Fragment>
           <button className="project-options button-borderless opens-pop-over" onClick={togglePopover}> 
             <div className="down-arrow"></div>
           </button>
-          { visible && <ProjectOptionsPop {...popupProps} {...projectOptions} togglePopover={togglePopover}></ProjectOptionsPop> }
+          { visible && <ProjectOptionsPop {...popupProps} {...projectOptions} togglePopover={togglePopover}/> }
         </React.Fragment>
       )}
-    </PopoverContainer>
+    </Popover>
   );
 }

--- a/src/presenters/pop-overs/project-options-pop.jsx
+++ b/src/presenters/pop-overs/project-options-pop.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Popover from './pop-over.jsx';
+import PopoverContainer from './popover-container.jsx';
 
 const PopoverButton = ({onClick, text, emoji}) => (
   <button className="button-small has-emoji button-tertiary" onClick={onClick}>
@@ -9,7 +9,7 @@ const PopoverButton = ({onClick, text, emoji}) => (
   </button>
 );
 
-export const ProjectOptionsPop = ({
+const ProjectOptionsPop = ({
   projectId,
   projectName, projectIsPinned, togglePopover, 
   togglePinnedState, deleteProject, 
@@ -91,7 +91,7 @@ export default function ProjectOptions({projectOptions={}, project}) {
   };
   
   return (
-    <Popover>
+    <PopoverContainer>
       {({togglePopover, visible}) => (
         <React.Fragment>
           <button className="project-options button-borderless opens-pop-over" onClick={togglePopover}> 
@@ -100,6 +100,6 @@ export default function ProjectOptions({projectOptions={}, project}) {
           { visible && <ProjectOptionsPop {...popupProps} {...projectOptions} togglePopover={togglePopover}/> }
         </React.Fragment>
       )}
-    </Popover>
+    </PopoverContainer>
   );
 }

--- a/src/presenters/reactlet.js
+++ b/src/presenters/reactlet.js
@@ -13,7 +13,7 @@ let distinctIds = new Set();
 let batchPending = false;
 
 export default function(Component, props, guid=null) {
-  const id = guid || `reactlet-${Component.name}-${anchorId++}`;
+  const id = guid || `reactlet-${Component.name || "anon"}-${anchorId++}`;
   
   // Rather than rendering immediately, 
   // collect the invocations into a stack.

--- a/src/templates/includes/featured-collection.jade
+++ b/src/templates/includes/featured-collection.jade
@@ -2,10 +2,10 @@ li
   - if @link()
     a(href=@link)
       .featured-container(data-track="featured project" data-track-label=@title)
-        img.featured(width=30 height=30 @src title=@imgTitle alt="background image for #{@title()}")
+        img.featured(@src title=@imgTitle alt="")
         p.project-name= @title
   - else
     span
       .featured-container(data-track="featured project" data-track-label=@title)
-        img.featured(width=30 height=30 @src title=@imgTitle alt="background image for #{@title()}")
+        img.featured(@src title=@imgTitle alt="")
         p.project-name= @title


### PR DESCRIPTION
I was able to make a general purpose, reusable Popover container with no (visible) external state.

check out https://glitch.com/edit/#!/future-riddle?path=src/presenters/pop-overs/popover-container.jsx:47:80  for how it works, and https://glitch.com/edit/#!/future-riddle?path=src/presenters/pop-overs/project-options-pop.jsx:105:1 for how it's used 