### PR TITLE
Quixotic rocket: Allow project page embed to request permissions

### DIFF
--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -60,7 +60,7 @@ PrivateToggle.propTypes = {
 
 const Embed = ({domain}) => (
   <div className="glitch-embed-wrap">
-    <iframe title="embed" allow="fullscreen; camera; microphone;" src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}></iframe>
+    <iframe title="embed" allow="geolocation; microphone; camera; midi; encrypted-media" src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}></iframe>
   </div>
 );
 Embed.propTypes = {

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -60,7 +60,7 @@ PrivateToggle.propTypes = {
 
 const Embed = ({domain}) => (
   <div className="glitch-embed-wrap">
-    <iframe title="embed" src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}></iframe>
+    <iframe title="embed" allow="fullscreen; camera; microphone;" src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}></iframe>
   </div>
 );
 Embed.propTypes = {

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -60,7 +60,10 @@ PrivateToggle.propTypes = {
 
 const Embed = ({domain}) => (
   <div className="glitch-embed-wrap">
-    <iframe title="embed" allow="geolocation; microphone; camera; midi; encrypted-media" src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}></iframe>
+    <iframe title="embed"
+      src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
+      allow="geolocation; microphone; camera; midi; encrypted-media"
+    ></iframe>
   </div>
 );
 Embed.propTypes = {


### PR DESCRIPTION
Allow project page embeds to request permissions. This isn't enough on its own, because the embed has an iframe in it to load the preview, which will also need the same permission set.

https://www.notion.so/glitch/Embeds-iframe-element-needs-allow-attribute-so-getusermedia-geolocation-and-other-web-apis-in-apps-work-130ffb626a2d4c50b8987f444be1cbc4