### PR TITLE
Superb guide: Handle 404s when getting users/teams, proxy the teams page

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -19,7 +19,9 @@ async function getFromCacheOrApi(id, cache, api) {
   if (item === null) {
     try {
       item = (await api(id)) || NOT_FOUND;
-    } catch (e) {
+    } catch (error) {
+      // Technically anything other than a 404 is a 'real' error
+      // but for our usage we can just go on as if it doesn't exist
       item = NOT_FOUND;
     }
     cache.put(id, item, CACHE_TIMEOUT);

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -54,6 +54,7 @@ module.exports = function(app) {
   
   // Pages hosted by 'about.glitch.me':
   [
+    'faq',
     'forplatforms',
     'email-sales',
   ].forEach((route) => proxyGlitch(route, 'about.glitch.me', route));

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -46,9 +46,10 @@ module.exports = function(app) {
 
   // Proxy the some parts of our site over to ghost blogs:
   proxyGhost('help', 'help-center.glitch.me');
-  proxyGhost('featured', 'featured.glitch.me');  
+  proxyGhost('featured', 'featured.glitch.me');
   proxyGhost('about', 'about-glitch.glitch.me');
   proxyGhost('legal', 'about-glitch.glitch.me', '/about');
+  proxyGlitch('teams', 'teams.glitch.me');
   
   // Pages hosted by 'about.glitch.me':
   [

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -1,5 +1,4 @@
 const proxy = require('express-http-proxy');
-const url = require('url');
 const urlJoin = require('url-join');
 
 //
@@ -32,8 +31,8 @@ module.exports = function(app) {
       preserveHostHdr: false, // glitch routes based on this, so we have to reset it
       https: true,
       proxyReqPathResolver: (req) => {
-        const path = urlJoin("/", pathOnTarget, url.parse(req.url).path);
-        console.log("Proxied:", path);
+        const path = urlJoin("/", pathOnTarget, req.path);
+        console.log("Proxied:", urlJoin(routeWithLeadingSlash, req.path));
         return path;
       }
     }));

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -56,10 +56,9 @@ module.exports = function(app) {
   [
     'forplatforms',
     'email-sales',
-    'teams',
   ].forEach((route) => proxyGlitch(route, 'about.glitch.me', route));
   
-  //proxyGlitch('teams', 'teams.glitch.me');
+  proxyGlitch('teams', 'teams.glitch.me');
   
   return routes;
 }

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -41,9 +41,9 @@ module.exports = function(app) {
     routes.push(routeWithLeadingSlash);
   }
 
-  function proxyGhost(route, glitchTarget, pathOnTarget='') {
+  function proxyGhost(route, glitchTarget, pathOnTarget="") {
     // Proxy all the requests to /{route}/ over to glitchTarget
-    proxyGlitch(route, glitchTarget, urlJoin(pathOnTarget, route));
+    proxyGlitch(route, glitchTarget, urlJoin("/", pathOnTarget, route));
   }
 
   // Proxy the some parts of our site over to ghost blogs:
@@ -56,9 +56,10 @@ module.exports = function(app) {
   [
     'forplatforms',
     'email-sales',
+    'teams',
   ].forEach((route) => proxyGlitch(route, 'about.glitch.me', route));
   
-  proxyGlitch('teams', 'teams.glitch.me');
+  //proxyGlitch('teams', 'teams.glitch.me');
   
   return routes;
 }

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -17,7 +17,7 @@ module.exports = function(app) {
       preserveHostHdr: false, // glitch routes based on this, so we have to reset it
       https: true,
       proxyReqPathResolver: (req) => {
-        const path = urlJoin("/", pathOnTarget, route, url.parse(req.url).path);
+        const path = urlJoin("/", pathOnTarget, url.parse(req.url).path);
         console.log("Proxied:", path);
         return path;
       }
@@ -25,7 +25,7 @@ module.exports = function(app) {
     routes.push(routeWithLeadingSlash);
   }
 
-  function proxyGhost(route, glitchTarget, pathOnTarget) {
+  function proxyGhost(route, glitchTarget, pathOnTarget='') {
     const routeWithLeadingSlash = urlJoin("/", route);
     const sandwichedRoute = urlJoin("/", route, "/");
     // node matches /{route} and /{route}/;
@@ -41,7 +41,7 @@ module.exports = function(app) {
     });
   
     // Proxy all the requests to /{route}/ over to glitchTarget
-    proxyGlitch(route, glitchTarget, pathOnTarget);
+    proxyGlitch(route, glitchTarget, urlJoin(pathOnTarget, route));
   }
 
   // Proxy the some parts of our site over to ghost blogs:
@@ -49,18 +49,18 @@ module.exports = function(app) {
   proxyGhost('featured', 'featured.glitch.me');
   proxyGhost('about', 'about-glitch.glitch.me');
   proxyGhost('legal', 'about-glitch.glitch.me', '/about');
-  proxyGlitch('teams', 'teams.glitch.me');
   
   // Pages hosted by 'about.glitch.me':
   [
     'faq',
     'react-starter-kit',
     'website-starter-kit',
-    'teams',
     'forplatforms',
     'you-got-this',
     'email-sales',
-  ].forEach((route) => proxyGlitch(route, 'about.glitch.me'));
+  ].forEach((route) => proxyGlitch(route, 'about.glitch.me', route));
+  
+  proxyGlitch('teams', 'teams.glitch.me');
   
   return routes;
 }

--- a/server/redirects.js
+++ b/server/redirects.js
@@ -2,10 +2,10 @@ module.exports = function(app) {
   redirect(app, '/partners*', '/teams/');
   redirect(app, '/foryourapi*', '/teams/');
   redirect(app, '/forteams*', '/teams/');
-  redirect(app, '/website-starter-kit*', '/featured/website-starter-kit');  
-  redirect(app, '/react-starter-kit*', '/featured/react-starter-kit');
-  redirect(app, '/you-got-this/2*', '/featured/you-got-this-zine-2');   
-  redirect(app, '/you-got-this*', '/featured/you-got-this-zine'); 
+  redirect(app, '/website-starter-kit*', '/featured/website-starter-kit/');  
+  redirect(app, '/react-starter-kit*', '/featured/react-starter-kit/');
+  redirect(app, '/you-got-this/2*', '/featured/you-got-this-zine-2/');   
+  redirect(app, '/you-got-this*', '/featured/you-got-this-zine/'); 
 }
 
 function redirect(app, route, target) {

--- a/server/redirects.js
+++ b/server/redirects.js
@@ -1,5 +1,4 @@
 module.exports = function(app) {
-  redirect(app, '/faq', '/help');
   redirect(app, '/partners*', '/teams');
   redirect(app, '/foryourapi*', '/teams');
   redirect(app, '/forteams*', '/teams');

--- a/server/redirects.js
+++ b/server/redirects.js
@@ -1,4 +1,5 @@
 module.exports = function(app) {
+  redirect(app, '/faq', '/help');
   redirect(app, '/partners*', '/teams');
   redirect(app, '/foryourapi*', '/teams');
   redirect(app, '/forteams*', '/teams');

--- a/server/redirects.js
+++ b/server/redirects.js
@@ -1,7 +1,7 @@
 module.exports = function(app) {
-  redirect(app, '/partners*', '/teams');
-  redirect(app, '/foryourapi*', '/teams');
-  redirect(app, '/forteams*', '/teams');
+  redirect(app, '/partners*', '/teams/');
+  redirect(app, '/foryourapi*', '/teams/');
+  redirect(app, '/forteams*', '/teams/');
   redirect(app, '/website-starter-kit*', '/featured/website-starter-kit');  
   redirect(app, '/react-starter-kit*', '/featured/react-starter-kit');
   redirect(app, '/you-got-this/2*', '/featured/you-got-this-zine-2');   

--- a/src/presenters/pages/join-team.jsx
+++ b/src/presenters/pages/join-team.jsx
@@ -19,7 +19,9 @@ class JoinTeamPageBase extends React.Component {
     try {
       var {data: team} = await this.props.api.get(`/teams/byUrl/${this.props.teamUrl}`);
     } catch (error) {
-      Raven.captureException(error);
+      if (error && !(error.response && error.response.status === 404)) {
+        Raven.captureException(error);
+      }
     }
     if (!team) {
       // Either the api is down or the team doesn't exist

--- a/src/presenters/pages/team-or-user.jsx
+++ b/src/presenters/pages/team-or-user.jsx
@@ -24,12 +24,12 @@ const getOrNull = async(api, route) => {
 };
 
 const getUserById = async (api, id) => {
-  const user = await getOrNull(api, `users/${id}`);
+  const user = await getOrNull(api, `/users/${id}`);
   return user && UserModel(user).asProps();
 };
 
 const getUser = async (api, name) => {
-  const id = await getOrNull(api, `userId/byLogin/${name}`);
+  const id = await getOrNull(api, `/userId/byLogin/${name}`);
   if (id === "NOT FOUND") {
     return null;
   }
@@ -46,12 +46,12 @@ const parseTeam = (team) => {
 };
 
 const getTeamById = async (api, id) => {
-  const team = await getOrNull(api, `teams/${id}`);
+  const team = await getOrNull(api, `/teams/${id}`);
   return team && parseTeam(team);
 };
 
 const getTeam = async (api, name) => {
-  const team = await getOrNull(api, `teams/byUrl/${name}`);
+  const team = await getOrNull(api, `/teams/byUrl/${name}`);
   return team && parseTeam(team);
 };
 

--- a/src/presenters/pages/team-or-user.jsx
+++ b/src/presenters/pages/team-or-user.jsx
@@ -11,43 +11,48 @@ import Layout from '../layout.jsx';
 import TeamPage from './team.jsx';
 import UserPage from './user.jsx';
 
+const getOrNull = async(api, route) => {
+  try {
+    const {data} = await api.get(route);
+    return data;
+  } catch (error) {
+    if (error && error.response && error.response.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+};
+
 const getUserById = async (api, id) => {
-  const {data} = await api.get(`users/${id}`);
-  return UserModel(data).asProps();
+  const user = await getOrNull(api, `users/${id}`);
+  return user && UserModel(user).asProps();
 };
 
 const getUser = async (api, name) => {
-  const {data} = await api.get(`userId/byLogin/${name}`);
-  if (data === "NOT FOUND") {
+  const id = await getOrNull(api, `userId/byLogin/${name}`);
+  if (id === "NOT FOUND") {
     return null;
   }
-  return getUserById(api, data);
+  return await getUserById(api, id);
 };
 
-const parseTeamAdminIds = (data) => {
-  if (!data) {
-    return data;
-  }
+const parseTeam = (team) => {
   const ADMIN_ACCESS_LEVEL = 30;
-  let adminIds = data.users.filter(user => {
+  const adminIds = team.users.filter(user => {
     return user.teamsUser.accessLevel === ADMIN_ACCESS_LEVEL;
   });
-  data.adminIds = adminIds.map(user => {
-    return user.id;
-  });
-  return data;
+  team.adminIds = adminIds.map(user => user.id);
+  return TeamModel(team).asProps();
 };
 
 const getTeamById = async (api, id) => {
-  let {data} = await api.get(`teams/${id}`);
-  data = parseTeamAdminIds(data);
-  return data && TeamModel(data).asProps();
+  const team = await getOrNull(api, `teams/${id}`);
+  return team && parseTeam(team);
 };
 
 const getTeam = async (api, name) => {
-  let {data} = await api.get(`teams/byUrl/${name}`);
-  data = parseTeamAdminIds(data);
-  return data && TeamModel(data).asProps();
+  const team = await getOrNull(api, `teams/byUrl/${name}`);
+  return team && parseTeam(team);
 };
 
 const TeamPageLoader = ({api, id, name, ...props}) => (

--- a/src/presenters/pages/team-or-user.jsx
+++ b/src/presenters/pages/team-or-user.jsx
@@ -44,7 +44,7 @@ const getTeamById = async (api, id) => {
   return data && TeamModel(data).asProps();
 };
 
-const getTeam = async(api, name) => {
+const getTeam = async (api, name) => {
   let {data} = await api.get(`teams/byUrl/${name}`);
   data = parseTeamAdminIds(data);
   return data && TeamModel(data).asProps();


### PR DESCRIPTION
The api is going to start giving 404s when teams don't exist rather than returning `null`.

I also did some cleanup around the proxy so we can use Pirijian's new teams page. Proxied sites can exist at their root url now, but they'll have to be careful not to use any base relative urls.