### PR TITLE
Nova Chance: Fix a regression when adding a project to a team

### DIFF
--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -140,7 +140,7 @@ class CurrentUserManager extends React.Component {
     const {fetched} = this.state;
     return children({
       api: this.api(),
-      currentUser: cachedUser,
+      currentUser: cachedUser ? UserModel(cachedUser).asProps() : null,
       fetched,
       reload: () => this.load(),
       login: user => setSharedUser(user),
@@ -168,7 +168,7 @@ const cleanUser = (user) => {
     Raven.captureMessage("Invalid cachedUser", {extra: {user}});
     return null;
   }
-  return UserModel(user).asProps();
+  return user;
 };
 
 export const CurrentUserProvider = ({children}) => (


### PR DESCRIPTION
I was putting the user object that gets shared with the editor through the model, but it's the community site specific cached user that gets used everywhere and needs to be run through the model func.