### PR TITLE
Quixotic rocket: Hopeful fix for proxied sitemaps

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -28,6 +28,8 @@ const app = express();
 
 app.use(Sentry.Handlers.requestHandler());
 
+app.enable('trust proxy');
+
 // Accept JSON as req.body
 const bodyParser = require("body-parser");
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/server/server.js
+++ b/server/server.js
@@ -28,6 +28,7 @@ const app = express();
 
 app.use(Sentry.Handlers.requestHandler());
 
+// Listen to X-Forwarded-Host, so request.hostname is glitch.com and not community.glitch.me
 app.enable('trust proxy');
 
 // Accept JSON as req.body


### PR DESCRIPTION
Over in server/proxy.js I deployed a bit of code that alters any sitemap.xml that gets proxied, rewriting urls to match the request. It works for glitch.me urls, but when you request https://glitch.com/culture/sitemap.xml req.hostname gets proxied as community.glitch.me. This change tells express to respect `X-Forwarded-Host`, which I expect to be set to glitch.com. https://expressjs.com/en/api.html#req.hostname