### PR TITLE
Quixotic rocket: Rewrite urls in proxied sitemaps

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -42,6 +42,7 @@ module.exports = function(app) {
     const sitemapProxy = proxy(target, {
       userResDecorator: (res, data, req) => {
         // do gross stuff to rewrite urls
+        // this is dangerous to do on a full page, but the sitemap is simple
         const regexp = new RegExp(escapeRegExp(target), 'g');
         return data.toString().replace(regexp, req.hostname);
       },

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -26,7 +26,8 @@ module.exports = function(app) {
         return next();
     });
     
-    const proxyConfig = {
+    // Do the actual proxy
+    app.use(routeWithLeadingSlash, proxy(target, {
       preserveHostHdr: false, // glitch routes based on this, so we have to reset it
       https: true,
       proxyReqPathResolver: (req) => {
@@ -34,19 +35,7 @@ module.exports = function(app) {
         console.log("Proxied:", urlJoin(routeWithLeadingSlash, req.path));
         return path;
       }
-    };
-    
-    const genericProxy = proxy(proxyConfig);
-    const rewwritingProxy = proxy({
-      ...proxyConfig,
-      userResDecorator: (proxyRes, proxyResData) => {
-      },
-    });
-    
-    // Do the actual proxy
-    app.use(routeWithLeadingSlash, (req, ...args) => {
-      console.log(req.path);
-    });
+    }));
     
     routes.push(routeWithLeadingSlash);
   }

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -39,12 +39,15 @@ module.exports = function(app) {
     const genericProxy = proxy(target, proxyConfig);
     
     const rewriteProxy = proxy(target, {
-      ...proxyConfig, userResDecorator: (res, data) => data.toString().replace(target, /quixotic-rocket\.glitch\.me/g),
+      userResDecorator: (res, data, req) => {
+        return data.toString().replace(target, req.hostname);
+      },
+      ...proxyConfig,
     });
     
     // Do the actual proxy
     app.use(routeWithLeadingSlash, (req, ...args) => {
-      if (req.path === '/sitemap.xml') {
+      if (/^\\sitemap.*\.xml$/.test(req.path)) {
         return rewriteProxy(req, ...args);
       }
       return genericProxy(req, ...args);

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -50,7 +50,7 @@ module.exports = function(app) {
     
     // Do the actual proxy
     app.use(routeWithLeadingSlash, (req, ...args) => {
-      if (/\/sitemap.*\.xml$/.test(req.path)) {
+      if (/\/sitemap.*(\.xml|\.xsl)$/.test(req.path)) {
         return sitemapProxy(req, ...args);
       }
       return genericProxy(req, ...args);

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -26,8 +26,7 @@ module.exports = function(app) {
         return next();
     });
     
-    // Do the actual proxy
-    app.use(routeWithLeadingSlash, proxy(target, {
+    const proxyConfig = {
       preserveHostHdr: false, // glitch routes based on this, so we have to reset it
       https: true,
       proxyReqPathResolver: (req) => {
@@ -35,7 +34,19 @@ module.exports = function(app) {
         console.log("Proxied:", urlJoin(routeWithLeadingSlash, req.path));
         return path;
       }
-    }));
+    };
+    
+    const genericProxy = proxy(proxyConfig);
+    const rewwritingProxy = proxy({
+      ...proxyConfig,
+      userResDecorator: (proxyRes, proxyResData) => {
+      },
+    });
+    
+    // Do the actual proxy
+    app.use(routeWithLeadingSlash, (req, ...args) => {
+      console.log(req.path);
+    });
     
     routes.push(routeWithLeadingSlash);
   }


### PR DESCRIPTION
https://glitch.com/about/sitemap.xml
https://quixotic-rocket.glitch.me/about/sitemap.xml

I split the proxy in two rather than making the check in the decorator because the presence of a decorator forces the proxy to download the full page in memory rather than streaming it to the response.

@garethx