### PR TITLE
Profuse tea: A couple small bug fixes

### DIFF
--- a/src/presenters/includes/project-result-item.jsx
+++ b/src/presenters/includes/project-result-item.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {getAvatarUrl} from  '../../models/project';
-import UsersList from '../users-list.jsx';
+import {StaticUsersList} from '../users-list.jsx';
 
 const ProjectResultItem = ({id, domain, description, users, action, isActive}) => {
   var resultClass = "button-unstyled result ";
@@ -16,7 +16,7 @@ const ProjectResultItem = ({id, domain, description, users, action, isActive}) =
       <div className="result-name" title={domain}>{domain}</div>
       
       { description.length > 0 && <div className="result-description">{description}</div> }
-      { users.length > 0 && <UsersList users={users} /> }
+      { users.length > 0 && <StaticUsersList users={users} /> }
     </button>
   );
 };

--- a/src/presenters/includes/team-users.jsx
+++ b/src/presenters/includes/team-users.jsx
@@ -16,6 +16,7 @@ export const TeamUsers = (props) => (
     {(user, togglePopover) =>
       <TeamUserInfoPop
         userIsTeamAdmin={props.adminIds.includes(user.id)}
+        userIsTheOnlyMember={props.users.length === 1}
         user={user} togglePopover={togglePopover}
         {...props}
       />

--- a/src/presenters/pages/router.jsx
+++ b/src/presenters/pages/router.jsx
@@ -37,7 +37,7 @@ const NotFoundPage = () => (
 class PageChangeHandlerBase extends React.Component {
   componentDidUpdate(prev) {
     if (this.props.location.key !== prev.location.key) {
-      window.scrollTo({left: 0, top: 0, behavior: 'instant'});
+      window.scrollTo(0, 0);
       this.props.reloadCurrentUser();
     }
   }

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -95,7 +95,7 @@ const TeamUserInfo = ({currentUser, showRemove, ...props}) => {
           updateUserPermissions={props.updateUserPermissions}
         />
       }
-      { canRemoveUser && <RemoveFromTeam onClick={showRemove} disabled={props.userIsTheOnlyMember}/> }
+      { canRemoveUser && !props.userIsTheOnlyMember && <RemoveFromTeam onClick={showRemove}/> }
     </dialog>
   );
 };

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -14,9 +14,9 @@ const ADMIN_ACCESS_LEVEL = 30;
 
 // Remove from Team 👋
 
-const RemoveFromTeam = ({onClick}) => (
+const RemoveFromTeam = (props) => (
   <section className="pop-over-actions danger-zone">
-    <button className="button-small has-emoji button-tertiary button-on-secondary-background" onClick={onClick}>
+    <button className="button-small has-emoji button-tertiary button-on-secondary-background" {...props}>
       Remove from Team <span className="emoji wave" role="img" aria-label=""/>
     </button>
   </section>
@@ -95,7 +95,7 @@ const TeamUserInfo = ({currentUser, showRemove, ...props}) => {
           updateUserPermissions={props.updateUserPermissions}
         />
       }
-      { canRemoveUser && <RemoveFromTeam onClick={showRemove}/> }
+      { canRemoveUser && <RemoveFromTeam onClick={showRemove} disabled={props.userIsTheOnlyMember}/> }
     </dialog>
   );
 };
@@ -123,11 +123,12 @@ TeamUserInfoAndRemovePop.propTypes = {
     color: PropTypes.string,
   }).isRequired,
   currentUserIsOnTeam: PropTypes.bool.isRequired,
+  currentUserIsTeamAdmin: PropTypes.bool.isRequired,
   removeUserFromTeam: PropTypes.func.isRequired,
   userIsTeamAdmin: PropTypes.bool.isRequired,
+  userIsTheOnlyMember: PropTypes.bool.isRequired,
   api: PropTypes.func.isRequired,
   teamId: PropTypes.number.isRequired,
-  currentUserIsTeamAdmin: PropTypes.bool.isRequired,
   updateUserPermissions: PropTypes.func.isRequired,
   team: PropTypes.shape({
     projects: PropTypes.array.isRequired,

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -300,7 +300,7 @@ details.popover-container
   .info-description
     margin-top: 10px
   .illustration
-    width: 110px
+    height: 100px
 
 .upgrade-team-pop
   top: 26px

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -300,6 +300,7 @@ details.popover-container
   .info-description
     margin-top: 10px
   .illustration
+    display: inline-block
     height: 100px
 
 .upgrade-team-pop

--- a/styles/tooltips.styl
+++ b/styles/tooltips.styl
@@ -55,7 +55,7 @@ secondary = #9B9B9B
 [data-tooltip]:hover,
 [data-tooltip]:focus,
 [data-tooltip]:focus-within,
-button:hover [data-tooltip] // workaround for a firefox bug where stuff inside a button ignores :hover
+button:hover > [data-tooltip] // workaround for a firefox bug where stuff inside a button ignores :hover
   &::before, &::after
     visibility: visible
     opacity: 1


### PR DESCRIPTION
1. Some just barely supported browsers don't support the `scrollTo` object syntax
2. Hide the remove from team button if you're the only member of the team
3. The analytics project switcher would show user names when you hovered over projects