### PR TITLE
Nova chance: Standardize NestedPopover

### DIFF
--- a/src/presenters/includes/team-users.jsx
+++ b/src/presenters/includes/team-users.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import {WhitelistedDomainIcon} from './team-elements.jsx';
 import AddTeamUserPop from '../pop-overs/add-team-user-pop.jsx';
 import PopoverContainer from '../pop-overs/popover-container.jsx';
-import TeamUserInfoAndRemovePop from '../pop-overs/team-user-info-and-remove-pop.jsx';
+import TeamUserInfoPop from '../pop-overs/team-user-info-pop.jsx';
 import {UserPopoversList} from '../users-list.jsx';
 
 
@@ -13,10 +13,9 @@ import {UserPopoversList} from '../users-list.jsx';
 
 export const TeamUsers = (props) => (
   <UserPopoversList users={props.users} adminIds={props.adminIds}>
-    {(user, togglePopover) => 
-      <TeamUserInfoAndRemovePop 
+    {user => 
+      <TeamUserInfoPop 
         userIsTeamAdmin={props.adminIds.includes(user.id)}
-        togglePopover={togglePopover}
         user={user}
         {...props}
       />

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export class PopoverNested extends React.Fragment {
+export class PopoverNested extends React.Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -13,10 +13,12 @@ export default class NestedPopover extends React.Component {
   }
   
   toggle() {
-    this.setState(({menu}) => ({menu: !menu}));
+    this.setState(prevState => ({menu: !prevState.menu}));
   }
   
   render() {
+    // Only use the provider on the sub menu
+    // Nested consumers want the back button, not the open menu
     if (this.state.menu) {
       return (
         <Provider value={this.toggle}>

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -37,7 +37,7 @@ export const NestedPopoverTitle = ({children}) => (
   <Consumer>
     {toggle => (
       <button className="button-unstyled clickable-label" onClick={toggle} aria-label="go back">
-        <section className="pop-over-info team-user-remove-header">
+        <section className="pop-over-info">
           <div className="back icon"><div className="left-arrow icon" /></div>
           &nbsp;
           <div className="pop-title">{children}</div>

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -7,22 +7,22 @@ export default class NestedPopover extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      menu: false, // true for alt page, false for main
+      alternateContentVisible: false,
     };
     this.toggle = this.toggle.bind(this);
   }
   
   toggle() {
-    this.setState(prevState => ({menu: !prevState.menu}));
+    this.setState(prevState => ({alternateContentVisible: !prevState.alternateContentVisible}));
   }
   
   render() {
     // Only use the provider on the sub menu
     // Nested consumers want the back button, not the open menu
-    if (this.state.menu) {
+    if (this.state.alternateContentVisible) {
       return (
         <Provider value={this.toggle}>
-          {this.props.menu(this.toggle)}
+          {this.props.alternateContent(this.toggle)}
         </Provider>
       );
     }
@@ -31,7 +31,7 @@ export default class NestedPopover extends React.Component {
 }
 NestedPopover.propTypes = {
   children: PropTypes.func.isRequired,
-  menu: PropTypes.func.isRequired,
+  alternateContent: PropTypes.func.isRequired,
 };
 
 

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -3,37 +3,35 @@ import PropTypes from 'prop-types';
 
 const {Provider, Consumer} = React.createContext();
 
-export class NestedPopover extends React.Component {
+export default class NestedPopover extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      page: false, // true for alt page, false for main
+      menu: false, // true for alt page, false for main
     };
     this.toggle = this.toggle.bind(this);
   }
   
   toggle() {
-    this.setState(({page}) => ({page: !page}));
+    this.setState(({menu}) => ({page: !page}));
   }
   
   render() {
-    const {children, menu} = this.props;
-    return (
-      <Provider value={this.toggle}>
-        {this.state.page ? menu(this.toggle) : children(this.toggle)}
-      </Provider>
-    );
+    if (this.state.page) {
+      return (
+        <Provider value={this.toggle}>
+          {this.props.menu(this.toggle)}
+        </Provider>
+      );
+    }
+    return this.props.children(this.toggle);
   }
 }
-
 NestedPopover.propTypes = {
   children: PropTypes.func.isRequired,
   menu: PropTypes.func.isRequired,
 };
 
-export default NestedPopover;
-
-export {Consumer as NestedPopoverConsumer};
 
 export const NestedPopoverTitle = ({children}) => (
   <Consumer>

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -13,11 +13,11 @@ export default class NestedPopover extends React.Component {
   }
   
   toggle() {
-    this.setState(({menu}) => ({page: !page}));
+    this.setState(({menu}) => ({menu: !menu}));
   }
   
   render() {
-    if (this.state.page) {
+    if (this.state.menu) {
       return (
         <Provider value={this.toggle}>
           {this.props.menu(this.toggle)}

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const {Provider, Consumer} = React.createContext();
+
 export class PopoverNested extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       page: false, // true for alt page, false for main
     };
+  }
+  
+  toggle() {
+    this.setState(({page}) => ({page: !page}));
   }
   
   render() {

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export class PopoverNested extends React.Fragment {
+  constructor(props) {
+    super(props);
+    this.state = {
+      page: null, // null or undefined show the default page
+    };
+    this.setPage = this.setPage.bind(this);
+  }
+  
+  setPage(page) {
+    this.setState({page});
+  }
+  
+  render() {
+  }
+}
+
+PopoverNested.propTypes = {
+  children: PropTypes.objectOf(PropTypes.func).isRequired,
+};
+
+export default PopoverNested;

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -5,21 +5,21 @@ export class PopoverNested extends React.Fragment {
   constructor(props) {
     super(props);
     this.state = {
-      page: null, // null or undefined show the default page
+      page: false, // true for alt page, false for main
     };
-    this.setPage = this.setPage.bind(this);
-  }
-  
-  setPage(page) {
-    this.setState({page});
   }
   
   render() {
+    if (this.state.page) {
+      return this.props.menu(() => this.setState({page: false}));
+    }
+    return this.props.children(() => this.setState({page: true}));
   }
 }
 
 PopoverNested.propTypes = {
-  children: PropTypes.objectOf(PropTypes.func).isRequired,
+  children: PropTypes.func.isRequired,
+  menu: PropTypes.func.isRequired,
 };
 
 export default PopoverNested;

--- a/src/presenters/pop-overs/popover-nested.jsx
+++ b/src/presenters/pop-overs/popover-nested.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 
 const {Provider, Consumer} = React.createContext();
 
-export class PopoverNested extends React.Component {
+export class NestedPopover extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       page: false, // true for alt page, false for main
     };
+    this.toggle = this.toggle.bind(this);
   }
   
   toggle() {
@@ -16,16 +17,37 @@ export class PopoverNested extends React.Component {
   }
   
   render() {
-    if (this.state.page) {
-      return this.props.menu(() => this.setState({page: false}));
-    }
-    return this.props.children(() => this.setState({page: true}));
+    const {children, menu} = this.props;
+    return (
+      <Provider value={this.toggle}>
+        {this.state.page ? menu(this.toggle) : children(this.toggle)}
+      </Provider>
+    );
   }
 }
 
-PopoverNested.propTypes = {
+NestedPopover.propTypes = {
   children: PropTypes.func.isRequired,
   menu: PropTypes.func.isRequired,
 };
 
-export default PopoverNested;
+export default NestedPopover;
+
+export {Consumer as NestedPopoverConsumer};
+
+export const NestedPopoverTitle = ({children}) => (
+  <Consumer>
+    {toggle => (
+      <button className="button-unstyled clickable-label" onClick={toggle} aria-label="go back">
+        <section className="pop-over-info team-user-remove-header">
+          <div className="back icon"><div className="left-arrow icon" /></div>
+          &nbsp;
+          <div className="pop-title">{children}</div>
+        </section>
+      </button>
+    )}
+  </Consumer>
+);
+NestedPopoverTitle.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
@@ -1,16 +1,13 @@
-/* globals Set */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
-import {getAvatarUrl} from  '../../models/project';
+import {getAvatarThumbnailUrl} from '../../models/user';
 
-import PopoverNested, {NestedPopoverConsumer, NestedPopoverTitle} from './popover-nested.jsx';
+import PopoverNested, {NestedPopoverConsumer} from './popover-nested.jsx';
 import {UserLink} from '../includes/link.jsx';
-import Loader from '../includes/loader.jsx';
-import Notifications from '../notifications.jsx';
 import Thanks from '../includes/thanks.jsx';
+
+import TeamUserRemovePop from './team-user-remove-pop.jsx';
 
 const MEMBER_ACCESS_LEVEL = 20;
 const ADMIN_ACCESS_LEVEL = 30;
@@ -110,155 +107,14 @@ const TeamUserInfo = ({currentUser, ...props}) => {
 
 // Team User Remove 💣
 
-class TeamUserRemove extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      gettingUser: true,
-      userTeamProjects: [],
-      selectedProjects: new Set(),
-    };
-    this.selectAllProjects = this.selectAllProjects.bind(this);
-    this.unselectAllProjects = this.unselectAllProjects.bind(this);
-    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
-    this.removeUser = this.removeUser.bind(this);
-  }
-  
-  removeUser() {
-    this.props.togglePopover();
-    this.props.createNotification(`${getDisplayName(this.props.user)} removed from Team`);
-    this.props.removeUserFromTeam(this.props.user.id, Array.from(this.state.selectedProjects));
-  }
-  
-  selectAllProjects() {
-    this.setState(({userTeamProjects}) => ({
-      selectedProjects: new Set(userTeamProjects.map(p => p.id))
-    }));
-  }
-  
-  unselectAllProjects() {
-    this.setState({
-      selectedProjects: new Set()
-    });
-  }
-  
-  handleCheckboxChange(evt) {
-    const {checked, value} = evt.target;
-    this.setState(({selectedProjects}) => {
-      selectedProjects = new Set(selectedProjects);
-      if (checked) {
-        selectedProjects.add(value);
-      } else {
-        selectedProjects.delete(value);
-      }
-      return {selectedProjects};
-    });
-  }
-  
-  async getUserWithProjects() {
-    const {data} = await this.props.api.get(`users/${this.props.user.id}`);
-    this.setState({
-      userTeamProjects: data.projects.filter(userProj => {
-        return this.props.team.projects.some(teamProj => teamProj.id === userProj.id);
-      }),
-      gettingUser: false
-    });
-  }
-  
-  componentDidMount() {
-    this.getUserWithProjects();    
-  }
-  
-  render() {
-    const allProjectsSelected = this.state.userTeamProjects.every(p => this.state.selectedProjects.has(p.id));
-    const userAvatarStyle = {backgroundColor: this.props.user.color};
-    
-    let projects = null;
-    if (this.state.gettingUser) {
-      projects = <Loader/>;
-    } else if (this.state.userTeamProjects.length > 0) {
-      projects = (
-        <React.Fragment>
-          <p className="action-description">
-            Also remove them from these projects
-          </p>
-          <div className="projects-list">
-            { this.state.userTeamProjects.map(project => (
-              <label key={project.id} htmlFor={`remove-user-project-${project.id}`}>
-                <input className="checkbox-project" type="checkbox" id={`remove-user-project-${project.id}`}
-                  checked={this.state.selectedProjects.has(project.id)} value={project.id}
-                  onChange={this.handleCheckboxChange}
-                />
-                <img className="avatar" src={getAvatarUrl(project.id)} alt={`Project avatar for ${project.domain}`}/>
-                {project.domain}
-              </label>
-            ))}
-          </div>
-          {this.state.userTeamProjects.length > 1 && (
-            <button className="button-small"
-              onClick={allProjectsSelected ? this.unselectAllProjects : this.selectAllProjects}
-            >
-              {allProjectsSelected ? 'Unselect All' : 'Select All'}
-            </button>
-          )}
-        </React.Fragment>
-      );
-    }
-    
-    return (
-      <dialog className="pop-over team-user-info-pop team-user-remove-pop">
-        <NestedPopoverTitle>
-          Remove {getDisplayName(this.props.user)}
-        </NestedPopoverTitle>
-        
-        <section className="pop-over-actions" id="user-team-projects">
-          {projects || (
-            <p className="action-description">
-              {getDisplayName(this.props.user)} is not a member of any projects
-            </p>
-          )}
-        </section>
-        
-        <section className="pop-over-actions danger-zone">
-          <button className="button-small has-emoji" onClick={this.removeUser}>
-            Remove <img className="emoji avatar" src={getAvatarThumbnailUrl(this.props.user)} alt={this.props.user.login} style={userAvatarStyle}/>
-          </button>
-        </section>
-      </dialog>
-    );
-  }
-}
-
-TeamUserRemove.propTypes = {
-  api: PropTypes.func.isRequired,
-  user: PropTypes.shape({
-    name: PropTypes.string,
-    login: PropTypes.string,
-    thanksCount: PropTypes.number.isRequired,
-    isOnTeam: PropTypes.bool,
-    color: PropTypes.string,
-  }).isRequired,
-  team: PropTypes.shape({
-    projects: PropTypes.array.isRequired
-  }),
-  removeUserFromTeam: PropTypes.func.isRequired,
-  createNotification: PropTypes.func.isRequired,
-};
-
 
 // Team User Info or Remove
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
 const TeamUserInfoAndRemovePop = (props) => (
-  <PopoverNested menu={() => (
-    <Notifications>
-      {notifyFuncs => (
-        <TeamUserRemove {...notifyFuncs} {...props}/>
-      )}
-    </Notifications>
-  )}>
-    {() => (
-      <TeamUserInfo {...props}/>
+  <PopoverNested menu={() => <TeamUserRemovePop {...props}/>}>
+    {showRemove => (
+      <TeamUserInfo {...props} showRemove={showRemove}/>
     )}
   </PopoverNested>
 );
@@ -268,7 +124,6 @@ TeamUserInfoAndRemovePop.propTypes = {
     name: PropTypes.string,
     login: PropTypes.string,
     thanksCount: PropTypes.number.isRequired,
-    isOnTeam: PropTypes.bool,
     color: PropTypes.string,
   }).isRequired,
   currentUserIsOnTeam: PropTypes.bool.isRequired,
@@ -284,9 +139,6 @@ TeamUserInfoAndRemovePop.propTypes = {
 };
 
 TeamUserInfoAndRemovePop.defaultProps = {
-  user: {
-    isOnTeam: false
-  },
   currentUserIsOnTeam: false,
 };
 

--- a/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import {getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
 import {getAvatarUrl} from  '../../models/project';
 
-import PopoverNested, {NestedPopoverTitle} from './popover-nested.jsx';
+import PopoverNested, {NestedPopoverConsumer, NestedPopoverTitle} from './popover-nested.jsx';
 import {UserLink} from '../includes/link.jsx';
 import Loader from '../includes/loader.jsx';
 import Notifications from '../notifications.jsx';
@@ -17,18 +17,17 @@ const ADMIN_ACCESS_LEVEL = 30;
 
 // Remove from Team 👋
 
-const RemoveFromTeam = ({toggleUserInfoHidden}) => (
+const RemoveFromTeam = () => (
   <section className="pop-over-actions danger-zone">
-    <button className="button-small has-emoji button-tertiary button-on-secondary-background" onClick={toggleUserInfoHidden}>
-      Remove from Team
-      <span className="emoji wave" />
-    </button>
+    <NestedPopoverConsumer>
+      {toggle => (
+        <button className="button-small has-emoji button-tertiary button-on-secondary-background" onClick={toggle}>
+          Remove from Team <span className="emoji wave" role="img" aria-label=""/>
+        </button>
+      )}
+    </NestedPopoverConsumer>
   </section>
 );
-
-RemoveFromTeam.propTypes = {
-  toggleUserInfoHidden: PropTypes.func.isRequired,
-};
 
 
 // Admin Actions Section ⏫⏬
@@ -72,7 +71,7 @@ const ThanksCount = ({count}) => (
 
 // Team User Info 😍
 
-const TeamUserInfo = ({toggleUserInfoHidden, currentUser, ...props}) => {
+const TeamUserInfo = ({currentUser, ...props}) => {
   const userAvatarStyle = {backgroundColor: props.user.color};
   const canRemoveUser = props.currentUserIsTeamAdmin || (currentUser && currentUser.id === props.user.id);
   return (
@@ -103,13 +102,9 @@ const TeamUserInfo = ({toggleUserInfoHidden, currentUser, ...props}) => {
           updateUserPermissions={props.updateUserPermissions}
         />
       }
-      { canRemoveUser && <RemoveFromTeam toggleUserInfoHidden={() => toggleUserInfoHidden()} /> }
+      { canRemoveUser && <RemoveFromTeam /> }
     </dialog>
   );
-};
-
-TeamUserInfo.propTypes = {
-  toggleUserInfoHidden: PropTypes.func.isRequired,
 };
 
 
@@ -212,13 +207,6 @@ class TeamUserRemove extends React.Component {
     
     return (
       <dialog className="pop-over team-user-info-pop team-user-remove-pop">
-        <button className="button-unstyled clickable-label" onClick={this.props.toggleUserInfoVisible} aria-label="go back">
-          <section className="pop-over-info team-user-remove-header">
-            <div className="back icon"><div className="left-arrow icon" /></div>
-            &nbsp;
-            <div className="pop-title">Remove {getDisplayName(this.props.user)}</div>
-          </section>
-        </button>
         <NestedPopoverTitle>
           Remove {getDisplayName(this.props.user)}
         </NestedPopoverTitle>
@@ -243,7 +231,6 @@ class TeamUserRemove extends React.Component {
 
 TeamUserRemove.propTypes = {
   api: PropTypes.func.isRequired,
-  toggleUserInfoVisible: PropTypes.func.isRequired,
   user: PropTypes.shape({
     name: PropTypes.string,
     login: PropTypes.string,
@@ -263,15 +250,15 @@ TeamUserRemove.propTypes = {
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
 const TeamUserInfoAndRemovePop = (props) => (
-  <PopoverNested menu={toggle => (
+  <PopoverNested menu={() => (
     <Notifications>
       {notifyFuncs => (
-        <TeamUserRemove {...notifyFuncs} {...props} toggleUserInfoVisible={toggle}/>
+        <TeamUserRemove {...notifyFuncs} {...props}/>
       )}
     </Notifications>
   )}>
-    {toggle => (
-      <TeamUserInfo {...props} toggleUserInfoHidden={toggle}/>
+    {() => (
+      <TeamUserInfo {...props}/>
     )}
   </PopoverNested>
 );

--- a/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
@@ -259,51 +259,19 @@ TeamUserRemove.propTypes = {
 // Team User Info or Remove
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
-export default class TeamUserInfoAndRemovePop extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      userInfoVisible: true
-    };
-    this.toggleUserInfoVisible = this.toggleUserInfoVisible.bind(this);
-    this.toggleUserInfoHidden = this.toggleUserInfoHidden.bind(this);
-  }
-  
-  toggleUserInfoHidden() {
-    this.setState({
-      userInfoVisible: false
-    });
-  }
-
-  toggleUserInfoVisible() {
-    this.setState({
-      userInfoVisible: true
-    });
-  }
-  
-  render() {
-    return (
-      <React.Fragment>
-        { this.state.userInfoVisible ? (
-          <TeamUserInfo
-            {...this.props}
-            toggleUserInfoHidden={() => this.toggleUserInfoHidden()}
-          />
-        ) : (
-          <Notifications>
-            {notifyFuncs => (
-              <TeamUserRemove
-                {...notifyFuncs}
-                {...this.props}
-                toggleUserInfoVisible={() => this.toggleUserInfoVisible()}
-              />
-            )}
-          </Notifications>
-        )}
-      </React.Fragment>
-    );
-  }
-}
+const TeamUserInfoAndRemovePop = (props) => (
+  <PopoverNested menu={toggle => (
+    <Notifications>
+      {notifyFuncs => (
+        <TeamUserRemove {...notifyFuncs} {...props} toggleUserInfoVisible={toggle}/>
+      )}
+    </Notifications>
+  )}>
+    {toggle => (
+      <TeamUserInfo {...props} toggleUserInfoHidden={toggle}/>
+    )}
+  </PopoverNested>
+);
 
 TeamUserInfoAndRemovePop.propTypes = {
   user: PropTypes.shape({
@@ -332,3 +300,4 @@ TeamUserInfoAndRemovePop.defaultProps = {
   currentUserIsOnTeam: false,
 };
 
+export default TeamUserInfoAndRemovePop;

--- a/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
 import {getAvatarUrl} from  '../../models/project';
 
+import PopoverNested from './popover-nested.jsx';
 import {UserLink} from '../includes/link.jsx';
 import Loader from '../includes/loader.jsx';
 import Notifications from '../notifications.jsx';

--- a/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-and-remove-pop.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import {getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
 import {getAvatarUrl} from  '../../models/project';
 
-import PopoverNested from './popover-nested.jsx';
+import PopoverNested, {NestedPopoverTitle} from './popover-nested.jsx';
 import {UserLink} from '../includes/link.jsx';
 import Loader from '../includes/loader.jsx';
 import Notifications from '../notifications.jsx';
@@ -219,6 +219,9 @@ class TeamUserRemove extends React.Component {
             <div className="pop-title">Remove {getDisplayName(this.props.user)}</div>
           </section>
         </button>
+        <NestedPopoverTitle>
+          Remove {getDisplayName(this.props.user)}
+        </NestedPopoverTitle>
         
         <section className="pop-over-actions" id="user-team-projects">
           {projects || (

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -31,15 +31,15 @@ const AdminActions = ({user, userIsTeamAdmin, updateUserPermissions}) => {
       <p className="action-description">
         Admins can update team info, billing, and remove users
       </p>
-      { userIsTeamAdmin && 
+      { userIsTeamAdmin ? (
         <button className="button-small button-tertiary has-emoji" onClick={() => updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)}>
           Remove Admin Status <span className="emoji fast-down" />
         </button>
-      ||
+      ) : (
         <button className="button-small button-tertiary has-emoji" onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}>
           Make an Admin <span className="emoji fast-up" />
         </button>
-      }
+      )}
     </section>
   );
 };

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {getAvatarThumbnailUrl} from '../../models/user';
 
-import PopoverNested from './popover-nested.jsx';
+import NestedPopover from './popover-nested.jsx';
 import {UserLink} from '../includes/link.jsx';
 import Thanks from '../includes/thanks.jsx';
 
@@ -108,11 +108,11 @@ const TeamUserInfo = ({currentUser, showRemove, ...props}) => {
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
 const TeamUserInfoAndRemovePop = (props) => (
-  <PopoverNested menu={() => <TeamUserRemovePop {...props}/>}>
+  <NestedPopover alternateContent={() => <TeamUserRemovePop {...props}/>}>
     {showRemove => (
       <TeamUserInfo {...props} showRemove={showRemove}/>
     )}
-  </PopoverNested>
+  </NestedPopover>
 );
 
 TeamUserInfoAndRemovePop.propTypes = {

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {getAvatarThumbnailUrl} from '../../models/user';
 
-import PopoverNested, {NestedPopoverConsumer} from './popover-nested.jsx';
+import PopoverNested from './popover-nested.jsx';
 import {UserLink} from '../includes/link.jsx';
 import Thanks from '../includes/thanks.jsx';
 
@@ -14,15 +14,11 @@ const ADMIN_ACCESS_LEVEL = 30;
 
 // Remove from Team 👋
 
-const RemoveFromTeam = () => (
+const RemoveFromTeam = ({onClick}) => (
   <section className="pop-over-actions danger-zone">
-    <NestedPopoverConsumer>
-      {toggle => (
-        <button className="button-small has-emoji button-tertiary button-on-secondary-background" onClick={toggle}>
-          Remove from Team <span className="emoji wave" role="img" aria-label=""/>
-        </button>
-      )}
-    </NestedPopoverConsumer>
+    <button className="button-small has-emoji button-tertiary button-on-secondary-background" onClick={onClick}>
+      Remove from Team <span className="emoji wave" role="img" aria-label=""/>
+    </button>
   </section>
 );
 
@@ -68,7 +64,7 @@ const ThanksCount = ({count}) => (
 
 // Team User Info 😍
 
-const TeamUserInfo = ({currentUser, ...props}) => {
+const TeamUserInfo = ({currentUser, showRemove, ...props}) => {
   const userAvatarStyle = {backgroundColor: props.user.color};
   const canRemoveUser = props.currentUserIsTeamAdmin || (currentUser && currentUser.id === props.user.id);
   return (
@@ -99,7 +95,7 @@ const TeamUserInfo = ({currentUser, ...props}) => {
           updateUserPermissions={props.updateUserPermissions}
         />
       }
-      { canRemoveUser && <RemoveFromTeam /> }
+      { canRemoveUser && <RemoveFromTeam onClick={showRemove}/> }
     </dialog>
   );
 };

--- a/src/presenters/pop-overs/team-user-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-remove-pop.jsx
@@ -9,7 +9,7 @@ import {NestedPopoverTitle} from './popover-nested.jsx';
 import {getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
 import {getAvatarUrl as getProjectAvatarUrl} from  '../../models/project';
 
-class TeamUserRemovePopImpl extends React.Component {
+class TeamUserRemovePopBase extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -127,7 +127,7 @@ class TeamUserRemovePopImpl extends React.Component {
     );
   }
 }
-TeamUserRemovePopImpl.propTypes = {
+TeamUserRemovePopBase.propTypes = {
   api: PropTypes.func.isRequired,
   user: PropTypes.shape({
     name: PropTypes.string,
@@ -145,7 +145,7 @@ TeamUserRemovePopImpl.propTypes = {
 
 export const TeamUserRemovePop = (props) => (
   <NotificationsConsumer>
-    {notifyFuncs => <TeamUserRemovePopImpl {...notifyFuncs} {...props}/>}
+    {notifyFuncs => <TeamUserRemovePopBase {...notifyFuncs} {...props}/>}
   </NotificationsConsumer>
 );
 

--- a/src/presenters/pop-overs/team-user-remove-pop.jsx
+++ b/src/presenters/pop-overs/team-user-remove-pop.jsx
@@ -1,0 +1,152 @@
+/* global Set */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Loader from '../includes/loader.jsx';
+import NotificationsConsumer from '../notifications.jsx';
+import {NestedPopoverTitle} from './popover-nested.jsx';
+import {getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
+import {getAvatarUrl as getProjectAvatarUrl} from  '../../models/project';
+
+class TeamUserRemovePopImpl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      gettingUser: true,
+      userTeamProjects: [],
+      selectedProjects: new Set(),
+    };
+    this.selectAllProjects = this.selectAllProjects.bind(this);
+    this.unselectAllProjects = this.unselectAllProjects.bind(this);
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
+    this.removeUser = this.removeUser.bind(this);
+  }
+  
+  removeUser() {
+    this.props.togglePopover();
+    this.props.createNotification(`${getDisplayName(this.props.user)} removed from Team`);
+    this.props.removeUserFromTeam(this.props.user.id, Array.from(this.state.selectedProjects));
+  }
+  
+  selectAllProjects() {
+    this.setState(({userTeamProjects}) => ({
+      selectedProjects: new Set(userTeamProjects.map(p => p.id))
+    }));
+  }
+  
+  unselectAllProjects() {
+    this.setState({
+      selectedProjects: new Set()
+    });
+  }
+  
+  handleCheckboxChange(evt) {
+    const {checked, value} = evt.target;
+    this.setState(({selectedProjects}) => {
+      selectedProjects = new Set(selectedProjects);
+      if (checked) {
+        selectedProjects.add(value);
+      } else {
+        selectedProjects.delete(value);
+      }
+      return {selectedProjects};
+    });
+  }
+  
+  async getUserWithProjects() {
+    const {data} = await this.props.api.get(`users/${this.props.user.id}`);
+    this.setState({
+      userTeamProjects: data.projects.filter(userProj => {
+        return this.props.team.projects.some(teamProj => teamProj.id === userProj.id);
+      }),
+      gettingUser: false
+    });
+  }
+  
+  componentDidMount() {
+    this.getUserWithProjects();    
+  }
+  
+  render() {
+    const allProjectsSelected = this.state.userTeamProjects.every(p => this.state.selectedProjects.has(p.id));
+    const userAvatarStyle = {backgroundColor: this.props.user.color};
+    
+    let projects = null;
+    if (this.state.gettingUser) {
+      projects = <Loader/>;
+    } else if (this.state.userTeamProjects.length > 0) {
+      projects = (
+        <React.Fragment>
+          <p className="action-description">
+            Also remove them from these projects
+          </p>
+          <div className="projects-list">
+            { this.state.userTeamProjects.map(project => (
+              <label key={project.id} htmlFor={`remove-user-project-${project.id}`}>
+                <input className="checkbox-project" type="checkbox" id={`remove-user-project-${project.id}`}
+                  checked={this.state.selectedProjects.has(project.id)} value={project.id}
+                  onChange={this.handleCheckboxChange}
+                />
+                <img className="avatar" src={getProjectAvatarUrl(project.id)} alt=""/>
+                {project.domain}
+              </label>
+            ))}
+          </div>
+          {this.state.userTeamProjects.length > 1 && (
+            <button className="button-small"
+              onClick={allProjectsSelected ? this.unselectAllProjects : this.selectAllProjects}
+            >
+              {allProjectsSelected ? 'Unselect All' : 'Select All'}
+            </button>
+          )}
+        </React.Fragment>
+      );
+    }
+    
+    return (
+      <dialog className="pop-over team-user-info-pop team-user-remove-pop">
+        <NestedPopoverTitle>
+          Remove {getDisplayName(this.props.user)}
+        </NestedPopoverTitle>
+        
+        <section className="pop-over-actions" id="user-team-projects">
+          {projects || (
+            <p className="action-description">
+              {getDisplayName(this.props.user)} is not a member of any projects
+            </p>
+          )}
+        </section>
+        
+        <section className="pop-over-actions danger-zone">
+          <button className="button-small has-emoji" onClick={this.removeUser}>
+            Remove <img className="emoji avatar" src={getAvatarThumbnailUrl(this.props.user)} alt={this.props.user.login} style={userAvatarStyle}/>
+          </button>
+        </section>
+      </dialog>
+    );
+  }
+}
+TeamUserRemovePopImpl.propTypes = {
+  api: PropTypes.func.isRequired,
+  user: PropTypes.shape({
+    name: PropTypes.string,
+    login: PropTypes.string,
+    thanksCount: PropTypes.number.isRequired,
+    isOnTeam: PropTypes.bool,
+    color: PropTypes.string,
+  }).isRequired,
+  team: PropTypes.shape({
+    projects: PropTypes.array.isRequired
+  }),
+  removeUserFromTeam: PropTypes.func.isRequired,
+  createNotification: PropTypes.func.isRequired,
+};
+
+export const TeamUserRemovePop = (props) => (
+  <NotificationsConsumer>
+    {notifyFuncs => <TeamUserRemovePopImpl {...notifyFuncs} {...props}/>}
+  </NotificationsConsumer>
+);
+
+export default TeamUserRemovePop;

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -60,6 +60,9 @@ details.popover-container
     
   .clickable-label
     width: 100%
+    .pop-over-info
+      display: flex
+      align-items: center
     .back
       background-color: transparent
       vertical-align: middle
@@ -305,9 +308,6 @@ details.popover-container
 
     
 .team-user-remove-pop
-  .team-user-remove-header
-    display: flex
-    align-items: center
   .projects-list
     label
       display: flex


### PR DESCRIPTION
Pretty much some separate code to handle the 'show an alt menu in place when you click the button'. I also added a popover component that renders a title with a back button. Through the magic of contexts you don't have to give it a function, it'll grab it from the closest menu.

I also split the team user info pop back into two files since it's gotten pretty large. The only differences are at the bottom of teamuserinfo where it uses NestedPopover and in teamuserremove where it uses NestedPopoverTitle.

Once either this or exopose-create-team gets merged I'll incorporate it into that menu.