### PR TITLE
Astonishing orchestra

### DIFF
--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -95,12 +95,8 @@ class EmailHandler extends React.Component {
               }
             </section>
             {(this.state.done && !this.state.error) &&
-              <section className="pop-over-actions last-sectionn pop-over-info">
-                <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
-                  <span>Use a sign in code</span>
-                </button>
-              </section>
-              }
+              <SignInCodeSection onClick={() => { onClick(); showCodeLogin(api); }}/>
+            }
           </dialog>
         }
       </NestedPopover>

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -82,13 +82,13 @@ class EmailHandler extends React.Component {
               }
               {(this.state.done && !this.state.error) &&
                 <>
-                  <div className="notification notifySuccess">Almost Done</div>
+                  <div className="notification notifyPersistent notifySuccess">Almost Done</div>
                   <div>Finish signing in from the email sent to {this.state.email}.</div>
                 </>
               }
               {(this.state.done && this.state.error) &&
                 <>
-                  <div className="notification notifyError">Error</div>
+                  <div className="notification notifyPersistent notifyError">Error</div>
                   <div>Something went wrong, email not sent.</div>
                 </>
               }
@@ -154,12 +154,12 @@ class SignInCodeHandler extends React.Component {
           }
           {(this.state.done && !this.state.error) &&
             <>
-              <div className="notification notifySuccess">Success!</div>
+              <div className="notification notifyPersistent notifySuccess">Success!</div>
             </>
           }
           {(this.state.done && this.state.error) &&
             <>
-              <div className="notification notifyError">Error</div>
+              <div className="notification notifyPersistent notifyError">Error</div>
               <div>Code not found or already used. Try signing in with email.</div>
             </>
           }       

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -67,7 +67,7 @@ class EmailHandler extends React.Component {
   render() {
     const isEnabled = this.state.email.length > 0;
     return (
-      <NestedPopover alternateContent={(login) => <SignInCodeHandler setUser={login} {...this.props}/>} startAlternateVisible={false}>
+      <NestedPopover alternateContent={() => <SignInWithConsumer {...this.props}/>} startAlternateVisible={false}>
         {showCodeLogin =>
           <dialog className="pop-over sign-in-pop">
             <NestedPopoverTitle>
@@ -124,10 +124,8 @@ class SignInCodeHandler extends React.Component {
   async onSubmit(e) {
     e.preventDefault();
     this.setState({done: true});
-    console.log(this.props);
     try {
       const {data} = await this.props.api.post('/auth/email/' + this.state.code);
-      console.log(data);
       this.props.setUser(data);
       this.setState({error: false});
     } catch (error) {

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -180,7 +180,7 @@ EmailSignInButton.propTypes = {
 
 const SignInCodeSection = ({onClick}) => (
   <section className="pop-over-actions last-section pop-over-info">
-    <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick();}}>
+    <button className="button-small button-tertiary button-on-secondary-background"  onClick={onClick}>
       <span>Use a sign in code</span>
     </button>
   </section>

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -66,9 +66,8 @@ class EmailHandler extends React.Component {
    
   render() {
     const isEnabled = this.state.email.length > 0;
-    const {header, prompt, api, location, hash} = this.props;
     return (
-      <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {...props}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
+      <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {this.props.api}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
         {showCodeLogin =>
           <dialog className="pop-over sign-in-pop">
             <NestedPopoverTitle>

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -66,39 +66,44 @@ class EmailHandler extends React.Component {
    
   render() {
     const isEnabled = this.state.email.length > 0;
+    const {header, prompt, api, location, hash} = this.props;
     return (
-      <dialog className="pop-over sign-in-pop">
-        <NestedPopoverTitle>
-          Email Sign In <span className="emoji email" />
-        </NestedPopoverTitle>
-        <section className="pop-over-actions first-section">
-          {!this.state.done &&
-            <form onSubmit={this.onSubmit} style={{marginBottom: 0}}>
-              <input value={this.state.email} onChange={this.onChange} className="pop-over-input" type="email" placeholder="new@user.com"></input>
-              <button style={{marginTop: 10}} className="button-small button-link" disabled={!isEnabled}>Send Link</button>
-            </form>
-          }
-          {(this.state.done && !this.state.error) &&
-            <>
-              <div className="notification notifySuccess">Almost Done</div>
-              <div>Finish signing in from the email sent to {this.state.email}.</div>
-            </>
-          }
-          {(this.state.done && this.state.error) &&
-            <>
-              <div className="notification notifyError">Error</div>
-              <div>Something went wrong, email not sent.</div>
-            </>
-          }
-        </section>
-        {(this.state.done && !this.state.error) &&
-          <section className="pop-over-actions last-sectionn pop-over-info">
+      <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {...props}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
+        {showCodeLogin =>
+          <dialog className="pop-over sign-in-pop">
+            <NestedPopoverTitle>
+              Email Sign In <span className="emoji email" />
+            </NestedPopoverTitle>
+            <section className="pop-over-actions first-section">
+              {!this.state.done &&
+                <form onSubmit={this.onSubmit} style={{marginBottom: 0}}>
+                  <input value={this.state.email} onChange={this.onChange} className="pop-over-input" type="email" placeholder="new@user.com"></input>
+                  <button style={{marginTop: 10}} className="button-small button-link" disabled={!isEnabled}>Send Link</button>
+                </form>
+              }
+              {(this.state.done && !this.state.error) &&
+                <>
+                  <div className="notification notifySuccess">Almost Done</div>
+                  <div>Finish signing in from the email sent to {this.state.email}.</div>
+                </>
+              }
+              {(this.state.done && this.state.error) &&
+                <>
+                  <div className="notification notifyError">Error</div>
+                  <div>Something went wrong, email not sent.</div>
+                </>
+              }
+            </section>
+            {(this.state.done && !this.state.error) &&
+              <section className="pop-over-actions last-sectionn pop-over-info">
                 <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
                   <span>Use a sign in code</span>
                 </button>
-          </section>
-          }
-      </dialog>
+              </section>
+              }
+          </dialog>
+        }
+      </NestedPopover>
     );
   }
 }
@@ -178,6 +183,17 @@ EmailSignInButton.propTypes = {
   onClick: PropTypes.func.isRequired
 };
 
+const SignInCodeSection = ({onClick}) => (
+  <section className="pop-over-actions last-section pop-over-info">
+    <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick();}}>
+      <span>Use a sign in code</span>
+    </button>
+  </section>
+);
+SignInCodeSection.propTypes = {
+  onClick: PropTypes.func.isRequired
+};
+
 const SignInPopWithoutRouter = (props) => (
   <LocalStorage name="destinationAfterAuth">
     {(destination, setDestination) => {
@@ -203,11 +219,7 @@ const SignInPopWithoutRouter = (props) => (
                     <SignInPopButton href={githubAuthLink()} company="GitHub" emoji="octocat" onClick={onClick}/>
                     <EmailSignInButton onClick={() => { onClick(); showEmailLogin(api); }}/>
                   </section>
-                  <section className="pop-over-actions last-section pop-over-info">
-                    <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
-                      <span>Use a sign in code</span>
-                    </button>
-                  </section>
+                  <SignInCodeSection onClick={() => { onClick(); showCodeLogin(api); }}/>
                 </div>
               }
             </NestedPopover>

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -67,7 +67,7 @@ class EmailHandler extends React.Component {
   render() {
     const isEnabled = this.state.email.length > 0;
     return (
-      <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {...this.props}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
+      <NestedPopover alternateContent={(login) => <SignInCodeHandler setUser={login} {...this.props}/>} startAlternateVisible={false}>
         {showCodeLogin =>
           <dialog className="pop-over sign-in-pop">
             <NestedPopoverTitle>
@@ -140,31 +140,33 @@ class SignInCodeHandler extends React.Component {
   render() {
     const isEnabled = this.state.code.length > 0;
     return (
-      <dialog className="pop-over sign-in-pop">
-        <NestedPopoverTitle>
-          Use a sign in code
-        </NestedPopoverTitle>
-        <section className="pop-over-actions first-section">
-          {!this.state.done &&
-            <form onSubmit={this.onSubmit} style={{marginBottom: 0}}>
-              Paste your temporary sign in code below
-              <input value={this.state.code} onChange={this.onChange} className="pop-over-input" type="text" placeholder="cute-unique-cosmos"></input>
-              <button style={{marginTop: 10}} className="button-small button-link" disabled={!isEnabled}>Sign In</button>
-            </form>
-          }
-          {(this.state.done && !this.state.error) &&
-            <>
-              <div className="notification notifyPersistent notifySuccess">Success!</div>
-            </>
-          }
-          {(this.state.done && this.state.error) &&
-            <>
-              <div className="notification notifyPersistent notifyError">Error</div>
-              <div>Code not found or already used. Try signing in with email.</div>
-            </>
-          }       
-        </section>
-      </dialog>
+      <CurrentUserConsumer>{(currentUser, fetched, {login}) =>
+        <dialog className="pop-over sign-in-pop">
+          <NestedPopoverTitle>
+            Use a sign in code
+          </NestedPopoverTitle>
+          <section className="pop-over-actions first-section">
+            {!this.state.done &&
+              <form onSubmit={this.onSubmit} style={{marginBottom: 0}}>
+                Paste your temporary sign in code below
+                <input value={this.state.code} onChange={this.onChange} className="pop-over-input" type="text" placeholder="cute-unique-cosmos"></input>
+                <button style={{marginTop: 10}} className="button-small button-link" disabled={!isEnabled}>Sign In</button>
+              </form>
+            }
+            {(this.state.done && !this.state.error) &&
+              <>
+                <div className="notification notifyPersistent notifySuccess">Success!</div>
+              </>
+            }
+            {(this.state.done && this.state.error) &&
+              <>
+                <div className="notification notifyPersistent notifyError">Error</div>
+                <div>Code not found or already used. Try signing in with email.</div>
+              </>
+            }       
+          </section>
+        </dialog>
+      }</CurrentUserConsumer>
     );
   }
 }
@@ -204,7 +206,7 @@ const SignInPopWithoutRouter = (props) => (
       return (
         <NestedPopover alternateContent={() => <EmailHandler {...props}/>} startAlternateVisible={false}>
           {showEmailLogin =>
-            <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {...props}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
+            <NestedPopover alternateContent={(login) => <SignInCodeHandler setUser={login} {...props}/>} startAlternateVisible={false}>
               {showCodeLogin =>
                 <div className="pop-over sign-in-pop">
                   {header}

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -82,6 +82,7 @@ class EmailHandler extends React.Component {
             <>
               <div className="notification notifySuccess">Almost Done</div>
               <div>Finish signing in from the email sent to {this.state.email}.</div>
+            </section>
               <section className="pop-over-actions last-sectionn pop-over-info">
                 <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
                   <span>Use a sign in code</span>
@@ -93,9 +94,9 @@ class EmailHandler extends React.Component {
             <>
               <div className="notification notifyError">Error</div>
               <div>Something went wrong, email not sent.</div>
+            </section>
             </>
           }       
-        </section>
       </dialog>
     );
   }

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -130,7 +130,6 @@ class SignInCodeHandler extends React.Component {
       this.setState({error: false});
     } catch (error) {
       captureException(error);
-      console.log(error);
       this.setState({error: true});
     }
   }

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -82,21 +82,22 @@ class EmailHandler extends React.Component {
             <>
               <div className="notification notifySuccess">Almost Done</div>
               <div>Finish signing in from the email sent to {this.state.email}.</div>
-            </section>
-              <section className="pop-over-actions last-sectionn pop-over-info">
-                <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
-                  <span>Use a sign in code</span>
-                </button>
-              </section>
             </>
           }
           {(this.state.done && this.state.error) &&
             <>
               <div className="notification notifyError">Error</div>
               <div>Something went wrong, email not sent.</div>
-            </section>
             </>
-          }       
+          }
+        </section>
+        {(this.state.done && !this.state.error) &&
+          <section className="pop-over-actions last-sectionn pop-over-info">
+                <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
+                  <span>Use a sign in code</span>
+                </button>
+          </section>
+          }
       </dialog>
     );
   }

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -140,36 +140,38 @@ class SignInCodeHandler extends React.Component {
   render() {
     const isEnabled = this.state.code.length > 0;
     return (
-      <CurrentUserConsumer>{(currentUser, fetched, {login}) =>
-        <dialog className="pop-over sign-in-pop">
-          <NestedPopoverTitle>
-            Use a sign in code
-          </NestedPopoverTitle>
-          <section className="pop-over-actions first-section">
-            {!this.state.done &&
-              <form onSubmit={this.onSubmit} style={{marginBottom: 0}}>
-                Paste your temporary sign in code below
-                <input value={this.state.code} onChange={this.onChange} className="pop-over-input" type="text" placeholder="cute-unique-cosmos"></input>
-                <button style={{marginTop: 10}} className="button-small button-link" disabled={!isEnabled}>Sign In</button>
-              </form>
-            }
-            {(this.state.done && !this.state.error) &&
-              <>
-                <div className="notification notifyPersistent notifySuccess">Success!</div>
-              </>
-            }
-            {(this.state.done && this.state.error) &&
-              <>
-                <div className="notification notifyPersistent notifyError">Error</div>
-                <div>Code not found or already used. Try signing in with email.</div>
-              </>
-            }       
-          </section>
-        </dialog>
-      }</CurrentUserConsumer>
+      <dialog className="pop-over sign-in-pop">
+        <NestedPopoverTitle>
+          Use a sign in code
+        </NestedPopoverTitle>
+        <section className="pop-over-actions first-section">
+          {!this.state.done &&
+            <form onSubmit={this.onSubmit} style={{marginBottom: 0}}>
+              Paste your temporary sign in code below
+              <input value={this.state.code} onChange={this.onChange} className="pop-over-input" type="text" placeholder="cute-unique-cosmos"></input>
+              <button style={{marginTop: 10}} className="button-small button-link" disabled={!isEnabled}>Sign In</button>
+            </form>
+          }
+          {(this.state.done && !this.state.error) &&
+            <>
+              <div className="notification notifyPersistent notifySuccess">Success!</div>
+            </>
+          }
+          {(this.state.done && this.state.error) &&
+            <>
+              <div className="notification notifyPersistent notifyError">Error</div>
+              <div>Code not found or already used. Try signing in with email.</div>
+            </>
+          }       
+        </section>
+      </dialog>
     );
   }
 }
+
+const SignInWithConsumer = (props) => (
+  <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {...props}/>}</CurrentUserConsumer>
+);
 
 const EmailSignInButton = ({onClick}) => (
   <button className="button button-small button-link has-emoji" onClick={() => {onClick();}}>
@@ -206,7 +208,7 @@ const SignInPopWithoutRouter = (props) => (
       return (
         <NestedPopover alternateContent={() => <EmailHandler {...props}/>} startAlternateVisible={false}>
           {showEmailLogin =>
-            <NestedPopover alternateContent={(login) => <SignInCodeHandler setUser={login} {...props}/>} startAlternateVisible={false}>
+            <NestedPopover alternateContent={() => <SignInWithConsumer {...props}/>} startAlternateVisible={false}>
               {showCodeLogin =>
                 <div className="pop-over sign-in-pop">
                   {header}

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -94,7 +94,7 @@ class EmailHandler extends React.Component {
               }
             </section>
             {(this.state.done && !this.state.error) &&
-              <SignInCodeSection onClick={() => { onClick(); showCodeLogin(this.props.api); }}/>
+              <SignInCodeSection onClick={() => { showCodeLogin(this.props.api); }}/>
             }
           </dialog>
         }

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -67,7 +67,7 @@ class EmailHandler extends React.Component {
   render() {
     const isEnabled = this.state.email.length > 0;
     return (
-      <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {this.props.api}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
+      <NestedPopover alternateContent={() => <CurrentUserConsumer>{(currentUser, fetched, {login}) => <SignInCodeHandler setUser={login} {...this.props}/>}</CurrentUserConsumer>} startAlternateVisible={false}>
         {showCodeLogin =>
           <dialog className="pop-over sign-in-pop">
             <NestedPopoverTitle>
@@ -94,7 +94,7 @@ class EmailHandler extends React.Component {
               }
             </section>
             {(this.state.done && !this.state.error) &&
-              <SignInCodeSection onClick={() => { onClick(); showCodeLogin(api); }}/>
+              <SignInCodeSection onClick={() => { onClick(); showCodeLogin(this.props.api); }}/>
             }
           </dialog>
         }

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -82,7 +82,10 @@ class EmailHandler extends React.Component {
             <>
               <div className="notification notifySuccess">Almost Done</div>
               <div>Finish signing in from the email sent to {this.state.email}.</div>
-              <section className="pop-over-actions last-section">
+              <section className="pop-over-actions last-sectionn pop-over-info">
+                <button className="button-small button-tertiary button-on-secondary-background"  onClick={() => { onClick(); showCodeLogin(api); }}>
+                  <span>Use a sign in code</span>
+                </button>
               </section>
             </>
           }

--- a/src/presenters/pop-overs/sign-in-pop.jsx
+++ b/src/presenters/pop-overs/sign-in-pop.jsx
@@ -81,7 +81,9 @@ class EmailHandler extends React.Component {
           {(this.state.done && !this.state.error) &&
             <>
               <div className="notification notifySuccess">Almost Done</div>
-              <div>Please click the confirmation link sent to {this.state.email}.</div>
+              <div>Finish signing in from the email sent to {this.state.email}.</div>
+              <section className="pop-over-actions last-section">
+              </section>
             </>
           }
           {(this.state.done && this.state.error) &&


### PR DESCRIPTION
https://astonishing-orchestra.glitch.me/

Now if you request a sign-in email, there's a button on the success state to take you to the sign-in code pop!

![screen shot 2019-01-14 at 3 17 50 pm](https://user-images.githubusercontent.com/3011231/51138623-93842d80-180f-11e9-9324-5f75695ebab0.png)


As noticed/requested by cori, https://glitch.manuscript.com/f/cases/3327667/sign-in-pop-text-after-email-has-been-sent-could-be-clearer

also fixed the fact that the notification banners would disappear (as you can see in the screenshot above)