### PR TITLE
Superb guide: Fix homepage categories having wrong project counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-onclickoutside": "^6.7.1",
     "react-pluralize": "^1.4.0",
     "react-router-dom": "^4.3.1",
+    "react-svg-inline": "^2.1.1",
     "react-textarea-autosize": "^7.0.4",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
@@ -62,8 +63,7 @@
     "url-join": "^4.0.0",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2",
-    "webpack-manifest-plugin": "^2.0.4",
-    "react-svg-inline": "^2.1.1"
+    "webpack-manifest-plugin": "^2.0.4"
   },
   "engines": {
     "node": "10.x"

--- a/src/presenters/random-categories.jsx
+++ b/src/presenters/random-categories.jsx
@@ -49,13 +49,6 @@ class CategoryLoader extends React.Component {
     };
   }
   
-  loadCategoryProjectCount(){
-    this.state.categories.forEach(async ({id}) => {
-      const {data} = await this.props.api.get(`categories/${id}`);
-      this.setState(({categoriesPro{categoriesProjectCount: this.state.categoriesProjectCount}});
-    });
-  }
-  
   async loadCategories() {
     // The API gives us a json blob with all of the categories, but only
     // the 'projects' field on 3 of them.  If the field is present,
@@ -64,7 +57,13 @@ class CategoryLoader extends React.Component {
     const categoriesWithProjects = data.filter(category => !!category.projects);
     const categories = sampleSize(categoriesWithProjects, 3);
     this.setState({categories});
-    this.loadCategoryProjectCount();
+    // Now load each category to see how many projects it has
+    this.state.categories.forEach(async ({id}) => {
+      const {data} = await this.props.api.get(`categories/${id}`);
+      this.setState(prevState => ({
+        categoriesProjectCount: {...prevState.categoriesProjectCount, [id]: data.projects.length},
+      }));
+    });
   }
   
   componentDidMount() {
@@ -72,7 +71,7 @@ class CategoryLoader extends React.Component {
   }
   
   render() {
-    return this.state.categories.map((category, index) => (
+    return this.state.categories.map(category => (
       <Category key={category.id} category={category} projectCount={this.state.categoriesProjectCount[category.id]}/>
     ));
   }

--- a/src/presenters/random-categories.jsx
+++ b/src/presenters/random-categories.jsx
@@ -49,7 +49,7 @@ class CategoryLoader extends React.Component {
     };
   }
   
-  async loadCategories() {
+  async componentDidMount() {
     // The API gives us a json blob with all of the categories, but only
     // the 'projects' field on 3 of them.  If the field is present,
     // then it's an array of projects.
@@ -58,16 +58,12 @@ class CategoryLoader extends React.Component {
     const categories = sampleSize(categoriesWithProjects, 3);
     this.setState({categories});
     // Now load each category to see how many projects it has
-    this.state.categories.forEach(async ({id}) => {
+    categories.forEach(async ({id}) => {
       const {data} = await this.props.api.get(`categories/${id}`);
       this.setState(prevState => ({
         categoriesProjectCount: {...prevState.categoriesProjectCount, [id]: data.projects.length},
       }));
     });
-  }
-  
-  componentDidMount() {
-    this.loadCategories();
   }
   
   render() {

--- a/src/presenters/random-categories.jsx
+++ b/src/presenters/random-categories.jsx
@@ -11,7 +11,6 @@ const Category = ({category, projectCount}) => {
     categoryColor: category.color,
     homepageCollection: true,
     collectionUrl: category.url,
-    projectCount: projectCount,
   };
   return (
     <article className="projects" style={{backgroundColor: category.backgroundColor}}>
@@ -46,17 +45,14 @@ class CategoryLoader extends React.Component {
     super(props);
     this.state = {
       categories: [],
-      categoriesProjectCount: []
+      categoriesProjectCount: {},
     };
   }
   
-  async loadCategoryProjectCount(){
-    this.state.categories.map( ({id}) => {
-      this.props.api.get(`categories/${id}`)
-        .then( ({data}) => {
-          this.state.categoriesProjectCount.push(data.projects.length); 
-          this.setState({categoriesProjectCount: this.state.categoriesProjectCount});
-        });  
+  loadCategoryProjectCount(){
+    this.state.categories.forEach(async ({id}) => {
+      const {data} = await this.props.api.get(`categories/${id}`);
+      this.setState(({categoriesPro{categoriesProjectCount: this.state.categoriesProjectCount}});
     });
   }
   
@@ -77,7 +73,7 @@ class CategoryLoader extends React.Component {
   
   render() {
     return this.state.categories.map((category, index) => (
-      <Category key={category.id} category={category} projectCount={this.state.categoriesProjectCount[index]}/>
+      <Category key={category.id} category={category} projectCount={this.state.categoriesProjectCount[category.id]}/>
     ));
   }
 }


### PR DESCRIPTION
The category project counts were getting stored in an array in the order that the requests came back, so they get jumbled relative to the categories they belong to. This stores them in a map of category id to count so the order they come back doesn't matter.