### PR TITLE
Superb guide: Send email invites to users

### DIFF
--- a/src/presenters/includes/team-users.jsx
+++ b/src/presenters/includes/team-users.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-//import {getDisplayName} from '../../models/user';
+import {getDisplayName} from '../../models/user';
 import {WhitelistedDomainIcon} from './team-elements.jsx';
 import AddTeamUserPop from '../pop-overs/add-team-user-pop.jsx';
 import PopoverContainer from '../pop-overs/popover-container.jsx';
@@ -99,7 +99,7 @@ export class AddTeamUser extends React.Component {
     togglePopover();
     await this.props.inviteUser(user);
     this.setState({
-      invitee: '', //getDisplayName(user),
+      invitee: getDisplayName(user),
     });
   }
   

--- a/src/presenters/pop-overs/add-team-user-pop.jsx
+++ b/src/presenters/pop-overs/add-team-user-pop.jsx
@@ -71,7 +71,7 @@ class AddTeamUserPop extends React.Component {
     const email = parseOneAddress(query);
     let domain = null;
     if (email) {
-      console.log({ //results.push({
+      ({ //results.push({
         key: 'invite-by-email',
         item: <InviteByEmail email={email.address} onClick={() => inviteEmail(email.address)}/>,
       });

--- a/src/presenters/pop-overs/add-team-user-pop.jsx
+++ b/src/presenters/pop-overs/add-team-user-pop.jsx
@@ -6,7 +6,7 @@ import {parseOneAddress} from 'email-addresses';
 import UserModel from '../../models/user';
 
 import Loader from '../includes/loader.jsx';
-import UserResultItem, {/*InviteByEmail,*/ WhitelistEmailDomain} from '../includes/user-result-item.jsx';
+import UserResultItem, {InviteByEmail, WhitelistEmailDomain} from '../includes/user-result-item.jsx';
 
 
 class AddTeamUserPop extends React.Component {
@@ -63,7 +63,7 @@ class AddTeamUserPop extends React.Component {
   }
     
   render() {
-    const {/*inviteEmail,*/ inviteUser, setWhitelistedDomain} = this.props;
+    const {inviteEmail, inviteUser, setWhitelistedDomain} = this.props;
     const {maybeRequest, maybeResults, query} = this.state;
     const isLoading = (!!maybeRequest || !maybeResults);
     const results = [];
@@ -71,12 +71,10 @@ class AddTeamUserPop extends React.Component {
     const email = parseOneAddress(query);
     let domain = null;
     if (email) {
-      /* Disallow invite by email until its ready
       results.push({
         key: 'invite-by-email',
         item: <InviteByEmail email={email.address} onClick={() => inviteEmail(email.address)}/>,
       });
-      */
       domain = email.domain;
     } else {
       const fakeEmail = parseOneAddress(query.replace('@', 'test@'));

--- a/src/presenters/pop-overs/add-team-user-pop.jsx
+++ b/src/presenters/pop-overs/add-team-user-pop.jsx
@@ -71,7 +71,7 @@ class AddTeamUserPop extends React.Component {
     const email = parseOneAddress(query);
     let domain = null;
     if (email) {
-      results.push({
+      console.log({ //results.push({
         key: 'invite-by-email',
         item: <InviteByEmail email={email.address} onClick={() => inviteEmail(email.address)}/>,
       });

--- a/src/presenters/team-editor.jsx
+++ b/src/presenters/team-editor.jsx
@@ -85,11 +85,7 @@ class TeamEditor extends React.Component {
 
   async inviteUser(user) {
     console.log('💣 inviteUser', user);
-    //await this.props.api.post(`teams/${this.state.id}/sendJoinTeamEmail`, {userId: user.id});
-    await this.props.api.post(`teams/${this.state.id}/users/${user.id}`);
-    this.setState(({users}) => ({
-      users: [...users, user],
-    }));
+    await this.props.api.post(`teams/${this.state.id}/sendJoinTeamEmail`, {userId: user.id});
   }
 
   async removeUser(id) {


### PR DESCRIPTION
https://superb-guide.glitch.me/@test-team

Code wise this is pretty much identical to the pr that got merged last week, but emails work now!

Adding users to teams sends them an invite email rather than immediately adding them. Sending invites to arbitrary email addresses isn't supported yet.

This is blocked on completion of the email template, and redirecting the join button to the team page rather than leaving you on the api response.