### PR TITLE
Nova chance: Show placeholder on empty description fields

### DIFF
--- a/src/presenters/includes/description-field.jsx
+++ b/src/presenters/includes/description-field.jsx
@@ -49,7 +49,7 @@ class EditableDescription extends React.Component {
       :
       <p
         className="description content-editable"
-        placeholder={placeholder}
+        placeholder={placeholder} aria-label={placeholder}
         role="textbox" // eslint-disable-line jsx-a11y/no-noninteractive-element-to-interactive-role
         tabIndex={0} onFocus={this.onFocus} onBlur={this.onBlur}
       >

--- a/src/presenters/includes/markdown.jsx
+++ b/src/presenters/includes/markdown.jsx
@@ -8,7 +8,7 @@ const md = markdownIt({
   breaks: true,
   linkify: true,
   typographer: true,
-}).use(markdownEmoji);
+}).disable('smartquotes').use(markdownEmoji);
 
 const RawHTML = ({children}) => (
   children ? <span dangerouslySetInnerHTML={{__html: children}}></span> : null

--- a/src/presenters/includes/markdown.jsx
+++ b/src/presenters/includes/markdown.jsx
@@ -11,7 +11,7 @@ const md = markdownIt({
 }).use(markdownEmoji);
 
 const RawHTML = ({children}) => (
-  <span dangerouslySetInnerHTML={{__html: children}}></span>
+  !!children && <span dangerouslySetInnerHTML={{__html: children}}></span>
 );
 RawHTML.propTypes = {
   children: PropTypes.string.isRequired,

--- a/src/presenters/includes/markdown.jsx
+++ b/src/presenters/includes/markdown.jsx
@@ -11,7 +11,7 @@ const md = markdownIt({
 }).use(markdownEmoji);
 
 const RawHTML = ({children}) => (
-  !!children && <span dangerouslySetInnerHTML={{__html: children}}></span>
+  children ? <span dangerouslySetInnerHTML={{__html: children}}></span> : null
 );
 RawHTML.propTypes = {
   children: PropTypes.string.isRequired,


### PR DESCRIPTION
empty markdown now renders as `<span></span>` which breaks the `:empty` check used to show the placeholder. Now it will render completely blank