### PR TITLE
Quixotic rocket: Fix source maps

### DIFF
--- a/sh/webpack.sh
+++ b/sh/webpack.sh
@@ -7,7 +7,7 @@ eslint --config server/.eslintrc.server.js webpack.config.js
 echo "Starting webpack watcher"
 
 while true; do
-  NODE_OPTIONS="--max-old-space-size=256" webpack --watch --info-verbosity verbose
+  NODE_OPTIONS="--max-old-space-size=320" webpack --watch --info-verbosity verbose
   
   echo "Webpack crashed; Restarting webpack --watch"
 done

--- a/sh/webpack.sh
+++ b/sh/webpack.sh
@@ -7,7 +7,7 @@ eslint --config server/.eslintrc.server.js webpack.config.js
 echo "Starting webpack watcher"
 
 while true; do
-  NODE_OPTIONS="--max-old-space-size=320" webpack --watch --info-verbosity verbose
+  NODE_OPTIONS="--max-old-space-size=384" webpack --watch --info-verbosity verbose
   
   echo "Webpack crashed; Restarting webpack --watch"
 done

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const webpack = require('webpack');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
@@ -14,7 +13,7 @@ const STYLE_BUNDLE_NAME = 'styles';
 
 
 let mode = 'development';
-if(process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production') {
   mode = 'production';
 }
 
@@ -31,6 +30,7 @@ module.exports = {
     path: PUBLIC,
     publicPath: '/',
   },
+  devtool: 'source-map',
   optimization: {
     splitChunks: {
       chunks: 'initial',
@@ -53,8 +53,9 @@ module.exports = {
       },
     },
     minimizer: [
-      new TerserPlugin({terserOptions: {safari10: true}}),
+      new TerserPlugin({terserOptions: {safari10: true}, sourceMap: true}),
     ],
+    noEmitOnErrors: true,
   },
   resolve: {
     extensions: ['.js', '.jsx'],
@@ -101,10 +102,8 @@ module.exports = {
       },
     ],
   },
-  devtool: 'source-map',
   plugins: [
     new LodashModuleReplacementPlugin(),
-    new webpack.NoEmitOnErrorsPlugin(),
     new ManifestPlugin({
       fileName: "scripts.json",
       filter: ({isInitial, name}) => (


### PR DESCRIPTION
Turns out the switch to terser for minification removed source maps, because terser doesn't include them by default. Including source maps in production bumps up webpack's memory usage enough that it was crashing again, so I upped it's memory limit a bit. It still seems to run fine without the perf boost team.

I also did an extra small cleanup, using optimization.noEmitOnErrors instead of the plugin