### PR TITLE
Ordinary emu -- touch up 'show more' button styling on readme files

### DIFF
--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -49,7 +49,7 @@ export default class Expander extends React.Component {
             {!expanded && (
               <button
                 onClick={this.expand.bind(this)}
-                className="expander-button button button-small button-tertiary"
+                className="expander-button button button-tertiary button-link"
               >
                 Show More
               </button>

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -49,7 +49,7 @@ export default class Expander extends React.Component {
             {!expanded && (
               <button
                 onClick={this.expand.bind(this)}
-                className="expander-button button-tertiary"
+                className="expander-button button-small button-tertiary"
               >
                 Show More
               </button>

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -49,7 +49,7 @@ export default class Expander extends React.Component {
             {!expanded && (
               <button
                 onClick={this.expand.bind(this)}
-                className="expander-button button button-tertiary button-link"
+                className="expander-button button-tertiary"
               >
                 Show More
               </button>

--- a/styles/includes/expander.styl
+++ b/styles/includes/expander.styl
@@ -12,10 +12,12 @@
     display: flex
     flex-direction: row
     align-items: flex-end
-    background: linear-gradient(to bottom, transparent calc(100% - 25px), white)
+    background: linear-gradient(to bottom, transparent calc(100% - 121px), white)
   
   .expander-button
     position: initial
+    margin-bottom: 2px
+    box-shadow: 2px 2px 0 tertiary
     &::before
       position: absolute
       top: 0

--- a/styles/includes/expander.styl
+++ b/styles/includes/expander.styl
@@ -18,6 +18,8 @@
     position: initial
     margin-bottom: 2px
     box-shadow: 2px 2px 0 tertiary
+    &:hover
+      border-color: primary
     &::before
       position: absolute
       top: 0


### PR DESCRIPTION
https://www.notion.so/glitch/87bda09f85184c1d81e1659aa62e4392?v=9f7963becc9341ed9af502682c6e9eef&p=44f17f21280442dca6c6a39949f4448b

before:
![image](https://user-images.githubusercontent.com/12502380/47037250-71b1d680-d14c-11e8-8400-c51152b3c5ee.png)

before (on hover):
![image](https://user-images.githubusercontent.com/12502380/47037259-78d8e480-d14c-11e8-9fb3-b10ef7eeb814.png)

after:
![image](https://user-images.githubusercontent.com/12502380/47037291-89895a80-d14c-11e8-872a-00d6c72576cf.png)

after (on hover):
![image](https://user-images.githubusercontent.com/12502380/47037297-90b06880-d14c-11e8-8eaf-efea315eda5f.png)

