### PR TITLE
Profuse tea: Fix issues with cache busting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-public/*.css
-public/*.css.map
-public/*.ks
-public/*.js.map
-public/*.js
-public/*.json
+public/*
 styles/style.css
 styles/style.css.map
 *.gz

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "terser-webpack-plugin": "^1.2.1",
     "url-join": "^4.0.0",
     "webpack": "^4.28.4",
-    "webpack-cli": "^3.2.0",
-    "webpack-dev-middleware": "GregWeil/webpack-dev-middleware"
+    "webpack-cli": "^3.2.1",
+    "webpack-dev-middleware": "^3.5.0"
   },
   "engines": {
     "node": "10.x"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "stylus-loader": "^3.0.2",
     "terser-webpack-plugin": "^1.2.1",
     "url-join": "^4.0.0",
-    "webpack": "^4.28.3",
+    "webpack": "^4.28.4",
     "webpack-cli": "^3.2.0",
     "webpack-dev-middleware": "^3.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url-join": "^4.0.0",
     "webpack": "^4.28.4",
     "webpack-cli": "^3.2.0",
-    "webpack-dev-middleware": "^3.5.0"
+    "webpack-dev-middleware": "GregWeil/webpack-dev-middleware"
   },
   "engines": {
     "node": "10.x"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url-join": "^4.0.0",
     "webpack": "^4.28.4",
     "webpack-cli": "^3.2.1",
-    "webpack-dev-middleware": "^3.5.0"
+    "webpack-dev-middleware": "^3.5.1"
   },
   "engines": {
     "node": "10.x"

--- a/server/routes.js
+++ b/server/routes.js
@@ -21,7 +21,7 @@ module.exports = function(external) {
   // Caching - js and CSS files have a hash in their name, so they last a long time
   ['/*.js', '/*.css'].forEach((path) => (
     app.use(path, (request, response, next) => {
-      const s = dayjs.convert(1, 'month', 'seconds');
+      const s = dayjs.convert(7, 'days', 'seconds');
       response.header('Cache-Control', `public, max-age=${s}`);
       return next();
     })
@@ -52,9 +52,9 @@ module.exports = function(external) {
         if (chunk.initial) {
           chunk.files.forEach(file => {
             if (file.endsWith('.js') && !chunk.names.includes('styles')) {
-              scripts.push(`/${file}?${chunk.hash}`);
+              scripts.push(`${stats.publicPath}${file}`);
             } else if (file.endsWith('.css')) {
-              styles.push(`/${file}?${chunk.hash}`);
+              styles.push(`${stats.publicPath}${file}`);
             }
           });
         }

--- a/server/routes.js
+++ b/server/routes.js
@@ -48,15 +48,14 @@ module.exports = function(external) {
     
     try {
       const stats = JSON.parse(await readFilePromise('public/stats.json'));
-      stats.chunks.forEach(chunk => {
-        if (chunk.initial) {
-          chunk.files.forEach(file => {
-            if (file.endsWith('.js') && !chunk.names.includes('styles')) {
-              scripts.push(`${stats.publicPath}${file}`);
-            } else if (file.endsWith('.css')) {
-              styles.push(`${stats.publicPath}${file}`);
-            }
-          });
+      stats.entrypoints.client.assets.forEach(file => {
+        if (file.match(/\.js(\?|$)/)) {
+          scripts.push(`${stats.publicPath}${file}`);
+        }
+      });
+      stats.entrypoints.styles.assets.forEach(file => {
+        if (file.match(/\.css(\?|$)/)) {
+          styles.push(`${stats.publicPath}${file}`);
         }
       });
     } catch (error) {

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -11,9 +11,11 @@ function webpackExpressMiddleware() {
   const compiler = webpack(webpackConfig);
   
   const webpackMiddleware = require('webpack-dev-middleware');
-  const middleware = webpackMiddleware(compiler, {writeToDisk: true});
+  const middleware = webpackMiddleware(compiler, {writeToDisk: false});
   
-  let ready = false;
+  // TODO: switch this back to false when webpack-dev-middleware merges
+  // https://github.com/webpack/webpack-dev-middleware/pull/361
+  let ready = true;
   middleware.waitUntilValid(() => {
     ready = true;
   });

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -11,11 +11,9 @@ function webpackExpressMiddleware() {
   const compiler = webpack(webpackConfig);
   
   const webpackMiddleware = require('webpack-dev-middleware');
-  const middleware = webpackMiddleware(compiler, {writeToDisk: false});
+  const middleware = webpackMiddleware(compiler, {writeToDisk: true});
   
-  // TODO: switch this back to false when webpack-dev-middleware merges
-  // https://github.com/webpack/webpack-dev-middleware/pull/361
-  let ready = true;
+  let ready = false;
   middleware.waitUntilValid(() => {
     ready = true;
   });

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -6268,6 +6268,6 @@ specifiers:
   stylus-loader: ^3.0.2
   terser-webpack-plugin: ^1.2.1
   url-join: ^4.0.0
-  webpack: ^4.28.3
+  webpack: ^4.28.4
   webpack-cli: ^3.2.0
   webpack-dev-middleware: ^3.5.0

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -56,7 +56,7 @@ dependencies:
   url-join: 4.0.0
   webpack: 4.28.4
   webpack-cli: 3.2.1
-  webpack-dev-middleware: 3.5.0
+  webpack-dev-middleware: 3.5.1
 packages:
   /@babel/code-frame/7.0.0:
     dependencies:
@@ -6034,7 +6034,7 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
-  /webpack-dev-middleware/3.5.0:
+  /webpack-dev-middleware/3.5.1:
     dependencies:
       memory-fs: 0.4.1
       mime: 2.4.0
@@ -6046,7 +6046,7 @@ packages:
     peerDependencies:
       webpack: ^4.0.0
     resolution:
-      integrity: sha512-1Zie7+dMr4Vv3nGyhr8mxGQkzTQK1PTS8K3yJ4yB1mfRGwO1DzQibgmNfUqbEfQY6eEtEEUzC+o7vhpm/Sfn5w==
+      integrity: sha512-4dwCh/AyMOYAybggUr8fiCkRnjVDp+Cqlr9c+aaNB3GJYgRGYQWJ1YX/WAKUNA9dPNHZ6QSN2lYDKqjKSI8Vqw==
   /webpack-log/2.0.0:
     dependencies:
       ansi-colors: 3.2.3
@@ -6270,4 +6270,4 @@ specifiers:
   url-join: ^4.0.0
   webpack: ^4.28.4
   webpack-cli: ^3.2.1
-  webpack-dev-middleware: ^3.5.0
+  webpack-dev-middleware: ^3.5.1

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -56,7 +56,7 @@ dependencies:
   url-join: 4.0.0
   webpack: 4.28.4
   webpack-cli: 3.2.1
-  webpack-dev-middleware: github.com/GregWeil/webpack-dev-middleware/c334eb9f33b20640acf731ed895435d652363c81
+  webpack-dev-middleware: 3.5.0
 packages:
   /@babel/code-frame/7.0.0:
     dependencies:
@@ -6034,6 +6034,19 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
+  /webpack-dev-middleware/3.5.0:
+    dependencies:
+      memory-fs: 0.4.1
+      mime: 2.4.0
+      range-parser: 1.2.0
+      webpack-log: 2.0.0
+    dev: false
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-1Zie7+dMr4Vv3nGyhr8mxGQkzTQK1PTS8K3yJ4yB1mfRGwO1DzQibgmNfUqbEfQY6eEtEEUzC+o7vhpm/Sfn5w==
   /webpack-log/2.0.0:
     dependencies:
       ansi-colors: 3.2.3
@@ -6196,21 +6209,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
-  github.com/GregWeil/webpack-dev-middleware/c334eb9f33b20640acf731ed895435d652363c81:
-    dependencies:
-      memory-fs: 0.4.1
-      mime: 2.4.0
-      range-parser: 1.2.0
-      webpack-log: 2.0.0
-    dev: false
-    engines:
-      node: '>= 6'
-    name: webpack-dev-middleware
-    peerDependencies:
-      webpack: ^4.0.0
-    resolution:
-      tarball: 'https://codeload.github.com/GregWeil/webpack-dev-middleware/tar.gz/c334eb9f33b20640acf731ed895435d652363c81'
-    version: 3.5.0
 registry: 'https://registry.npmjs.org/'
 shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
@@ -6271,5 +6269,5 @@ specifiers:
   terser-webpack-plugin: ^1.2.1
   url-join: ^4.0.0
   webpack: ^4.28.4
-  webpack-cli: ^3.2.0
-  webpack-dev-middleware: 'github:GregWeil/webpack-dev-middleware'
+  webpack-cli: ^3.2.1
+  webpack-dev-middleware: ^3.5.0

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -56,7 +56,7 @@ dependencies:
   url-join: 4.0.0
   webpack: 4.28.4
   webpack-cli: 3.2.1
-  webpack-dev-middleware: 3.5.0
+  webpack-dev-middleware: github.com/GregWeil/webpack-dev-middleware/c334eb9f33b20640acf731ed895435d652363c81
 packages:
   /@babel/code-frame/7.0.0:
     dependencies:
@@ -6034,19 +6034,6 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
-  /webpack-dev-middleware/3.5.0:
-    dependencies:
-      memory-fs: 0.4.1
-      mime: 2.4.0
-      range-parser: 1.2.0
-      webpack-log: 2.0.0
-    dev: false
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      webpack: ^4.0.0
-    resolution:
-      integrity: sha512-1Zie7+dMr4Vv3nGyhr8mxGQkzTQK1PTS8K3yJ4yB1mfRGwO1DzQibgmNfUqbEfQY6eEtEEUzC+o7vhpm/Sfn5w==
   /webpack-log/2.0.0:
     dependencies:
       ansi-colors: 3.2.3
@@ -6209,6 +6196,21 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  github.com/GregWeil/webpack-dev-middleware/c334eb9f33b20640acf731ed895435d652363c81:
+    dependencies:
+      memory-fs: 0.4.1
+      mime: 2.4.0
+      range-parser: 1.2.0
+      webpack-log: 2.0.0
+    dev: false
+    engines:
+      node: '>= 6'
+    name: webpack-dev-middleware
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      tarball: 'https://codeload.github.com/GregWeil/webpack-dev-middleware/tar.gz/c334eb9f33b20640acf731ed895435d652363c81'
+    version: 3.5.0
 registry: 'https://registry.npmjs.org/'
 shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
@@ -6270,4 +6272,4 @@ specifiers:
   url-join: ^4.0.0
   webpack: ^4.28.4
   webpack-cli: ^3.2.0
-  webpack-dev-middleware: ^3.5.0
+  webpack-dev-middleware: 'github:GregWeil/webpack-dev-middleware'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,7 +105,7 @@ module.exports = {
   plugins: [
     new LodashModuleReplacementPlugin(),
     new MiniCssExtractPlugin({filename: '[name].css?[chunkhash]'}),
-    new StatsPlugin('stats.json', {all: false, entrypoints: true}),
+    new StatsPlugin('stats.json', {all: false, entrypoints: true, publicPath: true}),
   ],
   watchOptions: {
     ignored: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     [STYLE_BUNDLE_NAME]: `${STYLES}/styles.styl`,
   },
   output: {
-    filename: '[name].js',
+    filename: '[name].js?[contenthash]',
     path: PUBLIC,
     publicPath: '/',
   },
@@ -104,7 +104,7 @@ module.exports = {
   },
   plugins: [
     new LodashModuleReplacementPlugin(),
-    new MiniCssExtractPlugin({filename: '[name].css'}),
+    new MiniCssExtractPlugin({filename: '[name].css?[chunkhash]'}),
     new StatsPlugin('stats.json', {children: false, chunkModules: false, modules: false}),
   ],
   watchOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,7 +105,7 @@ module.exports = {
   plugins: [
     new LodashModuleReplacementPlugin(),
     new MiniCssExtractPlugin({filename: '[name].css?[chunkhash]'}),
-    new StatsPlugin('stats.json', {children: false, chunkModules: false, modules: false}),
+    new StatsPlugin('stats.json', {all: false, entrypoints: true}),
   ],
   watchOptions: {
     ignored: /node_modules/,


### PR DESCRIPTION
I had switched from including the content hash in the webpack config filename to adding it  while rendering the template because the webpack-dev-middleware tries to write the file to disk with the querystring still intact. Lazy loaded js is linked by webpack, so c3 lost its cache buster.

I've got a 'real' fix out, which is for the dev middleware to clip the querystring off of filenames when writing to disk (like webpack normally does) https://github.com/webpack/webpack-dev-middleware/pull/361

In the meantime, I switched back to cache busting in the webpack config and disabled writing to disk in dev mode. That has the side effect that when you switch a server from dev to prod mode, it will show an outdated site until the next prod build finishes.

I also cut the cache time down from a month to a week, because we usually deploy at least that often anyway.