### PR TITLE
Nova chance: Ensure that there is always a currentUser object

### DIFF
--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -12,11 +12,11 @@ const {Provider, Consumer} = React.createContext();
 // Default values for all of the user fields we need you to have
 // We always generate a 'real' anon user, but use this until we do
 const defaultUser = {
-  id: -1,
+  id: 0,
   login: null,
   name: null,
   description: '',
-  color: '#ccc',
+  color: '#aaa',
   avatarUrl: null,
   avatarThumbnailUrl: null,
   hasCoverImage: false,

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -13,19 +13,19 @@ const {Provider, Consumer} = React.createContext();
 // We always generate a 'real' anon user, but use this until we do
 const defaultUser = {
   id: -1,
-  avatarUrl: null,
-  avatarThumbnailUrl: null,
   login: null,
   name: null,
-  color: '#aaa',
   description: '',
+  color: '#ccc',
+  avatarUrl: null,
+  avatarThumbnailUrl: null,
   hasCoverImage: false,
   coverColor: null,
-  teams: [],
   emails: [],
-  collections: [],
   features: [],
   projects: [],
+  teams: [],
+  collections: [],
 };
 
 function identifyUser(user) {
@@ -205,8 +205,8 @@ class CurrentUserManager extends React.Component {
 }
 CurrentUserManager.propTypes = {
   sharedUser: PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    persistentToken: PropTypes.string.isRequired,
+    id: PropTypes.number,
+    persistentToken: PropTypes.string,
   }),
   cachedUser: PropTypes.object,
   setSharedUser: PropTypes.func.isRequired,

--- a/src/presenters/current-user.jsx
+++ b/src/presenters/current-user.jsx
@@ -9,6 +9,25 @@ import LocalStorage from './includes/local-storage.jsx';
 
 const {Provider, Consumer} = React.createContext();
 
+// Default values for all of the user fields we need you to have
+// We always generate a 'real' anon user, but use this until we do
+const defaultUser = {
+  id: -1,
+  avatarUrl: null,
+  avatarThumbnailUrl: null,
+  login: null,
+  name: null,
+  color: '#aaa',
+  description: '',
+  hasCoverImage: false,
+  coverColor: null,
+  teams: [],
+  emails: [],
+  collections: [],
+  features: [],
+  projects: [],
+};
+
 function identifyUser(user) {
   if (user) {
     console.log("👀 current user is", user);
@@ -47,14 +66,6 @@ function identifyUser(user) {
     console.error(error);
     captureException(error);
   }
-}
-
-function cleanUser({projects, teams, ...user}) {
-  return {
-    projects: projects || [],
-    teams: teams || [],
-    ...user,
-  };
 }
 
 // Test if two user objects reference the same person
@@ -181,10 +192,9 @@ class CurrentUserManager extends React.Component {
   
   render() {
     const {children, sharedUser, cachedUser, setSharedUser, setCachedUser} = this.props;
-    const currentUser = cachedUser || sharedUser;
     return children({
       api: this.api(),
-      currentUser: currentUser ? cleanUser(currentUser) : null,
+      currentUser: {...defaultUser, ...sharedUser, ...cachedUser},
       fetched: !!cachedUser && this.state.fetched,
       reload: () => this.load(),
       login: user => setSharedUser(user),

--- a/src/presenters/pages/category.jsx
+++ b/src/presenters/pages/category.jsx
@@ -101,19 +101,15 @@ const CategoryPage = ({api, category, ...props}) => (
       renderError={() => <CategoryPageError category={category} api={api} {...props}/>}
     >
       {category => (
-        <CurrentUserConsumer>
-          {(currentUser) => (
-            currentUser ? (
-              <CollectionEditor api={api} initialCollection={category} >
-                {(category, funcs) =>(
-                  <CategoryPageWrap category={category} api={api} userIsAuthor={false} currentUser={currentUser} {...funcs} {...props}/>
-                )}
-              </CollectionEditor>
-            ) : (
-              <Loader/>
-            )
+        <CollectionEditor api={api} initialCollection={category} >
+          {(category, funcs) => (
+            <CurrentUserConsumer>
+              {(currentUser) => (
+                <CategoryPageWrap category={category} api={api} userIsAuthor={false} currentUser={currentUser} {...funcs} {...props}/>
+              )}
+            </CurrentUserConsumer>
           )}
-        </CurrentUserConsumer>
+        </CollectionEditor>
       )}
     </DataLoader>
   </Layout>

--- a/src/presenters/pages/index.jsx
+++ b/src/presenters/pages/index.jsx
@@ -73,12 +73,12 @@ const IndexPage = ({api, user}) => (
       <Link to="https://glitch.com">Glitch</Link>{' '}
       is the friendly community where everyone can discover & create the best stuff on the web
     </h1>
-    {!!(user && user.login) && <Questions api={api}/>}
-    {!!(user && user.projects.length) && <RecentProjects api={api}/>}
+    {!!user.login && <Questions api={api}/>}
+    {!!user.projects.length && <RecentProjects api={api}/>}
     <Featured/>
     <RandomCategories api={api}/>
     <Categories/>
-    {!(user && user.login) && <WhatIsGlitch/>}
+    {!user.login && <WhatIsGlitch/>}
     <MadeInGlitch/>
   </main>
 );

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import {getAvatarUrl} from '../../models/project';
 
-import {Loader, DataLoader} from '../includes/loader.jsx';
+import {DataLoader} from '../includes/loader.jsx';
 import NotFound from '../includes/not-found.jsx';
 import {Markdown} from '../includes/markdown.jsx';
 import ProjectEditor from '../project-editor.jsx';

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -188,9 +188,7 @@ ProjectPageLoader.propTypes = {
 const ProjectPageContainer = ({api, name}) => (
   <Layout api={api}>
     <CurrentUserConsumer>
-      {currentUser => (
-        currentUser ? <ProjectPageLoader api={api} domain={name} currentUser={currentUser}/> : <Loader/>
-      )}
+      {currentUser => <ProjectPageLoader api={api} domain={name} currentUser={currentUser}/>}
     </CurrentUserConsumer>
   </Layout>
 );

--- a/src/presenters/pages/search.jsx
+++ b/src/presenters/pages/search.jsx
@@ -139,7 +139,7 @@ const SearchPage = ({api, query}) => (
         {errorFuncs => (
           <CurrentUserConsumer>
             {(currentUser) => (
-              currentUser && <SearchResults {...errorFuncs} api={api} query={query} currentUser={currentUser}/>
+              <SearchResults {...errorFuncs} api={api} query={query} currentUser={currentUser}/>
             )}
           </CurrentUserConsumer>
         )}

--- a/src/presenters/pop-overs/user-options-pop.jsx
+++ b/src/presenters/pop-overs/user-options-pop.jsx
@@ -92,6 +92,7 @@ Are you sure you want to sign out?`)) {
         return;
       }
     }
+    togglePopover();
     /* global analytics */
     analytics.track("Logout");
     analytics.reset();
@@ -125,7 +126,7 @@ Are you sure you want to sign out?`)) {
         </button>
         <Link to="https://support.glitch.com" className="button button-small has-emoji button-tertiary button-on-secondary-background">
           Support <span className="emoji ambulance"></span>
-        </Link>        
+        </Link>
         <button onClick={clickSignout} className="button-small has-emoji button-tertiary button-on-secondary-background">
           Sign Out <span className="emoji balloon"></span>
         </button>
@@ -167,7 +168,7 @@ export default function UserOptionsAndCreateTeamPopContainer(props) {
         <PopoverContainer startOpen={createTeamOpen}>
           {({togglePopover, visible}) => (
             <div className="button user-options-pop-button" data-tooltip="User options" data-tooltip-right="true">
-              <button className="user" onClick={togglePopover}>
+              <button className="user" onClick={togglePopover} disabled={!props.user.id}>
                 <img src={avatarUrl} style={avatarStyle} width="30px" height="30px" alt="User options"/>
                 <span className="down-arrow icon"/>
               </button>


### PR DESCRIPTION
If currentUser would be null, instead act like we're an anon user. The two differences between this and a real anon is the id (`0`) and the avatar color (`#aaa`). The user pop is visible while signed out now, but it is disabled.

There's probably a lot of potential cleanup, I just hit the main 'do not render if there is no user' spots.