### PR TITLE
Maple harmonica - switch between API backends based on hostname

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -4,9 +4,7 @@ const axios = require("axios");
 const {Cache} = require("memory-cache");
 const moment = require("moment-mini");
 
-// in the backend, just switch between staging and production
-const env = process.env.RUNNING_ON === "staging" ? "staging" : "production";
-const {API_URL} = require("./constants")[env];
+const {API_URL} = require("./constants").current;
 
 const CACHE_TIMEOUT = moment.duration(15, 'minutes').asMilliseconds()
 

--- a/server/api.js
+++ b/server/api.js
@@ -4,7 +4,9 @@ const axios = require("axios");
 const {Cache} = require("memory-cache");
 const moment = require("moment-mini");
 
-const {API_URL} = require("./constants");
+// in the backend, just switch between staging and production
+const env = process.env.RUNNING_ON === "staging" ? "staging" : "production";
+const {API_URL} = require("./constants")[env];
 
 const CACHE_TIMEOUT = moment.duration(15, 'minutes').asMilliseconds()
 

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,26 +1,28 @@
-// Define a bunch of variables based on our environment
-
-let APP_URL = 'https://glitch.com';
-let API_URL = 'https://api.glitch.com/';
-let EDITOR_URL = 'https://glitch.com/edit/';
-let CDN_URL = 'https://cdn.glitch.com';
-let GITHUB_CLIENT_ID = "b4cb743ed07e20abf0b2";
-let FACEBOOK_CLIENT_ID = "660180164153542";
-
-if (process.env.RUNNING_ON === 'staging') {
-  APP_URL = 'https://staging.glitch.com';
-  API_URL = 'https://api.staging.glitch.com/';
-  EDITOR_URL = 'https://staging.glitch.com/edit/';
-  CDN_URL = 'https://cdn.staging.glitch.com';
-  GITHUB_CLIENT_ID = "65efbd87382354ca25e7";
-  FACEBOOK_CLIENT_ID = "1858825521057112";
-}
+// Define a bunch of variables split by environment
 
 module.exports = {
-  APP_URL,
-  API_URL,
-  EDITOR_URL,
-  CDN_URL,
-  GITHUB_CLIENT_ID,
-  FACEBOOK_CLIENT_ID,
-};
+  production: {
+    APP_URL: 'https://glitch.com',
+    API_URL: 'https://api.glitch.com/',
+    EDITOR_URL: 'https://glitch.com/edit/',
+    CDN_URL: 'https://cdn.glitch.com',
+    GITHUB_CLIENT_ID: "b4cb743ed07e20abf0b2",
+    FACEBOOK_CLIENT_ID: "660180164153542",
+  },
+  staging: {
+    APP_URL: 'https://staging.glitch.com',
+    API_URL: 'https://api.staging.glitch.com/',
+    EDITOR_URL: 'https://staging.glitch.com/edit/',
+    CDN_URL: 'https://cdn.staging.glitch.com',
+    GITHUB_CLIENT_ID: "65efbd87382354ca25e7",
+    FACEBOOK_CLIENT_ID: "1858825521057112",
+  },
+  development: {
+    APP_URL: 'https://glitch.development',
+    API_URL: 'https://api.glitch.development/',
+    EDITOR_URL: 'https://glitch.development/edit/',
+    CDN_URL: 'https://s3.amazonaws.com/hyperdev-development',
+    GITHUB_CLIENT_ID: "5d4f1392f69bcdf73d9f",
+    FACEBOOK_CLIENT_ID: "1121393391305429",
+  },
+}

