### PR TITLE
Profuse tea: Fix an odd hover bug in the remix list

### DIFF
--- a/src/presenters/includes/avatar.jsx
+++ b/src/presenters/includes/avatar.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {FALLBACK_AVATAR_URL, getAvatarUrl as getProjectAvatarUrl} from '../../models/project';
 import {DEFAULT_TEAM_AVATAR, getAvatarUrl as getTeamAvatarUrl} from '../../models/team';
 import {ANON_AVATAR_URL, getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
 

--- a/src/presenters/includes/avatar.jsx
+++ b/src/presenters/includes/avatar.jsx
@@ -7,11 +7,12 @@ import {ANON_AVATAR_URL, getAvatarThumbnailUrl, getDisplayName} from '../../mode
 
 // UserAvatar
 
-export const Avatar = ({name, src, color, srcFallback}) => (
+export const Avatar = ({name, src, color, srcFallback, ...props}) => (
   <div data-tooltip={name} data-tooltip-left="true">
     <img width="32px" height="32px" src={src} alt={name}
       style={color ? {backgroundColor: color} : null}
       onError={srcFallback ? (event => event.target.src = srcFallback) : null}
+      {...props}
     />
   </div>
 );
@@ -20,16 +21,6 @@ Avatar.propTypes = {
   src: PropTypes.string.isRequired,
   srcFallback: PropTypes.string,
   color: PropTypes.string,
-};
-
-export const ProjectAvatar = ({project}) => (
-  <Avatar name={project.domain} src={getProjectAvatarUrl(project.id)} srcFallback={FALLBACK_AVATAR_URL}/>
-);
-ProjectAvatar.propTypes = {
-  project: PropTypes.shape({
-    domain: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 export const TeamAvatar = ({team}) => (

--- a/src/presenters/includes/avatar.jsx
+++ b/src/presenters/includes/avatar.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {ANON_AVATAR_URL, getAvatarThumbnailUrl, getDisplayName} from '../../models/user.js';
-import {DEFAULT_TEAM_AVATAR, getAvatarUrl as getTeamAvatarUrl} from '../../models/team.js';
+import {FALLBACK_AVATAR_URL, getAvatarUrl as getProjectAvatarUrl} from '../../models/project';
+import {DEFAULT_TEAM_AVATAR, getAvatarUrl as getTeamAvatarUrl} from '../../models/team';
+import {ANON_AVATAR_URL, getAvatarThumbnailUrl, getDisplayName} from '../../models/user';
 
 // UserAvatar
 
@@ -19,6 +20,16 @@ Avatar.propTypes = {
   src: PropTypes.string.isRequired,
   srcFallback: PropTypes.string,
   color: PropTypes.string,
+};
+
+export const ProjectAvatar = ({project}) => (
+  <Avatar name={project.domain} src={getProjectAvatarUrl(project.id)} srcFallback={FALLBACK_AVATAR_URL}/>
+);
+ProjectAvatar.propTypes = {
+  project: PropTypes.shape({
+    domain: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export const TeamAvatar = ({team}) => (

--- a/src/presenters/includes/avatar.jsx
+++ b/src/presenters/includes/avatar.jsx
@@ -6,12 +6,11 @@ import {ANON_AVATAR_URL, getAvatarThumbnailUrl, getDisplayName} from '../../mode
 
 // UserAvatar
 
-export const Avatar = ({name, src, color, srcFallback, ...props}) => (
+export const Avatar = ({name, src, color, srcFallback}) => (
   <div data-tooltip={name} data-tooltip-left="true">
     <img width="32px" height="32px" src={src} alt={name}
       style={color ? {backgroundColor: color} : null}
       onError={srcFallback ? (event => event.target.src = srcFallback) : null}
-      {...props}
     />
   </div>
 );

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-mini';
 
+import {ProjectAvatar} from './avatar.jsx';
 import {ProjectLink} from './link.jsx';
 import Loader from './loader.jsx';
 import {FALLBACK_AVATAR_URL, getAvatarUrl} from '../../models/project.js';
@@ -22,11 +23,10 @@ const addFallbackSrc = (event) => {
 };
 
 const ProjectDetails = ({projectDetails}) => {
-  let projectAvatar = getAvatarUrl(projectDetails.id);
   return (
     <article className="project-details">
       <ProjectLink project={projectDetails}>
-        <img className="avatar" src={projectAvatar} onError={addFallbackSrc} alt="project avatar" />
+        <ProjectAvatar project={projectDetails}/>
       </ProjectLink>
       <table>
         <tbody>
@@ -80,12 +80,9 @@ const ProjectDetails = ({projectDetails}) => {
 };
 
 const ProjectRemixItem = ({remix}) => {
-  let projectAvatar = getAvatarUrl(remix.id);
   return (
     <ProjectLink project={remix}>
-      <span data-tooltip={remix.domain} data-tooltip-left="true">
-        <img className="avatar" src={projectAvatar} alt={remix.domain} onError={addFallbackSrc} />
-      </span>
+      <ProjectAvatar project={remix}/>
     </ProjectLink>
   );
 };

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-mini';
 
-import {ProjectAvatar} from './avatar.jsx';
 import {ProjectLink} from './link.jsx';
 import Loader from './loader.jsx';
 import {FALLBACK_AVATAR_URL, getAvatarUrl} from '../../models/project.js';
@@ -22,11 +21,24 @@ const addFallbackSrc = (event) => {
   event.target.src = FALLBACK_AVATAR_URL;
 };
 
+const ProjectAvatar = ({project, className}) => (
+  <img src={getAvatarUrl(project.id)} className={className}
+    alt={project.domain} onError={addFallbackSrc}
+  />
+);
+ProjectAvatar.propTypes = {
+  project: PropTypes.shape({
+    domain: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
 const ProjectDetails = ({projectDetails}) => {
+  let projectAvatar = getAvatarUrl(projectDetails.id);
   return (
     <article className="project-details">
       <ProjectLink project={projectDetails}>
-        <ProjectAvatar project={projectDetails}/>
+        <img className="avatar" src={projectAvatar} onError={addFallbackSrc} alt="project avatar" />
       </ProjectLink>
       <table>
         <tbody>
@@ -80,9 +92,12 @@ const ProjectDetails = ({projectDetails}) => {
 };
 
 const ProjectRemixItem = ({remix}) => {
+  let projectAvatar = getAvatarUrl(remix.id);
   return (
     <ProjectLink project={remix}>
-      <ProjectAvatar project={remix}/>
+      <span data-tooltip={remix.domain} data-tooltip-left="true">
+        <img className="avatar" src={projectAvatar} alt={remix.domain} onError={addFallbackSrc} />
+      </span>
     </ProjectLink>
   );
 };

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -21,8 +21,8 @@ const addFallbackSrc = (event) => {
   event.target.src = FALLBACK_AVATAR_URL;
 };
 
-const ProjectAvatar = ({project, className}) => (
-  <img src={getAvatarUrl(project.id)} className={className}
+const ProjectAvatar = ({project, className=''}) => (
+  <img src={getAvatarUrl(project.id)} className={`avatar ${className}`}
     alt={project.domain} onError={addFallbackSrc}
   />
 );
@@ -31,14 +31,14 @@ ProjectAvatar.propTypes = {
     domain: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
   }).isRequired,
+  className: PropTypes.string,
 };
 
 const ProjectDetails = ({projectDetails}) => {
-  let projectAvatar = getAvatarUrl(projectDetails.id);
   return (
     <article className="project-details">
       <ProjectLink project={projectDetails}>
-        <img className="avatar" src={projectAvatar} onError={addFallbackSrc} alt="project avatar" />
+        <ProjectAvatar project={projectDetails}/>
       </ProjectLink>
       <table>
         <tbody>
@@ -79,9 +79,9 @@ const ProjectDetails = ({projectDetails}) => {
               <td className="label">Originally remixed from</td>
               <td>
                 <ProjectLink project={projectDetails.baseProject}>
-                  <img alt="project avatar" className="avatar baseproject-avatar" src={getAvatarUrl(projectDetails.baseProject.id)} onError={addFallbackSrc} />
+                  <ProjectAvatar project={projectDetails.baseProject} className="baseproject-avatar"/>
+                  {projectDetails.baseProject.domain}
                 </ProjectLink>
-                {projectDetails.baseProject.domain}
               </td>
             </tr>
           }
@@ -92,11 +92,10 @@ const ProjectDetails = ({projectDetails}) => {
 };
 
 const ProjectRemixItem = ({remix}) => {
-  let projectAvatar = getAvatarUrl(remix.id);
   return (
     <ProjectLink project={remix}>
       <span data-tooltip={remix.domain} data-tooltip-left="true">
-        <img className="avatar" src={projectAvatar} alt={remix.domain} onError={addFallbackSrc} />
+        <ProjectAvatar project={remix}/>
       </span>
     </ProjectLink>
   );
@@ -145,16 +144,18 @@ class TeamAnalyticsProjectDetails extends React.Component {
             <ProjectDetails 
               projectDetails = {this.state.projectDetails}
             />
-            <h4>Latest Remixes</h4>
-            { (this.state.projectRemixes.length === 0) &&
-              <p>No remixes yet (／_^)／ ●</p>
-            }
-            { this.state.projectRemixes.map(remix => (
-              <ProjectRemixItem
-                key = {remix.id}
-                remix = {remix}
-              />
-            ))}
+            <article className="project-remixes">
+              <h4>Latest Remixes</h4>
+              { (this.state.projectRemixes.length === 0) &&
+                <p>No remixes yet (／_^)／ ●</p>
+              }
+              { this.state.projectRemixes.map(remix => (
+                <ProjectRemixItem
+                  key = {remix.id}
+                  remix = {remix}
+                />
+              ))}
+            </article>
           </React.Fragment>
         }
       </React.Fragment>

--- a/styles/includes/team-analytics.styl
+++ b/styles/includes/team-analytics.styl
@@ -114,6 +114,9 @@ analytics-remixes = #ff7f0f
     button
     margin-left: 0
     margin-right: 5px
+  
+  .project-remixes a
+    display: inline-block
 
   .explanation
     p


### PR DESCRIPTION
https://www.notion.so/glitch/87bda09f85184c1d81e1659aa62e4392?v=78db6cf11f8a43859bd17bc800cebde0&p=4be850f96ef14972a33f2a6c3780d31b

in the team analytics project details, if you hover over the first project in any row after the first, the tooltip will appear over the last project in the previous row. Not sure why this is happening, but adding `display: inline-block` fixes it. I also did some cleanup around project avatars within that file.