### PR TITLE
Gifted Suede: update the pupdate to not use CSS transforms

### DIFF
--- a/styles/overlays.styl
+++ b/styles/overlays.styl
@@ -84,6 +84,9 @@ dialog.overlay
   
   &.overlay-narrow
     max-width: 460px
+    left: 0px
+    margin: 0 auto
+    transform: initial
 
   // wistia embed styling
   .wistia_responsive_padding


### PR DESCRIPTION
using `transform:translateX(50%)` causes blurriness when the screen is an odd number of pixels in width (definitely in chromeOS, possibly also in other OS/browsers). Changed the pupdate so that it is centered in the screen without using this CSS.

https://gifted-suede.glitch.me/ (to check it out, go to the avatar menu and click the "new stuff" button)

https://glitch.manuscript.com/f/cases/3326591/pupdate-blurry-overlays-in-chromeos

giving to Sheridan because we were just talking CSS in coffeetime :)