### PR TITLE
Superb guide: Remove the dev toggle for team collections

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -39,6 +39,11 @@ Now select 'BlackBoxing' on the left, and blackbox `@sentry`:
 Now, in your devtools, it'll be just like Raven.js doesn't exist -- line numbers and exceptions will flow straight through, but it'll stay functional behind the scenes.
 
 
+### What are dev toggles?
+
+We use them to hide features that we're still working on. The code lives in `dev-toggles.jsx`. Visit remix.glitch.me/secret to enable a feature locally.
+
+
 ### Is any configuration required to get my remix running?
 
 Nope! Though you can set your remix to run in production mode by setting `NODE_ENV=production` in the `.env` file. Doing so will improve performance a bit, but webpack will take a lot longer.

--- a/src/presenters/collection-editor.jsx
+++ b/src/presenters/collection-editor.jsx
@@ -19,7 +19,7 @@ class CollectionEditor extends React.Component {
     if (this.state.user) {
       return this.state.user.id === currentUserId;
     }
-    if (this.state.team && this.props.teamsEnabled) {
+    if (this.state.team) {
       return this.state.team.users.some(user => user.id === currentUserId);
     }
     return false;

--- a/src/presenters/collection-editor.jsx
+++ b/src/presenters/collection-editor.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import {CurrentUserConsumer} from './current-user.jsx';
 import ErrorHandlers from './error-handlers.jsx';
-import DevToggles from './includes/dev-toggles';
 
 class CollectionEditor extends React.Component {
   constructor(props) {
@@ -72,23 +71,18 @@ CollectionEditor.propTypes = {
   handleError: PropTypes.func.isRequired,
   handleErrorForInput: PropTypes.func.isRequired,
   initialCollection: PropTypes.object.isRequired,
-  teamsEnabled: PropTypes.bool.isRequired,
 };
 
 const CollectionEditorContainer = ({api, children, initialCollection}) => (
   <ErrorHandlers>
     {errorFuncs => (
-      <DevToggles>
-        {enabledToggles => (
-          <CurrentUserConsumer>
-            {(currentUser) => (
-              <CollectionEditor {...{api, currentUser, initialCollection}} {...errorFuncs} teamsEnabled={enabledToggles.includes('Team Collections')}>
-                {children}
-              </CollectionEditor>
-            )}
-          </CurrentUserConsumer>
+      <CurrentUserConsumer>
+        {(currentUser) => (
+          <CollectionEditor {...{api, currentUser, initialCollection}} {...errorFuncs}>
+            {children}
+          </CollectionEditor>
         )}
-      </DevToggles>
+      </CurrentUserConsumer>
     )}
   </ErrorHandlers>
 );

--- a/src/presenters/includes/dev-toggles.jsx
+++ b/src/presenters/includes/dev-toggles.jsx
@@ -17,7 +17,7 @@ const {Provider, Consumer} = React.createContext();
 const toggleData = [
   {name: "Email Invites", description: "Enables invite-by-email behavior on the team page."},
   {name: "Everybody Dance!", description: "Placeholder for a new toggle."},
-  {name: "Team Collections", description: "Co-op mode for collections"},
+  {name: "Inflatable Crocodiles", description: "I don't think this does anything yet."},
 ].splice(0,3); // <-- Yeah really, only 3.  If you need more, clean up one first.
 
 

--- a/src/presenters/pages/team.jsx
+++ b/src/presenters/pages/team.jsx
@@ -53,20 +53,16 @@ const TeamNameUrlFields = ({team, updateName, updateUrl}) => (
 );
 
 const TeamPageCollections = ({collections, team, api, currentUser, currentUserIsOnTeam}) => (
-  <DevToggles>
-    {enabledToggles => (
-      <CollectionsList
-        title={<>Collections {!collections.length && currentUserIsOnTeam && (
-          <aside className="inline-banners team-page">
-            Use collections to organize projects
-          </aside>
-        )}</>}
-        collections={collections.map(collection => ({...collection, team: team}))}
-        api={api} maybeCurrentUser={currentUser} maybeTeam={team}
-        isAuthorized={currentUserIsOnTeam && enabledToggles.includes('Team Collections')}
-      />
-    )}
-  </DevToggles>
+  <CollectionsList
+    title={<>Collections {!collections.length && currentUserIsOnTeam && (
+      <aside className="inline-banners team-page">
+        Use collections to organize projects
+      </aside>
+    )}</>}
+    collections={collections.map(collection => ({...collection, team: team}))}
+    api={api} maybeCurrentUser={currentUser} maybeTeam={team}
+    isAuthorized={currentUserIsOnTeam}
+  />
 );
 
 // Team Page

--- a/src/presenters/pages/team.jsx
+++ b/src/presenters/pages/team.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import Helmet from 'react-helmet';
 import {AnalyticsContext} from '../analytics';
-import DevToggles from '../includes/dev-toggles';
 import {CurrentUserConsumer} from '../current-user';
 import {DataLoader} from '../includes/loader';
 import TeamEditor from '../team-editor.jsx';

--- a/src/presenters/pages/team.jsx
+++ b/src/presenters/pages/team.jsx
@@ -53,11 +53,7 @@ const TeamNameUrlFields = ({team, updateName, updateUrl}) => (
 
 const TeamPageCollections = ({collections, team, api, currentUser, currentUserIsOnTeam}) => (
   <CollectionsList
-    title={<>Collections {!collections.length && currentUserIsOnTeam && (
-      <aside className="inline-banners team-page">
-        Use collections to organize projects
-      </aside>
-    )}</>}
+    title="Collections"
     collections={collections.map(collection => ({...collection, team: team}))}
     api={api} maybeCurrentUser={currentUser} maybeTeam={team}
     isAuthorized={currentUserIsOnTeam}

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -228,10 +228,7 @@ class AddCollectionProjectPop extends React.Component {
   }
   
   render() {
-    // load user's recent projects
-    const ownProjects = (this.props.collection.team && this.props.collection.team.projects) || this.props.currentUser.projects;
-    
-    const showResults = !!(this.state.query || this.state.maybeResults);
+    const showResults = !!(this.state.query || this.state.maybeResults.length);
     const isLoading = !!(this.state.maybeRequest || !this.state.maybeResults);
     
     return (

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -229,7 +229,10 @@ class AddCollectionProjectPop extends React.Component {
   
   render() {
     // load user's recent projects
-    const isLoading = (!!this.state.maybeRequest || !this.state.maybeResults);
+    const ownProjects = (this.props.collection.team && this.props.collection.team.projects) || this.props.currentUser.projects;
+    
+    const showResults = !!(this.state.query || this.state.maybeResults);
+    const isLoading = !!(this.state.maybeRequest || !this.state.maybeResults);
     
     return (
       <dialog className="pop-over add-collection-project-pop wide-pop">
@@ -241,7 +244,7 @@ class AddCollectionProjectPop extends React.Component {
             placeholder="Search by project name or URL"
           />
         </section>
-        {(!!this.state.query || this.state.maybeResults) && <section className="pop-over-actions last-section results-list">
+        {showResults && <section className="pop-over-actions last-section results-list">
           {isLoading && <Loader />}
         
           {!!this.state.maybeResults && 

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -214,10 +214,9 @@ class AddCollectionProjectPop extends React.Component {
     // load user's recent projects
     const ownProjects = this.props.collection.team ? this.props.collection.team.projects : this.props.currentUser.projects;
     const results = this.state.query ? this.state.maybeResults : ownProjects.slice(0,20);
-    console.log(ownProjects);
     
     const showResults = !!(this.state.query || results.length);
-    const isLoading = !!(this.state.maybeRequest || !results.length);
+    const isLoading = !!(this.state.maybeRequest || !results);
     
     return (
       <dialog className="pop-over add-collection-project-pop wide-pop">

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -213,10 +213,11 @@ class AddCollectionProjectPop extends React.Component {
   render() {
     // load user's recent projects
     const ownProjects = this.props.collection.team ? this.props.collection.team.projects : this.props.currentUser.projects;
-    const results = this.state.maybeResults || ownProjects.slice(1,20);
+    const results = this.state.query ? this.state.maybeResults : ownProjects.slice(0,20);
+    console.log(ownProjects);
     
     const showResults = !!(this.state.query || results.length);
-    const isLoading = !!(this.state.maybeRequest || !this.state.maybeResults);
+    const isLoading = !!(this.state.maybeRequest || !results.length);
     
     return (
       <dialog className="pop-over add-collection-project-pop wide-pop">

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -61,8 +61,7 @@ const ProjectSearchResults = ({projects, collection, onClick, projectName, exclu
 
   return (
     <p className="results-empty">
-      nothing found 
-      <span role="img" aria-label="">💫</span><br/>
+      nothing found <span role="img" aria-label="">💫</span><br/>
       {excludedProjectsCount > 0 && (
         <span>(Excluded {excludedProjectsCount} search {(excludedProjectsCount > 1 ? "results" : "result")} already found in collection)</span>
       )}

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -215,7 +215,7 @@ class AddCollectionProjectPop extends React.Component {
     const ownProjects = this.props.collection.team ? this.props.collection.team.projects : this.props.currentUser.projects;
     const results = this.state.query ? this.state.maybeResults : ownProjects.slice(0,20);
     
-    const showResults = !!(this.state.query || results.length);
+    const showResults = !!(this.state.query || (results && results.length));
     const isLoading = !!(this.state.maybeRequest || !results);
     
     return (

--- a/src/presenters/pop-overs/add-collection-project-pop.jsx
+++ b/src/presenters/pop-overs/add-collection-project-pop.jsx
@@ -96,27 +96,10 @@ class AddCollectionProjectPop extends React.Component {
       excludedProjectsCount: 0, // number of projects omitted from search
     };
     
-    this.loadRecentProjects = this.loadRecentProjects.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.clearSearch = this.clearSearch.bind(this);
     this.startSearch = debounce(this.startSearch.bind(this), 300);
     this.onClick = this.onClick.bind(this);
-  }
-  
-  componentDidMount(){
-    // load user's recent projects to show in dropdown by default
-    if(this.props.currentUser.projects.length > 0){
-      this.loadRecentProjects();
-    }
-  }
-  
-  loadRecentProjects(){
-    const MAX_PROJECTS = 20;
-    if (this.props.collection.team && this.props.collection.team.projects) {
-      this.setState({ maybeResults: this.props.collection.team.projects.slice(0,MAX_PROJECTS) });
-    } else {
-      this.setState({ maybeResults: this.props.currentUser.projects.slice(0,MAX_PROJECTS) });
-    }
   }
   
   handleChange(evt) {
@@ -132,10 +115,10 @@ class AddCollectionProjectPop extends React.Component {
   clearSearch() {
     this.setState({
       maybeRequest: null,
+      maybeResults: null,
       projectName: '',
       excludedProjectsCount: 0,
     });
-    this.loadRecentProjects();
   } 
   
   async startSearch() {
@@ -228,7 +211,11 @@ class AddCollectionProjectPop extends React.Component {
   }
   
   render() {
-    const showResults = !!(this.state.query || this.state.maybeResults.length);
+    // load user's recent projects
+    const ownProjects = this.props.collection.team ? this.props.collection.team.projects : this.props.currentUser.projects;
+    const results = this.state.maybeResults || ownProjects.slice(1,20);
+    
+    const showResults = !!(this.state.query || results.length);
     const isLoading = !!(this.state.maybeRequest || !this.state.maybeResults);
     
     return (
@@ -244,8 +231,8 @@ class AddCollectionProjectPop extends React.Component {
         {showResults && <section className="pop-over-actions last-section results-list">
           {isLoading && <Loader />}
         
-          {!!this.state.maybeResults && 
-            <ProjectsLoader api={this.props.api} projects={this.state.maybeResults}>
+          {!!results && 
+            <ProjectsLoader api={this.props.api} projects={results}>
               {projects => <ProjectSearchResults
                 projects={projects}
                 onClick={this.onClick}

--- a/src/presenters/pop-overs/project-options-pop.jsx
+++ b/src/presenters/pop-overs/project-options-pop.jsx
@@ -70,7 +70,7 @@ const ProjectOptionsContent = ({addToCollectionPopover, ...props}) => {
       
       {!!props.addProjectToCollection &&
         <section className="pop-over-actions">
-          <PopoverButton onClick={addToCollectionPopover} {...props} text="Add to Collection " emoji="framed_picture"/>
+          <PopoverButton onClick={addToCollectionPopover} {...props} text="Add to My Collection " emoji="framed_picture"/>
         </section>
       }
 


### PR DESCRIPTION
Missing the ability to undelete collections and the preview collections on team pages, but I don't think they should block enabling this for people.