### PR TITLE
Removed the bottom border from the last element in the new projects popover

### DIFF
--- a/src/presenters/pop-overs/new-project-pop.jsx
+++ b/src/presenters/pop-overs/new-project-pop.jsx
@@ -13,7 +13,7 @@ const NewProjectPop = ({projects}) => (
     <section className="pop-over-actions results-list">
       <div className="results">
         {projects.length ? projects.map((project) => (
-          <TrackedExternalLink className="result-wrapper" key={project.id} to={getRemixUrl(project.domain)}
+          <TrackedExternalLink key={project.id} to={getRemixUrl(project.domain)}
             name="New Project Clicked" properties={{
               baseDomain: project.domain,
               origin: "community new project pop",

--- a/src/presenters/pop-overs/new-project-pop.jsx
+++ b/src/presenters/pop-overs/new-project-pop.jsx
@@ -13,7 +13,7 @@ const NewProjectPop = ({projects}) => (
     <section className="pop-over-actions results-list">
       <div className="results">
         {projects.length ? projects.map((project) => (
-          <TrackedExternalLink key={project.id} to={getRemixUrl(project.domain)}
+          <TrackedExternalLink className="result-wrapper" key={project.id} to={getRemixUrl(project.domain)}
             name="New Project Clicked" properties={{
               baseDomain: project.domain,
               origin: "community new project pop",

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -66,7 +66,7 @@
       margin-right: 10px
       width: 57%
 
-  .result-wrapper:last-child
+  a:last-child .result
     border-bottom: none
       
   .result

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -80,9 +80,8 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
-        
-.results:last-child button
-  border-bottom: 1px solid section-line
+    &:last-of-type
+      border-bottom: 1px solid section-line
     
   .result-name
     display: inline-block

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -66,10 +66,12 @@
   .result
     list-style-type: none
     cursor: pointer
-    border-bottom: 1px solid section-line
+    //border-bottom: 1px solid section-line
     padding: 6px
     padding-top: 12px
     padding-bottom: 12px
+    &:last-child
+      border-bottom: 1px solid section-line
     &:hover,
     &.hover,
     &:focus,
@@ -80,8 +82,6 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
-    &:last-child
-      border-bottom: none
   .result-name
     display: inline-block
     vertical-align: middle

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -66,12 +66,12 @@
   .result
     list-style-type: none
     cursor: pointer
-    //border-bottom: 1px solid section-line
+    // border-bottom: 1px solid section-line
     padding: 6px
     padding-top: 12px
     padding-bottom: 12px
-    &:last-child
-      border-bottom: 1px solid section-line
+    &:first-child
+      border-bottom 1px solid section-line
     &:hover,
     &.hover,
     &:focus,

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -26,6 +26,7 @@
         background-color: general-link
         a
           color: background-color
+      
     .result-user
       .avatar
         float: left
@@ -79,6 +80,8 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
+    &:last-child
+      border-bottom: none
   .result-name
     display: inline-block
     vertical-align: middle

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -79,8 +79,6 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
-        
-        
   .result-name
     display: inline-block
     vertical-align: middle

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -66,10 +66,13 @@
       margin-right: 10px
       width: 57%
 
+  .result-wrapper:last-child
+    border-bottom: none
+      
   .result
     list-style-type: none
     cursor: pointer
-    // border-bottom: 1px solid section-line
+    border-bottom: 1px solid section-line
     padding: 6px
     padding-top: 12px
     padding-bottom: 12px

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -1,3 +1,6 @@
+.result:last-of-type
+  border-bottom: 1px solid section-line
+
 .results-list
   overflow-y: auto
   max-height: 357px
@@ -80,8 +83,6 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
-    &:last-of-type
-      border-bottom: 1px solid section-line
     
   .result-name
     display: inline-block

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -1,6 +1,3 @@
-.result:last-of-type
-  border-bottom: 1px solid section-line
-
 .results-list
   overflow-y: auto
   max-height: 357px
@@ -29,7 +26,6 @@
         background-color: general-link
         a
           color: background-color
-      
     .result-user
       .avatar
         float: left
@@ -86,7 +82,6 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
-    
   .result-name
     display: inline-block
     vertical-align: middle

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -70,8 +70,6 @@
     padding: 6px
     padding-top: 12px
     padding-bottom: 12px
-    &:first-child
-      border-bottom 1px solid section-line
     &:hover,
     &.hover,
     &:focus,
@@ -82,6 +80,10 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
+        
+.results:last-child button
+  border-bottom: 1px solid section-line
+    
   .result-name
     display: inline-block
     vertical-align: middle

--- a/styles/results-list.styl
+++ b/styles/results-list.styl
@@ -79,6 +79,8 @@
         color: secondary-hover-on-color
       .result-name
         color: background-color
+        
+        
   .result-name
     display: inline-block
     vertical-align: middle


### PR DESCRIPTION
This PR fixes https://glitch.manuscript.com/f/cases/3309594/css-bottom-of-new-project-list-has-a-border

Note that there is a similar rule already implemented here:
https://glitch.com/edit/#!/ribbon-pipe?path=styles/pop-overs.styl:55:9
which removes bottom borders from some popovers, but the pop-over-section class which implements the styling is only currently used in NestedPopover components, not single-level popovers like this one.

I considered just using that class here, but in the new projects popover, the top-level element in the results list is actually a tracked link, and it seemed weird to add the class to that element. Additionally the pop-over-section class also adds extra padding which looks bad on this popover. Seems like these popovers could be a good candidate for later refactoring.