### PR TITLE
Pop-over fixes

### DIFF
--- a/src/presenters/pop-overs/team-analytics-project-pop.jsx
+++ b/src/presenters/pop-overs/team-analytics-project-pop.jsx
@@ -42,7 +42,7 @@ const PopOver = ({projects, togglePopover, setFilter, filter, updateProjectDomai
   });
   
   return (
-    <dialog className="pop-over analytics-projects-pop">
+    <dialog className="pop-over analytics-projects-pop wide-pop">
       <section className="pop-over-info">
         <input
           autoFocus // eslint-disable-line jsx-a11y/no-autofocus

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -417,11 +417,12 @@ details.popover-container
     margin-bottom: 0
 
 .wide-pop
-    width: 90%
-    min-width: 360px
+    min-width: 350px
     right: 0
     top: 27px
     display: inline-block
+    @media (max-width: smallViewport)
+      min-width: 320px
     
 .team-user-remove-pop
   .projects-list

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -52,7 +52,7 @@
         width: 65px     
     .results-info
       margin-right: 10px
-      width: 60%
+      width: 57%
 
   .result
     list-style-type: none


### PR DESCRIPTION
https://pop-over-fixes.glitch.me

1. Changes analytics pop-over on teams page to use wide-pop styling
![image](https://user-images.githubusercontent.com/519336/48435539-c1cf8900-e74a-11e8-89f3-ff123fa18722.png)

2. Enables wide-pop to fit nicely on mobile
![image](https://user-images.githubusercontent.com/519336/48435501-acf2f580-e74a-11e8-9384-0efea3b306fb.png)

./styles/pop-overs.styl:867163/104
./styles/results-list.styl:867163/4
./src/presenters/pop-overs/team-analytics-project-pop.jsx:867163/9