### PR TITLE
Profuse Tea: Fix the delete project button on the teams page

### DIFF
--- a/src/presenters/pages/team.jsx
+++ b/src/presenters/pages/team.jsx
@@ -180,6 +180,7 @@ class TeamPage extends React.Component {
           projectOptions={{
             addProjectToCollection: this.addProjectToCollection,
             removeProjectFromTeam: this.props.removeProject,
+            deleteProject: this.props.deleteProject,
             joinTeamProject: this.props.joinTeamProject,
             leaveTeamProject: this.props.leaveTeamProject,
           }}
@@ -194,6 +195,7 @@ class TeamPage extends React.Component {
           projectOptions={{
             addProjectToCollection: this.addProjectToCollection,
             removeProjectFromTeam: this.props.removeProject,
+            deleteProject: this.props.deleteProject,
             joinTeamProject: this.props.joinTeamProject,
             leaveTeamProject: this.props.leaveTeamProject,
           }}
@@ -267,6 +269,7 @@ TeamPage.propTypes = {
   }),
   addPin: PropTypes.func.isRequired,
   addProject: PropTypes.func.isRequired,
+  deleteProject:PropTypes.func.isRequired,
   updateWhitelistedDomain: PropTypes.func.isRequired,
   inviteEmail: PropTypes.func.isRequired,
   inviteUser: PropTypes.func.isRequired,

--- a/src/presenters/team-editor.jsx
+++ b/src/presenters/team-editor.jsx
@@ -142,6 +142,13 @@ class TeamEditor extends React.Component {
     }));
   }
 
+  async deleteProject(id) {
+    await this.props.api.delete(`/projects/${id}`);
+    this.setState(({projects}) => ({
+      projects: projects.filter(p => p.id !== id),
+    }));
+  }
+
   async addPin(id) {
     await this.props.api.post(`teams/${this.state.id}/pinned-projects/${id}`);
     this.setState(({teamPins}) => ({
@@ -192,6 +199,7 @@ class TeamEditor extends React.Component {
       clearCover: () => this.updateFields({hasCoverImage: false}).catch(handleError),
       addProject: project => this.addProject(project).catch(handleError),
       removeProject: id => this.removeProject(id).catch(handleError),
+      deleteProject: id => this.deleteProject(id).catch(handleError),
       addPin: id => this.addPin(id).catch(handleError),
       removePin: id => this.removePin(id).catch(handleError),
       updateWhitelistedDomain: whitelistedDomain => this.updateFields({whitelistedDomain}).catch(handleError),


### PR DESCRIPTION
Future work: move api calls to where they're used and expose an 'onProjectDeleted' event for the user page to listen to and act on.