--- a/server/constants.js
+++ b/server/constants.js
@@ -8,6 +8,7 @@ module.exports = {
     CDN_URL: 'https://cdn.glitch.com',
     GITHUB_CLIENT_ID: "b4cb743ed07e20abf0b2",
     FACEBOOK_CLIENT_ID: "660180164153542",
+    PROJECTS_DOMAIN: 'glitch.me',
   },
   staging: {
     APP_URL: 'https://staging.glitch.com',
@@ -16,6 +17,7 @@ module.exports = {
     CDN_URL: 'https://cdn.staging.glitch.com',
     GITHUB_CLIENT_ID: "65efbd87382354ca25e7",
     FACEBOOK_CLIENT_ID: "1858825521057112",
+    PROJECTS_DOMAIN: 'staging.glitch.me',
   },
   development: {
     APP_URL: 'https://glitch.development',
@@ -24,5 +26,6 @@ module.exports = {
     CDN_URL: 'https://s3.amazonaws.com/hyperdev-development',
     GITHUB_CLIENT_ID: "5d4f1392f69bcdf73d9f",
     FACEBOOK_CLIENT_ID: "1121393391305429",
+    PROJECTS_DOMAIN: 'glitch.development',
   },
 }

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,6 +1,6 @@
 // Define a bunch of variables split by environment
 
-module.exports = {
+const envs = {
   production: {
     APP_URL: 'https://glitch.com',
     API_URL: 'https://api.glitch.com/',
@@ -28,4 +28,12 @@ module.exports = {
     FACEBOOK_CLIENT_ID: "1121393391305429",
     PROJECTS_DOMAIN: 'glitch.development',
   },
+}
+
+// in the backend, just switch between staging and production
+const currentEnv = process.env.RUNNING_ON === "staging" ? "staging" : "production";
+envs.current = envs[currentEnv];
+
+module.exports = {
+  ...envs,
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -102,7 +102,6 @@ module.exports = function(external) {
   });
 
   app.get('*', async (req, res) => {
-    console.log(req.headers);
     await render(res,
       "Glitch",
       "The friendly community where everyone can discover & create the best stuff on the web");

--- a/server/routes.js
+++ b/server/routes.js
@@ -69,11 +69,12 @@ module.exports = function(external) {
       ZINE_POSTS: JSON.stringify(zine),
       PROJECT_DOMAIN: process.env.PROJECT_DOMAIN,
       ENVIRONMENT: process.env.NODE_ENV || "dev",
-      ...constants,
+      CONSTANTS: constants,
     });
   }
 
-  const {CDN_URL} = constants;
+  const env = process.env.RUNNING_ON === "staging" ? "staging" : "production";
+  const {CDN_URL} = constants[env];
 
   app.get('/~:domain', async (req, res) => {
     const {domain} = req.params;

--- a/server/routes.js
+++ b/server/routes.js
@@ -102,6 +102,7 @@ module.exports = function(external) {
   });
 
   app.get('*', async (req, res) => {
+    console.log(req.headers);
     await render(res,
       "Glitch",
       "The friendly community where everyone can discover & create the best stuff on the web");

--- a/server/routes.js
+++ b/server/routes.js
@@ -73,8 +73,7 @@ module.exports = function(external) {
     });
   }
 
-  const env = process.env.RUNNING_ON === "staging" ? "staging" : "production";
-  const {CDN_URL} = constants[env];
+  const {CDN_URL} = constants.current;
 
   app.get('/~:domain', async (req, res) => {
     const {domain} = req.params;

--- a/sh/webpack.sh
+++ b/sh/webpack.sh
@@ -2,12 +2,14 @@
 
 # Webpack will occassionally crash, so run it in a loop so that it'll come back to life on failure.
 
+export TMP=/app/.tmp
+
 eslint --config server/.eslintrc.server.js webpack.config.js
 
 echo "Starting webpack watcher"
 
 while true; do
-  env NODE_OPTIONS="--max-old-space-size=256" webpack --watch --info-verbosity verbose
+  webpack --watch --info-verbosity verbose
   
   echo "Webpack crashed; Restarting webpack --watch"
 done

--- a/sh/webpack.sh
+++ b/sh/webpack.sh
@@ -2,8 +2,6 @@
 
 # Webpack will occassionally crash, so run it in a loop so that it'll come back to life on failure.
 
-export TMP=/app/.tmp
-
 eslint --config server/.eslintrc.server.js webpack.config.js
 
 echo "Starting webpack watcher"

--- a/sh/webpack.sh
+++ b/sh/webpack.sh
@@ -9,7 +9,7 @@ eslint --config server/.eslintrc.server.js webpack.config.js
 echo "Starting webpack watcher"
 
 while true; do
-  webpack --watch --info-verbosity verbose
+  NODE_OPTIONS="--max-old-space-size=256" webpack --watch --info-verbosity verbose
   
   echo "Webpack crashed; Restarting webpack --watch"
 done

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -14,8 +14,7 @@ export default function Project({teams, users, ...project}) {
   };
 }
 
-export function getAvatarUrl(id, cdnUrl) {
-  cdnUrl = cdnUrl || CDN_URL;
+export function getAvatarUrl(id, cdnUrl=CDN_URL) {
   return `${cdnUrl}/project-avatar/${id}.png`;
 }
 
@@ -23,21 +22,18 @@ export function getLink(domain) {
   return `/~${domain}`;
 }
 
-export function getShowUrl(domain, projectsDomain) {
-  projectsDomain = projectsDomain || PROJECTS_DOMAIN;
+export function getShowUrl(domain, projectsDomain=PROJECTS_DOMAIN) {
   return `//${domain}.${projectsDomain}`;
 }
 
-export function getEditorUrl(domain, path, line, character, editorUrl) {
-  editorUrl = editorUrl || EDITOR_URL;
+export function getEditorUrl(domain, path, line, character, editorUrl=EDITOR_URL) {
   if (path && !isNaN(line) && !isNaN(character)) {
     return `${editorUrl}#!/${domain}?path=${path}:${line}:${character}`;
   }
   return `${editorUrl}#!/${domain}`;
 }
 
-export function getRemixUrl(domain, editorUrl) {
-  editorUrl = editorUrl || EDITOR_URL;
+export function getRemixUrl(domain, editorUrl=EDITOR_URL) {
   return `${editorUrl}#!/remix/${domain}`;
 }
 

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -1,4 +1,4 @@
-/* global CDN_URL EDITOR_URL*/
+/* global CDN_URL EDITOR_URL PROJECTS_DOMAIN */
 
 export const FALLBACK_AVATAR_URL = "https://cdn.glitch.com/c53fd895-ee00-4295-b111-7e024967a033%2Ffallback-project-avatar.svg?1528812220123";
 
@@ -23,20 +23,22 @@ export function getLink(domain) {
   return `/~${domain}`;
 }
 
-export function getShowUrl(domain) {
-  return `//${domain}.glitch.me`;
+export function getShowUrl(domain, projectsDomain) {
+  projectsDomain = projectsDomain || PROJECTS_DOMAIN;
+  return `//${domain}.${projectsDomain}`;
 }
 
 export function getEditorUrl(domain, path, line, character, editorUrl) {
-  
+  editorUrl = editorUrl || EDITOR_URL;
   if (path && !isNaN(line) && !isNaN(character)) {
-    return `${EDITOR_URL}#!/${domain}?path=${path}:${line}:${character}`;
+    return `${editorUrl}#!/${domain}?path=${path}:${line}:${character}`;
   }
-  return `${EDITOR_URL}#!/${domain}`;
+  return `${editorUrl}#!/${domain}`;
 }
 
-export function getRemixUrl(domain) {
-  return `${EDITOR_URL}#!/remix/${domain}`;
+export function getRemixUrl(domain, editorUrl) {
+  editorUrl = editorUrl || EDITOR_URL;
+  return `${editorUrl}#!/remix/${domain}`;
 }
 
 // Circular dependencies must go below module.exports

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -14,8 +14,9 @@ export default function Project({teams, users, ...project}) {
   };
 }
 
-export function getAvatarUrl(id) {
-  return `${CDN_URL}/project-avatar/${id}.png`;
+export function getAvatarUrl(id, cdnUrl) {
+  cdnUrl = cdnUrl || CDN_URL;
+  return `${cdnUrl}/project-avatar/${id}.png`;
 }
 
 export function getLink(domain) {
@@ -26,7 +27,8 @@ export function getShowUrl(domain) {
   return `//${domain}.glitch.me`;
 }
 
-export function getEditorUrl(domain, path, line, character) {
+export function getEditorUrl(domain, path, line, character, editorUrl) {
+  
   if (path && !isNaN(line) && !isNaN(character)) {
     return `${EDITOR_URL}#!/${domain}?path=${path}:${line}:${character}`;
   }

--- a/src/presenters/includes/project-result-item.jsx
+++ b/src/presenters/includes/project-result-item.jsx
@@ -12,7 +12,7 @@ const ProjectResultItem = ({id, domain, description, users, action, isActive, is
   return (
     <div>
       <button className={resultClass} onClick={action} data-project-id={id}>
-        <img className="avatar" src={getAvatarUrl(id)} alt={`Project avatar for ${domain}`}/>
+        <img className="avatar" src={getAvatarUrl(id, 'https://cdn.glitch.com')} alt={`Project avatar for ${domain}`}/>
         <div className="results-info">
           <div className="result-name" title={domain}>{domain}</div>
           { description.length > 0 && <div className="result-description">{description}</div> }

--- a/src/presenters/includes/project-result-item.jsx
+++ b/src/presenters/includes/project-result-item.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {getAvatarUrl} from  '../../models/project';
 import {StaticUsersList} from '../users-list.jsx';
 
-const ProjectResultItem = ({id, domain, description, users, action, isActive, isPrivate}) => {
+const ProjectResultItem = ({id, domain, description, users, action, isActive, isPrivate, cdnUrl}) => {
   const activeClass = isActive ? "active" : "";
   const privateClass = isPrivate ? "private" : "";
   const resultClass = `button-unstyled result result-project ${activeClass} ${privateClass}`;
@@ -12,7 +12,7 @@ const ProjectResultItem = ({id, domain, description, users, action, isActive, is
   return (
     <div>
       <button className={resultClass} onClick={action} data-project-id={id}>
-        <img className="avatar" src={getAvatarUrl(id, 'https://cdn.glitch.com')} alt={`Project avatar for ${domain}`}/>
+        <img className="avatar" src={getAvatarUrl(id, cdnUrl)} alt={`Project avatar for ${domain}`}/>
         <div className="results-info">
           <div className="result-name" title={domain}>{domain}</div>
           { description.length > 0 && <div className="result-description">{description}</div> }

--- a/src/presenters/includes/team-analytics-activity.jsx
+++ b/src/presenters/includes/team-analytics-activity.jsx
@@ -21,7 +21,7 @@ const createHistogram = (bins) => {
         timestamp = data['@timestamp'];
       }
       totalRemixes += data.analytics.remixes;
-      totalAppViews += data.analytics.requests;
+      totalAppViews += data.analytics.visits;
       // referrers.push(data.analytics.referrers)
     });
     histogram.push({

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -51,7 +51,7 @@ const ProjectDetails = ({projectDetails}) => {
             <td>{moment(projectDetails.lastAccess).fromNow()}</td>
           </tr>
           <tr>
-            <td className="label">Last code view</td>
+            <td className="label">Last edited</td>
             <td>{moment(projectDetails.lastEditedAt).fromNow()}</td>
           </tr>
           <tr>

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -47,7 +47,7 @@ const ProjectDetails = ({projectDetails}) => {
             <td>{moment(projectDetails.createdAt).fromNow()}</td>
           </tr>
           <tr>
-            <td className="label">Last app view</td>
+            <td className="label">Last viewed</td>
             <td>{moment(projectDetails.lastAccess).fromNow()}</td>
           </tr>
           <tr>
@@ -64,7 +64,7 @@ const ProjectDetails = ({projectDetails}) => {
           </tr>
           <tr>
             <td className="label">Total code views</td>
-            <td>{projectDetails.numUniqueEditorVisits || projectDetails.numEditorVisits}</td>
+            <td>{projectDetails.numEditorVisits}</td>
           </tr>
           <tr>
             <td className="label">Total direct remixes</td>

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -64,7 +64,7 @@ const ProjectDetails = ({projectDetails}) => {
           </tr>
           <tr>
             <td className="label">Total code views</td>
-            <td>{projectDetails.numUniqueEditorVisits}</td>
+            <td>{projectDetails.numEditorVisits}</td>
           </tr>
           <tr>
             <td className="label">Total direct remixes</td>

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -47,11 +47,11 @@ const ProjectDetails = ({projectDetails}) => {
             <td>{moment(projectDetails.createdAt).fromNow()}</td>
           </tr>
           <tr>
-            <td className="label">Last code view</td>
+            <td className="label">Last app view</td>
             <td>{moment(projectDetails.lastAccess).fromNow()}</td>
           </tr>
           <tr>
-            <td className="label">Last edited</td>
+            <td className="label">Last code view</td>
             <td>{moment(projectDetails.lastEditedAt).fromNow()}</td>
           </tr>
           <tr>

--- a/src/presenters/includes/team-analytics-project-details.jsx
+++ b/src/presenters/includes/team-analytics-project-details.jsx
@@ -64,7 +64,7 @@ const ProjectDetails = ({projectDetails}) => {
           </tr>
           <tr>
             <td className="label">Total code views</td>
-            <td>{projectDetails.numEditorVisits}</td>
+            <td>{projectDetails.numUniqueEditorVisits || projectDetails.numEditorVisits}</td>
           </tr>
           <tr>
             <td className="label">Total direct remixes</td>

--- a/src/presenters/includes/team-analytics.jsx
+++ b/src/presenters/includes/team-analytics.jsx
@@ -75,7 +75,7 @@ class TeamAnalytics extends React.Component {
     let totalAppViews = 0;
     let totalRemixes = 0;
     this.state.analytics.buckets.forEach(bucket => {
-      totalAppViews += bucket.analytics.requests;
+      totalAppViews += bucket.analytics.visits;
       totalRemixes += bucket.analytics.remixes;
     });
     this.setState({

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -1,4 +1,4 @@
-/* global analytics */
+/* global analytics APP_URL */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -64,7 +64,7 @@ PrivateToggle.propTypes = {
 const Embed = ({domain}) => (
   <div className="glitch-embed-wrap">
     <iframe title="embed"
-      src={`https://glitch.com/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
+      src={`${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
       allow="geolocation; microphone; camera; midi; encrypted-media"
     ></iframe>
   </div>

--- a/src/presenters/pop-overs/new-project-pop.jsx
+++ b/src/presenters/pop-overs/new-project-pop.jsx
@@ -13,7 +13,7 @@ const NewProjectPop = ({projects}) => (
     <section className="pop-over-actions results-list">
       <div className="results">
         {projects.length ? projects.map((project) => (
-          <Link key={project.id} to={getRemixUrl(project.domain)}>
+          <Link key={project.id} to={getRemixUrl(project.domain, 'https://glitch.com/edit/')}>
             <ProjectResultItem {...project} users={[]} action={()=>{
               /* global analytics */
               analytics.track("New Project Clicked", {
@@ -47,7 +47,15 @@ class NewProjectPopButton extends React.Component {
       'cb519589-591c-474f-8986-a513f22dbf88', // 'hello-sqlite'
       '929980a8-32fc-4ae7-a66f-dddb3ae4912c', // 'hello-webpage'
     ];
-    const {data} = await this.props.api.get(`projects/byIds?ids=${projectIds.join(',')}`);
+    // always request against the production API, with no token
+    const {data} = await this.props.api.get(
+      `https://api.glitch.com/projects/byIds?ids=${projectIds.join(',')}`,
+      {
+        headers: {
+          Authorization: ''
+        },
+      },
+    );
     const projects = data.map(project => ProjectModel(project).update(project).asProps());
     this.setState({projects});
   }

--- a/src/presenters/pop-overs/new-project-pop.jsx
+++ b/src/presenters/pop-overs/new-project-pop.jsx
@@ -13,8 +13,8 @@ const NewProjectPop = ({projects}) => (
     <section className="pop-over-actions results-list">
       <div className="results">
         {projects.length ? projects.map((project) => (
-          <Link key={project.id} to={getRemixUrl(project.domain, 'https://glitch.com/edit/')}>
-            <ProjectResultItem {...project} users={[]} action={()=>{
+          <Link key={project.id} to={getRemixUrl(project.domain)}>
+            <ProjectResultItem {...project} cdnUrl="https://cdn.glitch.com" users={[]} action={()=>{
               /* global analytics */
               analytics.track("New Project Clicked", {
                 baseDomain: project.domain,

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -35,7 +35,7 @@
     <% } %>
     <noscript><style>#fallback, #fallback-noscript { display: initial !important; }</style></noscript>
   </head>
-  <body> 
+  <body>
     <script>
       var CONSTANTS = <%- JSON.stringify(CONSTANTS) %>;
       var _env;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,31 +37,22 @@
   </head>
   <body> 
     <script>
+      var CONSTANTS = <%- JSON.stringify(CONSTANTS) %>;
+      var _env;
       if (document.location.hostname.indexOf('glitch.development') >= 0) {
-        var API_URL = '<%= CONSTANTS.development.API_URL %>';
-        var APP_URL = '<%= CONSTANTS.development.APP_URL %>';
-        var CDN_URL = '<%= CONSTANTS.development.CDN_URL %>';
-        var EDITOR_URL = '<%= CONSTANTS.development.EDITOR_URL %>';
-        var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.development.FACEBOOK_CLIENT_ID %>';
-        var GITHUB_CLIENT_ID = '<%= CONSTANTS.development.GITHUB_CLIENT_ID %>';
-        var PROJECTS_DOMAIN = '<%= CONSTANTS.development.PROJECTS_DOMAIN %>';
+        _env = "development";
       } else if (document.location.hostname.indexOf('staging.glitch.com') >= 0) {
-        var API_URL = '<%= CONSTANTS.staging.API_URL %>';
-        var APP_URL = '<%= CONSTANTS.staging.APP_URL %>';
-        var CDN_URL = '<%= CONSTANTS.staging.CDN_URL %>';
-        var EDITOR_URL = '<%= CONSTANTS.staging.EDITOR_URL %>';
-        var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.staging.FACEBOOK_CLIENT_ID %>';
-        var GITHUB_CLIENT_ID = '<%= CONSTANTS.staging.GITHUB_CLIENT_ID %>';
-        var PROJECTS_DOMAIN = '<%= CONSTANTS.staging.PROJECTS_DOMAIN %>';
+        _env = "staging";
       } else {
-        var API_URL = '<%= CONSTANTS.production.API_URL %>';
-        var APP_URL = '<%= CONSTANTS.production.APP_URL %>';
-        var CDN_URL = '<%= CONSTANTS.production.CDN_URL %>';
-        var EDITOR_URL = '<%= CONSTANTS.production.EDITOR_URL %>';
-        var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.production.FACEBOOK_CLIENT_ID %>';
-        var GITHUB_CLIENT_ID = '<%= CONSTANTS.production.GITHUB_CLIENT_ID %>';
-        var PROJECTS_DOMAIN = '<%= CONSTANTS.production.PROJECTS_DOMAIN %>';
+        _env = "production";
       }
+      var API_URL = CONSTANTS[_env].API_URL;
+      var APP_URL = CONSTANTS[_env].APP_URL;
+      var CDN_URL = CONSTANTS[_env].CDN_URL;
+      var EDITOR_URL = CONSTANTS[_env].EDITOR_URL;
+      var FACEBOOK_CLIENT_ID = CONSTANTS[_env].FACEBOOK_CLIENT_ID;
+      var GITHUB_CLIENT_ID = CONSTANTS[_env].GITHUB_CLIENT_ID;
+      var PROJECTS_DOMAIN = CONSTANTS[_env].PROJECTS_DOMAIN;
       var ENVIRONMENT = '<%= ENVIRONMENT %>';
       var EXTERNAL_ROUTES = <%- EXTERNAL_ROUTES %>;
       var PROJECT_DOMAIN = '<%= PROJECT_DOMAIN %>';

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -44,6 +44,7 @@
         var EDITOR_URL = '<%= CONSTANTS.development.EDITOR_URL %>';
         var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.development.FACEBOOK_CLIENT_ID %>';
         var GITHUB_CLIENT_ID = '<%= CONSTANTS.development.GITHUB_CLIENT_ID %>';
+        var PROJECTS_DOMAIN = '<%= CONSTANTS.development.PROJECTS_DOMAIN %>';
       } else if (document.location.hostname.indexOf('staging.glitch.com') >= 0) {
         var API_URL = '<%= CONSTANTS.staging.API_URL %>';
         var APP_URL = '<%= CONSTANTS.staging.APP_URL %>';
@@ -51,6 +52,7 @@
         var EDITOR_URL = '<%= CONSTANTS.staging.EDITOR_URL %>';
         var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.staging.FACEBOOK_CLIENT_ID %>';
         var GITHUB_CLIENT_ID = '<%= CONSTANTS.staging.GITHUB_CLIENT_ID %>';
+        var PROJECTS_DOMAIN = '<%= CONSTANTS.staging.PROJECTS_DOMAIN %>';
       } else {
         var API_URL = '<%= CONSTANTS.production.API_URL %>';
         var APP_URL = '<%= CONSTANTS.production.APP_URL %>';
@@ -58,6 +60,7 @@
         var EDITOR_URL = '<%= CONSTANTS.production.EDITOR_URL %>';
         var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.production.FACEBOOK_CLIENT_ID %>';
         var GITHUB_CLIENT_ID = '<%= CONSTANTS.production.GITHUB_CLIENT_ID %>';
+        var PROJECTS_DOMAIN = '<%= CONSTANTS.production.PROJECTS_DOMAIN %>';
       }
       var ENVIRONMENT = '<%= ENVIRONMENT %>';
       var EXTERNAL_ROUTES = <%- EXTERNAL_ROUTES %>;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,17 +37,33 @@
   </head>
   <body> 
     <script>
-      var API_URL = '<%= API_URL %>';
-      var APP_URL = '<%= APP_URL %>';
-      var BUILD_COMPLETE = <%- BUILD_COMPLETE %>;
-      var CDN_URL = '<%= CDN_URL %>';
-      var EDITOR_URL = '<%= EDITOR_URL %>';
+      if (document.location.hostname.indexOf('glitch.development') >= 0) {
+        var API_URL = '<%= CONSTANTS.development.API_URL %>';
+        var APP_URL = '<%= CONSTANTS.development.APP_URL %>';
+        var CDN_URL = '<%= CONSTANTS.development.CDN_URL %>';
+        var EDITOR_URL = '<%= CONSTANTS.development.EDITOR_URL %>';
+        var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.development.FACEBOOK_CLIENT_ID %>';
+        var GITHUB_CLIENT_ID = '<%= CONSTANTS.development.GITHUB_CLIENT_ID %>';
+      } else if (document.location.hostname.indexOf('staging.glitch.com') >= 0) {
+        var API_URL = '<%= CONSTANTS.staging.API_URL %>';
+        var APP_URL = '<%= CONSTANTS.staging.APP_URL %>';
+        var CDN_URL = '<%= CONSTANTS.staging.CDN_URL %>';
+        var EDITOR_URL = '<%= CONSTANTS.staging.EDITOR_URL %>';
+        var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.staging.FACEBOOK_CLIENT_ID %>';
+        var GITHUB_CLIENT_ID = '<%= CONSTANTS.staging.GITHUB_CLIENT_ID %>';
+      } else {
+        var API_URL = '<%= CONSTANTS.production.API_URL %>';
+        var APP_URL = '<%= CONSTANTS.production.APP_URL %>';
+        var CDN_URL = '<%= CONSTANTS.production.CDN_URL %>';
+        var EDITOR_URL = '<%= CONSTANTS.production.EDITOR_URL %>';
+        var FACEBOOK_CLIENT_ID = '<%= CONSTANTS.production.FACEBOOK_CLIENT_ID %>';
+        var GITHUB_CLIENT_ID = '<%= CONSTANTS.production.GITHUB_CLIENT_ID %>';
+      }
       var ENVIRONMENT = '<%= ENVIRONMENT %>';
       var EXTERNAL_ROUTES = <%- EXTERNAL_ROUTES %>;
-      var FACEBOOK_CLIENT_ID = '<%= FACEBOOK_CLIENT_ID %>';
-      var GITHUB_CLIENT_ID = '<%= GITHUB_CLIENT_ID %>';
       var PROJECT_DOMAIN = '<%= PROJECT_DOMAIN %>';
       var ZINE_POSTS = <%- ZINE_POSTS %>;
+      var BUILD_COMPLETE = <%- BUILD_COMPLETE %>;
     </script>
 
     <div id="fallback" style="display: none">


### PR DESCRIPTION
This PR allows the Platform team (and anyone else in the company, actually!) to let the community site or any of its remixes use the _development_ API that they are running in their devbox. Of course this only applies to them, the real community site at glitch.com is not affected at all :)

The goal of the PR is to make it easier to collaborate between the Platform team and the Community team: API changes can be tested directly against the community site _before being pushed to production_, and bugfixes can be done _in real time_.

As described in [this notion case](https://www.notion.so/glitch/87bda09f85184c1d81e1659aa62e4392?v=9f7963becc9341ed9af502682c6e9eef&p=92d2d65272d74da7bc59d3397af57275), API is switched on the frontend based on the hostname on which the community site is served.

This PR also add the following fixes (just to show myself and everyone that this is _actually_ super helpful!):

- The New Project popup works on all environments
- The "Show Project" button works on all environments
- The embed in the project page works on all environments
- The Analytics page _finally_ uses the right value for visits!

Additionally, I've been using this remix of the community site against my development API changes that are in [this other PR](https://github.com/FogCreek/Glitch/pull/826), and it was great, I was able to fix several bugs that couldn't be found by unit tests nor manual API calls!
