### PR TITLE
Profuse-tea: Fix currentUser identification

### DIFF
--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -146,6 +146,7 @@ class CurrentUserManager extends React.Component {
   }
   
   componentDidMount() {
+    identifyUser(this.props.cachedUser);
     this.load();
   }
   


### PR DESCRIPTION
The change to auto create anon users broke an assumption on page load such that we don't report the current user to sentry and analytics unless you sign in or out on that page load.

It used to only report the user when the user changed, but now you start with the user loaded and generally don't change it.