### PR TITLE
Superb-guide: Fix the the extra add project buttons on team pages

### DIFF
--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -11,7 +11,7 @@ const RECENT_REMIXES_COUNT = 100;
 const getProjectDetails = async ({id, api, currentProjectDomain}) => {
   let path = `analytics/${id}/project/${currentProjectDomain}/overview`;
   try {
-    return await api().get(path);
+    return await api.get(path);
   } catch (error) {
     console.error('getProjectDetails', error);
   }
@@ -153,7 +153,7 @@ class TeamAnalyticsProjectDetails extends React.Component {
 TeamAnalyticsProjectDetails.propTypes = {
   currentProjectDomain: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired,
-  api: PropTypes.func.isRequired,
+  api: PropTypes.any.isRequired,
 };
 
 export default TeamAnalyticsProjectDetails;

--- a/src/presenters/includes/team-analytics.jsx
+++ b/src/presenters/includes/team-analytics.jsx
@@ -40,7 +40,7 @@ const getAnalytics = async ({id, api}, fromDate, currentProjectDomain) => {
     path = `analytics/${id}/project/${currentProjectDomain}?from=${fromDate}`;
   }
   try {
-    return await api().get(path);
+    return await api.get(path);
   } catch (error) {
     console.error('getAnalytics', error);
   }
@@ -231,7 +231,7 @@ class TeamAnalytics extends React.Component {
         { this.props.projects.length === 0 &&
           <aside className="inline-banners add-project-to-analytics-banner">
             <div className="description">Add Projects to see who's viewing and remixing</div>
-            <AddTeamProject 
+            <AddTeamProject
               {...this.props}
               extraButtonClass = "button-small"
               teamProjects = {this.props.projects}
@@ -245,7 +245,7 @@ class TeamAnalytics extends React.Component {
 
 TeamAnalytics.propTypes = {
   id: PropTypes.number,
-  api: PropTypes.func.isRequired,
+  api: PropTypes.any.isRequired,
   projects: PropTypes.array.isRequired,
   currentUserIsOnTeam: PropTypes.bool.isRequired,
   addProject: PropTypes.func.isRequired,

--- a/src/presenters/pages/team.jsx
+++ b/src/presenters/pages/team.jsx
@@ -179,14 +179,14 @@ class TeamPage extends React.Component {
               {...this.props}
               extraButtonClass = "button-small"
               teamProjects = {this.props.team.projects}
-              api={() => this.props.api}
+              api={this.props.api}
             />
           </aside>
         }
 
         { this.props.currentUserIsOnTeam &&
           <TeamAnalytics
-            api={() => this.props.api}
+            api={this.props.api}
             id={this.props.team.id}
             currentUserIsOnTeam={this.props.currentUserIsOnTeam}
             projects={this.props.team.projects}


### PR DESCRIPTION
https://www.notion.so/glitch/bug-teams-page-crasher-click-add-project-in-analytics-when-no-projects-4e95f5a8dcbe405da6c576215091cbee