### PR TITLE
Profuse tea: stricter email identification, more 404 handling, error boundaries

### DIFF
--- a/src/client.jsx
+++ b/src/client.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {render} from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 
+import ErrorBoundary from './presenters/includes/error-boundary.jsx';
 import {CurrentUserProvider} from './presenters/current-user.jsx';
 import {UserPrefsProvider} from './presenters/includes/user-prefs.jsx';
 import {DevTogglesProvider} from './presenters/includes/dev-toggles.jsx';
@@ -13,17 +14,19 @@ import {Notifications} from './presenters/notifications.jsx';
 import Router from './presenters/pages/router.jsx';
 
 const App = () => (
-  <BrowserRouter>
-    <Notifications>
-      <UserPrefsProvider>
-        <DevTogglesProvider>
-          <CurrentUserProvider>
-            {api => <Router api={api}/>}
-          </CurrentUserProvider>
-        </DevTogglesProvider>
-      </UserPrefsProvider>
-    </Notifications>
-  </BrowserRouter>
+  <ErrorBoundary fallback="Something went very wrong, try refreshing?">
+    <BrowserRouter>
+      <Notifications>
+        <UserPrefsProvider>
+          <DevTogglesProvider>
+            <CurrentUserProvider>
+              {api => <Router api={api}/>}
+            </CurrentUserProvider>
+          </DevTogglesProvider>
+        </UserPrefsProvider>
+      </Notifications>
+    </BrowserRouter>
+  </ErrorBoundary>
 );
 
 // Here's a bunch of browser support tests

--- a/src/presenters/includes/error-boundary.jsx
+++ b/src/presenters/includes/error-boundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+/* global Raven */
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {error: null};
+  }
+  
+  componentDidCatch(error) {
+    console.error(error);
+    Raven.captureException(error);
+    this.setState({error});
+  }
+  
+  render() {
+    const {children, fallback} = this.props;
+    const {error} = this.state;
+    return error ? fallback(error) : children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  fallback: PropTypes.func.isRequired,
+};
+
+ErrorBoundary.defaultProps = {
+  fallback: () => 'Something went wrong, try refreshing?',
+};

--- a/src/presenters/includes/error-boundary.jsx
+++ b/src/presenters/includes/error-boundary.jsx
@@ -17,15 +17,15 @@ export default class ErrorBoundary extends React.Component {
   render() {
     const {children, fallback} = this.props;
     const {error} = this.state;
-    return error ? fallback(error) : children;
+    return error ? fallback : children;
   }
 }
 
 ErrorBoundary.propTypes = {
   children: PropTypes.node.isRequired,
-  fallback: PropTypes.func.isRequired,
+  fallback: PropTypes.node,
 };
 
 ErrorBoundary.defaultProps = {
-  fallback: () => 'Something went wrong, try refreshing?',
+  fallback: 'Something went wrong, try refreshing?',
 };

--- a/src/presenters/layout.jsx
+++ b/src/presenters/layout.jsx
@@ -5,6 +5,7 @@ import Helmet from 'react-helmet';
 
 import Header from './header.jsx';
 import Footer from './footer.jsx';
+import ErrorBoundary 
 import Konami from './includes/konami.jsx';
 
 

--- a/src/presenters/layout.jsx
+++ b/src/presenters/layout.jsx
@@ -5,7 +5,7 @@ import Helmet from 'react-helmet';
 
 import Header from './header.jsx';
 import Footer from './footer.jsx';
-import ErrorBoundary 
+import ErrorBoundary from './includes/error-boundary.jsx';
 import Konami from './includes/konami.jsx';
 
 
