### PR TITLE
Superb guide: Don't auto expand readmes

### DIFF
--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -5,6 +5,7 @@ export default class Expander extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      expanding: false,
       expanded: false,
       scrollHeight: Infinity,
     };
@@ -21,34 +22,36 @@ export default class Expander extends React.Component {
   }
   
   updateHeight() {
-    if (this.ref.current.scrollHeight !== this.state.scrollHeight) {
-      this.setState({scrollHeight: this.ref.current.scrollHeight});
+    const scrollHeight = this.ref.current.scrollHeight
+    if (scrollHeight !== this.state.scrollHeight) {
+      this.setState({scrollHeight});
     }
   }
   
   expand() {
     this.updateHeight();
-    this.setState({expanded: true});
+    this.setState({expanding: true});
   }
   
   onExpandEnd(evt) {
     if (evt.propertyName === 'max-height') {
-      this.setState({maxHeight: undefined});
+      this.setState({expanded: true});
     }
   }
   
   render() {
-    const {expanded, scrollHeight, maxHeight} = this.state;
+    const {expanding, expanded, scrollHeight} = this.state;
+    const maxHeight = expanding ? scrollHeight : this.props.height;
     return (
       <div
-        className="expander" style={{maxHeight}}
-        onTransitionEnd={(expanded && !!maxHeight) ? this.onExpandEnd.bind(this) : null}
+        className="expander" style={!expanded ? {maxHeight} : null}
+        onTransitionEnd={(expanding && !expanded) ? this.onExpandEnd.bind(this) : null}
         ref={this.ref}
       >
         {this.props.children}
-        {!!maxHeight && scrollHeight > maxHeight && (
+        {!expanded && scrollHeight > maxHeight && (
           <div className="expander-mask">
-            {!expanded && scrollHeight > maxHeight && (
+            {!expanding && scrollHeight > maxHeight && (
               <button
                 onClick={this.expand.bind(this)}
                 className="expander-button button-small button-tertiary"

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -42,16 +42,16 @@ export default class Expander extends React.Component {
   render() {
     const {expanding, expanded, scrollHeight} = this.state;
     const maxHeight = expanding ? scrollHeight : this.props.height;
+    const style = !expanded ? {maxHeight} : null;
     return (
       <div
-        className="expander" style={!expanded ? {maxHeight} : null}
-        onTransitionEnd={(expanding && !expanded) ? this.onExpandEnd.bind(this) : null}
-        ref={this.ref}
+        ref={this.ref} className="expander" style={style}
+        onTransitionEnd={this.onExpandEnd.bind(this)}
       >
         {this.props.children}
         {!expanded && scrollHeight > maxHeight && (
           <div className="expander-mask">
-            {!expanding && scrollHeight > maxHeight && (
+            {!expanding && (
               <button
                 onClick={this.expand.bind(this)}
                 className="expander-button button-small button-tertiary"

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -84,5 +84,5 @@ Expander.propTypes = {
 };
 
 Expander.defaultProps = {
-  minSlide: 100,
+  minSlide: 50,
 };

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -30,7 +30,6 @@ export default class Expander extends React.Component {
   
   updateHeight() {
     const scrollHeight = this.ref.current.scrollHeight;
-    console.log(scrollHeight);
     if (scrollHeight !== this.state.scrollHeight) {
       this.setState({scrollHeight});
     }
@@ -53,7 +52,6 @@ export default class Expander extends React.Component {
     const limitHeight = aboveLimit ? this.props.height - this.props.minSlide : this.props.height;
     const maxHeight = startedExpanding ? scrollHeight : limitHeight;
     const style = !doneExpanding ? {maxHeight} : null;
-    console.log(aboveLimit, limitHeight, maxHeight, style);
     return (
       <div
         ref={this.ref} className="expander" style={style}

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -6,6 +6,7 @@ export default class Expander extends React.Component {
     super(props);
     this.state = {
       expanded: false,
+      scrollHeight: Infinity,
       maxHeight: props.height,
     };
     this.ref = React.createRef();
@@ -16,8 +17,8 @@ export default class Expander extends React.Component {
     const maxHeight = this.props.height + 60;
     if (this.ref.current.scrollHeight <= maxHeight) {
       this.setState({
-        expanded: true,
-        maxHeight: undefined,
+        //expanded: true,
+        //maxHeight: undefined,
       });
     }
   }
@@ -36,7 +37,13 @@ export default class Expander extends React.Component {
   }
   
   render() {
-    const {expanded, maxHeight} = this.state;
+    const {expanded, scrollHeight, maxHeight} = this.state;
+    let showMask = !!maxHeight;
+    let showButton = !expanded;
+    if (!expanded && scrollHeight < this.props.height + 60) {
+      showMask = false;
+      showButton = false;
+    }
     return (
       <div
         className="expander" style={{maxHeight}}
@@ -44,9 +51,9 @@ export default class Expander extends React.Component {
         ref={this.ref}
       >
         {this.props.children}
-        {!!maxHeight && (
+        {showMask && (
           <div className="expander-mask">
-            {!expanded && (
+            {showButton && (
               <button
                 onClick={this.expand.bind(this)}
                 className="expander-button button-small button-tertiary"

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -5,8 +5,8 @@ export default class Expander extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      expanding: false,
-      expanded: false,
+      startedExpanding: false,
+      doneExpanding: false,
       scrollHeight: Infinity,
     };
     this.ref = React.createRef();
@@ -22,7 +22,7 @@ export default class Expander extends React.Component {
   }
   
   updateHeight() {
-    const scrollHeight = this.ref.current.scrollHeight
+    const scrollHeight = this.ref.current.scrollHeight;
     if (scrollHeight !== this.state.scrollHeight) {
       this.setState({scrollHeight});
     }
@@ -30,28 +30,28 @@ export default class Expander extends React.Component {
   
   expand() {
     this.updateHeight();
-    this.setState({expanding: true});
+    this.setState({startedExpanding: true});
   }
   
   onExpandEnd(evt) {
     if (evt.propertyName === 'max-height') {
-      this.setState({expanded: true});
+      this.setState({doneExpanding: true});
     }
   }
   
   render() {
-    const {expanding, expanded, scrollHeight} = this.state;
-    const maxHeight = expanding ? scrollHeight : this.props.height;
-    const style = !expanded ? {maxHeight} : null;
+    const {startedExpanding, doneExpanding, scrollHeight} = this.state;
+    const maxHeight = startedExpanding ? scrollHeight : this.props.height;
+    const style = !doneExpanding ? {maxHeight} : null;
     return (
       <div
         ref={this.ref} className="expander" style={style}
         onTransitionEnd={this.onExpandEnd.bind(this)}
       >
         {this.props.children}
-        {!expanded && scrollHeight > maxHeight && (
+        {!doneExpanding && scrollHeight > this.props.height && (
           <div className="expander-mask">
-            {!expanding && (
+            {!startedExpanding && (
               <button
                 onClick={this.expand.bind(this)}
                 className="expander-button button-small button-tertiary"

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -16,7 +16,8 @@ export default class Expander extends React.Component {
     this.setState({scrollHeight: this.ref.current.scrollHeight});
   }
   
-  componentDidUpdate() {
+  onLoad(event) {
+    console.log(event);
     if (this.ref.current.scrollHeight !== this.state.scrollHeight) {
       this.setState({scrollHeight: this.ref.current.scrollHeight});
     }
@@ -41,7 +42,7 @@ export default class Expander extends React.Component {
       <div
         className="expander" style={{maxHeight}}
         onTransitionEnd={(expanded && !!maxHeight) ? this.onExpandEnd.bind(this) : null}
-        onLoadCapture={this.componentDidUpdate.bind(this)}
+        onLoadCapture={this.onLoad.bind(this)}
         ref={this.ref}
       >
         {this.props.children}

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -10,11 +10,18 @@ export default class Expander extends React.Component {
       scrollHeight: Infinity,
     };
     this.ref = React.createRef();
+    this.updateHeight = this.updateHeight.bind(this);
   }
   
   componentDidMount() {
     this.updateHeight();
-    this.ref.current.addEventListener('load', this.updateHeight.bind(this), {capture: true});
+    this.ref.current.addEventListener('load', this.updateHeight, {capture: true});
+    window.addEventListener('resize', this.updateHeight, {passive: true});
+  }
+  
+  componentWillUnmount() {
+    this.ref.current.removeEventListener('load', this.updateHeight, {capture: true});
+    window.removeEventListener('resize', this.updateHeight, {passive: true});
   }
   
   componentDidUpdate() {

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -30,6 +30,7 @@ export default class Expander extends React.Component {
   
   updateHeight() {
     const scrollHeight = this.ref.current.scrollHeight;
+    console.log(scrollHeight);
     if (scrollHeight !== this.state.scrollHeight) {
       this.setState({scrollHeight});
     }
@@ -48,13 +49,15 @@ export default class Expander extends React.Component {
   
   render() {
     const {startedExpanding, doneExpanding, scrollHeight} = this.state;
-    const aboveLimit = scrollHeight > this.props.height + this.props.buffer;
-    const maxHeight = startedExpanding ? scrollHeight : this.props.height;
+    const aboveLimit = scrollHeight > this.props.height;
+    const limitHeight = aboveLimit ? this.props.height - this.props.minSlide : this.props.height;
+    const maxHeight = startedExpanding ? scrollHeight : limitHeight;
     const style = !doneExpanding ? {maxHeight} : null;
+    console.log(aboveLimit, limitHeight, maxHeight, style);
     return (
       <div
         ref={this.ref} className="expander" style={style}
-        onTransitionEnd={this.onExpandEnd.bind(this)}
+        onTransitionEnd={startedExpanding ? this.onExpandEnd.bind(this) : null}
       >
         {this.props.children}
         {!doneExpanding && aboveLimit && (
@@ -77,9 +80,9 @@ export default class Expander extends React.Component {
 Expander.propTypes = {
   children: PropTypes.node.isRequired,
   height: PropTypes.number.isRequired,
-  buffer: PropTypes.number.isRequired,
+  minSlide: PropTypes.number.isRequired,
 };
 
 Expander.defaultProps = {
-  buffer: 50,
+  minSlide: 100,
 };

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -7,27 +7,28 @@ export default class Expander extends React.Component {
     this.state = {
       expanded: false,
       scrollHeight: Infinity,
-      maxHeight: props.height,
     };
     this.ref = React.createRef();
   }
   
   componentDidMount() {
-    this.setState({scrollHeight: this.ref.current.scrollHeight});
+    this.updateHeight();
+    this.ref.current.addEventListener('load', this.updateHeight.bind(this), {capture: true});
   }
   
-  onLoad(event) {
-    console.log(event);
+  componentDidUpdate() {
+    this.updateHeight();
+  }
+  
+  updateHeight() {
     if (this.ref.current.scrollHeight !== this.state.scrollHeight) {
       this.setState({scrollHeight: this.ref.current.scrollHeight});
     }
   }
   
   expand() {
-    this.setState({
-      expanded: true,
-      maxHeight: this.ref.current.scrollHeight,
-    });
+    this.updateHeight();
+    this.setState({expanded: true});
   }
   
   onExpandEnd(evt) {
@@ -42,7 +43,6 @@ export default class Expander extends React.Component {
       <div
         className="expander" style={{maxHeight}}
         onTransitionEnd={(expanded && !!maxHeight) ? this.onExpandEnd.bind(this) : null}
-        onLoadCapture={this.onLoad.bind(this)}
         ref={this.ref}
       >
         {this.props.children}

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -13,13 +13,12 @@ export default class Expander extends React.Component {
   }
   
   componentDidMount() {
-    // If the area is only slightly too big don't bother cutting it off
-    const maxHeight = this.props.height + 60;
-    if (this.ref.current.scrollHeight <= maxHeight) {
-      this.setState({
-        //expanded: true,
-        //maxHeight: undefined,
-      });
+    this.setState({scrollHeight: this.ref.current.scrollHeight});
+  }
+  
+  componentDidUpdate() {
+    if (this.ref.current.scrollHeight !== this.state.scrollHeight) {
+      this.setState({scrollHeight: this.ref.current.scrollHeight});
     }
   }
   
@@ -38,22 +37,17 @@ export default class Expander extends React.Component {
   
   render() {
     const {expanded, scrollHeight, maxHeight} = this.state;
-    let showMask = !!maxHeight;
-    let showButton = !expanded;
-    if (!expanded && scrollHeight < this.props.height + 60) {
-      showMask = false;
-      showButton = false;
-    }
     return (
       <div
         className="expander" style={{maxHeight}}
         onTransitionEnd={(expanded && !!maxHeight) ? this.onExpandEnd.bind(this) : null}
+        onLoadCapture={this.componentDidUpdate.bind(this)}
         ref={this.ref}
       >
         {this.props.children}
-        {showMask && (
+        {!!maxHeight && scrollHeight > maxHeight && (
           <div className="expander-mask">
-            {showButton && (
+            {!expanded && scrollHeight > maxHeight && (
               <button
                 onClick={this.expand.bind(this)}
                 className="expander-button button-small button-tertiary"

--- a/src/presenters/includes/expander.jsx
+++ b/src/presenters/includes/expander.jsx
@@ -48,6 +48,7 @@ export default class Expander extends React.Component {
   
   render() {
     const {startedExpanding, doneExpanding, scrollHeight} = this.state;
+    const aboveLimit = scrollHeight > this.props.height + this.props.buffer;
     const maxHeight = startedExpanding ? scrollHeight : this.props.height;
     const style = !doneExpanding ? {maxHeight} : null;
     return (
@@ -56,7 +57,7 @@ export default class Expander extends React.Component {
         onTransitionEnd={this.onExpandEnd.bind(this)}
       >
         {this.props.children}
-        {!doneExpanding && scrollHeight > this.props.height && (
+        {!doneExpanding && aboveLimit && (
           <div className="expander-mask">
             {!startedExpanding && (
               <button
@@ -76,4 +77,9 @@ export default class Expander extends React.Component {
 Expander.propTypes = {
   children: PropTypes.node.isRequired,
   height: PropTypes.number.isRequired,
+  buffer: PropTypes.number.isRequired,
+};
+
+Expander.defaultProps = {
+  buffer: 50,
 };

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -74,7 +74,7 @@ const ReadmeError = (error) => (
 );
 const ReadmeLoader = ({api, domain}) => (
   <DataLoader get={() => api.get(`projects/${domain}/readme`)} renderError={ReadmeError}>
-    {({data}) => <Expander height={200}><Markdown>{data}</Markdown></Expander>}
+    {({data}) => <Expander height={250}><Markdown>{data}</Markdown></Expander>}
   </DataLoader>
 );
 ReadmeLoader.propTypes = {


### PR DESCRIPTION
https://superb-guide.glitch.me/~three-js

I got inspired for this based on the only show x projects pr. Readmes used to check their height on load and if they were short enough they'd snap to the expanded state.

That had the side effect of sometimes expanding readmes that were too large, because they images that didn't load until after the height check. The new solution is to track the scrollHeight and show the fade/button if the readme is actually being cut off.

There is no way to actually listen for scrollHeight changes, so instead I'm just watching for onLoad events and updating whenever one comes in. (capturing because onLoad doesn't bubble)