### PR TITLE
Nova chance: Always create an anon user for visitors

### DIFF
--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -140,8 +140,8 @@ class CurrentUserManager extends React.Component {
           to: newSharedUser || null,
         }});
       } else {
+        this.setState({fetched: false});
         this.props.setCachedUser(newCachedUser);
-        this.setState({fetched: true});
       }
     } else {
       const newAnonUser = await this.createAnonUser();
@@ -190,7 +190,6 @@ CurrentUserManager.propTypes = {
     persistentToken: PropTypes.string.isRequired,
   }),
   cachedUser: PropTypes.object,
-  loaded: PropTypes.bool.isRequired,
   setSharedUser: PropTypes.func.isRequired,
   setCachedUser: PropTypes.func.isRequired,
 };
@@ -199,11 +198,11 @@ export const CurrentUserProvider = ({children}) => (
   <LocalStorage name="community-cachedUser" default={null}>
     {(cachedUser, setCachedUser, loadedCachedUser) => (
       <LocalStorage name="cachedUser" default={null}>
-        {(sharedUser, setSharedUser, loadedSharedUser) => (
-          <CurrentUserManager sharedUser={sharedUser} setSharedUser={setSharedUser} cachedUser={cachedUser} setCachedUser={setCachedUser} loaded={loadedSharedUser && loadedCachedUser}>
+        {(sharedUser, setSharedUser, loadedSharedUser) => (loadedSharedUser && loadedCachedUser &&
+          <CurrentUserManager sharedUser={sharedUser} setSharedUser={setSharedUser} cachedUser={cachedUser} setCachedUser={setCachedUser}>
             {({api, ...props}) => (
               <Provider value={props}>
-                {loadedSharedUser && loadedCachedUser && children(api)}
+                {children(api)}
               </Provider>
             )}
           </CurrentUserManager>

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -144,8 +144,8 @@ class CurrentUserManager extends React.Component {
         this.props.setCachedUser(newCachedUser);
       }
     } else {
-      const newAnonUser = await this.createAnonUser();
-      this.props.setSharedUser(newAnonUser);
+      const {data} = await this.api().post('users/anon');
+      this.props.setSharedUser(data);
     }
     this.setState({working: false});
   }

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -83,6 +83,9 @@ class CurrentUserManager extends React.Component {
     });
   }
   
+  async getAnonUser() {
+  }
+  
   async getSharedUser() {
     try {
       const {data: {user}} = await this.api().get(`boot?latestProjectOnly=true`);

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -83,7 +83,9 @@ class CurrentUserManager extends React.Component {
     });
   }
   
-  async getAnonUser() {
+  async createAnonUser() {
+    const {data} = await this.api().post('users/anon');
+    return data;
   }
   
   async getSharedUser() {
@@ -141,6 +143,9 @@ class CurrentUserManager extends React.Component {
         this.props.setCachedUser(newCachedUser);
         this.setState({fetched: true});
       }
+    } else {
+      const newAnonUser = await this.createAnonUser();
+      this.props.setSharedUser(newAnonUser);
     }
     this.setState({working: false});
   }
@@ -184,8 +189,9 @@ CurrentUserManager.propTypes = {
     id: PropTypes.number.isRequired,
     persistentToken: PropTypes.string.isRequired,
   }),
-  setSharedUser: PropTypes.func.isRequired,
   cachedUser: PropTypes.object,
+  loaded: PropTypes.bool.isRequired,
+  setSharedUser: PropTypes.func.isRequired,
   setCachedUser: PropTypes.func.isRequired,
 };
 
@@ -194,7 +200,7 @@ export const CurrentUserProvider = ({children}) => (
     {(cachedUser, setCachedUser, loadedCachedUser) => (
       <LocalStorage name="cachedUser" default={null}>
         {(sharedUser, setSharedUser, loadedSharedUser) => (
-          <CurrentUserManager sharedUser={sharedUser} setSharedUser={setSharedUser} cachedUser={cachedUser} setCachedUser={setCachedUser}>
+          <CurrentUserManager sharedUser={sharedUser} setSharedUser={setSharedUser} cachedUser={cachedUser} setCachedUser={setCachedUser} loaded={loadedSharedUser && loadedCachedUser}>
             {({api, ...props}) => (
               <Provider value={props}>
                 {loadedSharedUser && loadedCachedUser && children(api)}

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -83,11 +83,6 @@ class CurrentUserManager extends React.Component {
     });
   }
   
-  async createAnonUser() {
-    const {data} = await this.api().post('users/anon');
-    return data;
-  }
-  
   async getSharedUser() {
     try {
       const {data: {user}} = await this.api().get(`boot?latestProjectOnly=true`);

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -135,8 +135,8 @@ class CurrentUserManager extends React.Component {
           to: newSharedUser || null,
         }});
       } else {
-        this.setState({fetched: false});
         this.props.setCachedUser(newCachedUser);
+        this.setState({fetched: true});
       }
     } else {
       const {data} = await this.api().post('users/anon');


### PR DESCRIPTION
We already get an anon user from any page with an embed on it (the homepage and all ~project pages). I'm standardizing it so it happens on every page instead. Creating the anon user doesn't block rendering, so everything will still need to handle the 'no user object at all' condition.