@@ -15,11 +15,15 @@ const Layout = ({children, api, searchQuery}) => (
       <title>Glitch</title>
     </Helmet>
     <Header api={api} searchQuery={searchQuery}/>
-    {children}
+    <ErrorBoundary>
+      {children}
+    </ErrorBoundary>
     <Footer/>
-    <Konami>
-      <Redirect to="/secret" push={true}/>
-    </Konami>
+    <ErrorBoundary fallback={null}>
+      <Konami>
+        <Redirect to="/secret" push={true}/>
+      </Konami>
+    </ErrorBoundary>
   </div>
 );
 Layout.propTypes = {

--- a/src/presenters/pop-overs/add-team-user-pop.jsx
+++ b/src/presenters/pop-overs/add-team-user-pop.jsx
@@ -78,7 +78,7 @@ class AddTeamUserPop extends React.Component {
       domain = email.domain;
     } else {
       const fakeEmail = parseOneAddress(query.replace('@', 'test@'));
-      if (fakeEmail) {
+      if (fakeEmail && fakeEmail.domain.includes('.')) {
         domain = fakeEmail.domain;
       }
     }

--- a/src/presenters/pop-overs/create-team-pop.jsx
+++ b/src/presenters/pop-overs/create-team-pop.jsx
@@ -45,7 +45,9 @@ class CreateTeamPopBase extends React.Component {
     if (name) {
       const url = _.kebabCase(name);
       
-      const userReq = this.props.api.get(`userId/byLogin/${url}`);
+      const userReq = this.props.api.get(`userId/byLogin/${url}`).catch(error => {
+        
+      });
       const teamReq = this.props.api.get(`teams/byUrl/${url}`);
       const [user, team] = await Promise.all([userReq, teamReq]);
       

--- a/src/presenters/pop-overs/create-team-pop.jsx
+++ b/src/presenters/pop-overs/create-team-pop.jsx
@@ -44,19 +44,30 @@ class CreateTeamPopBase extends React.Component {
     const name = this.state.teamName;
     if (name) {
       const url = _.kebabCase(name);
-      
-      const userReq = this.props.api.get(`userId/byLogin/${url}`).catch(error => {
-        
-      });
-      const teamReq = this.props.api.get(`teams/byUrl/${url}`);
-      const [user, team] = await Promise.all([userReq, teamReq]);
-      
       let error = null;
-      if (user.data !== 'NOT FOUND') {
-        error = 'Name in use, try another';
-      } else if (team.data) {
-        error = 'Team already exists, try another';
+      
+      try {
+        const {data} = await this.props.api.get(`userId/byLogin/${url}`);
+        if (data !== 'NOT FOUND') {
+          error = 'Name in use, try another';
+        }
+      } catch (error) {
+        if (!(error.response && error.response.status === 404)) {
+          throw error;
+        }
       }
+      
+      try {
+        const {data} = await this.props.api.get(`teams/byUrl/${url}`);
+        if (data) {
+          error = 'Team already exists, try another';
+        }
+      } catch (error) {
+        if (!(error.response && error.response.status === 404)) {
+          throw error;
+        }
+      }
+      
       if (error) {
         this.setState(({teamName}) => (name === teamName) ? {error} : {});
       }

--- a/src/presenters/question-item.jsx
+++ b/src/presenters/question-item.jsx
@@ -15,6 +15,7 @@ function truncateQuestion(question) {
 }
 
 function truncateTag(tag) {
+      throw new Error('asdf');
   const max = 15;
   return tag.substring(0, max);
 }

--- a/src/presenters/question-item.jsx
+++ b/src/presenters/question-item.jsx
@@ -15,7 +15,6 @@ function truncateQuestion(question) {
 }
 
 function truncateTag(tag) {
-      throw new Error('asdf');
   const max = 15;
   return tag.substring(0, max);
 }

--- a/src/presenters/questions.jsx
+++ b/src/presenters/questions.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import randomColor from 'randomcolor';
 import {sample} from 'lodash';
 
+import ErrorBoundary from './includes/error-boundary.jsx';
 import Link from './includes/link.jsx';
 import QuestionItem from './question-item.jsx';
 
@@ -69,13 +70,15 @@ class Questions extends React.Component {
         </h2>
         <article className="projects">
           {questions.length ? (
-            <ul className="projects-container">
-              {questions.map(question => (
-                <li key={question.questionId}>
-                  <QuestionItem {...question}/>
-                </li>
-              ))}
-            </ul>
+            <ErrorBoundary>
+              <ul className="projects-container">
+                {questions.map(question => (
+                  <li key={question.questionId}>
+                    <QuestionItem {...question}/>
+                  </li>
+                ))}
+              </ul>
+            </ErrorBoundary>
           ) : (
             <React.Fragment>
               {kaomoji} Looks like nobody is asking for help right now.{' '}


### PR DESCRIPTION
- When adding a user to a team, don't consider the string to be an email domain unless it contains a . (`@greg` is not a domain, but `@gre.g` is)
- The create team pop didn't handle 404 errors from the api, now it does
- Added an `ErrorBoundary` component, which catches errors during rendering (not in event handlers or async stuff, only during rendering) and replaces its children with the standard 'something went wrong' text. It's used on the questions list (since it has had issue with bad data in the past) the page within `Layout`, and around the entire react tree. This should be enough such that users are never left with a completely blank page, and in most cases will still have a functional header