### PR TITLE
Puddle slip - fixes bug where readmes that are just numbers breaks the project page

### DIFF
--- a/src/curated/featured-embed.js
+++ b/src/curated/featured-embed.js
@@ -1,13 +1,13 @@
 var body = `<p>Follow along with MythBusters Jr. by remixing your own Glitch apps inspired by each episode.</p>
-<p><b>Episode 7:</b></p>
-<p>How much reliable energy can be harnessed from a human fart?</p>`;
+<p><b>Episode 9:</b></p>
+<p>Can you move the shredder to the documents in a room of magnetized furniture?</p>`;
 
 export default {
-  "image": "https://culture-zine.glitch.me/culture/content/images/2019/01/episode-8-flatus.jpg",
+  "image": "http://culture-zine.glitch.me/culture/content/images/2019/02/breaking-bad-2.jpg",
   "mask": "mask-4",
   "title": "MythBusters Jr.",
-  "appDomain": "whoopie-cushion",
-  "blogUrl": "/flatus-special/",
+  "appDomain": "magnet-caper",
+  "blogUrl": "/breaking-bad-blow-up/",
   "body": body,
-  "color": '#F87D93',
+  "color": '#458F65',
 };

--- a/src/presenters/includes/markdown.jsx
+++ b/src/presenters/includes/markdown.jsx
@@ -16,14 +16,14 @@ const md = markdownIt({
   .use(markdownSanitizer);
 
 const RawHTML = ({children}) => (
-  children.toString() ? <span className="markdown-content" dangerouslySetInnerHTML={{__html: children.toString()}}></span> : null
+  children ? <span className="markdown-content" dangerouslySetInnerHTML={{__html: children}}></span> : null
 );
 RawHTML.propTypes = {
   children: PropTypes.string.isRequired,
 };
 
 export const Markdown = React.memo(function Markdown({children}) {
-  const rendered = md.render(children.toString() || '');
+  const rendered = md.render(children || '');
   return <RawHTML>{rendered}</RawHTML>;
 });
 Markdown.propTypes = {
@@ -31,7 +31,7 @@ Markdown.propTypes = {
 };
 
 export const TruncatedMarkdown = React.memo(({children, length}) => {
-  const rendered = md.render(children.toString() || '');
+  const rendered = md.render(children || '');
   const truncated = truncate(rendered, length, {ellipsis: '…'});
   return <RawHTML>{truncated}</RawHTML>;
 });

--- a/src/presenters/includes/markdown.jsx
+++ b/src/presenters/includes/markdown.jsx
@@ -16,14 +16,14 @@ const md = markdownIt({
   .use(markdownSanitizer);
 
 const RawHTML = ({children}) => (
-  children ? <span className="markdown-content" dangerouslySetInnerHTML={{__html: children}}></span> : null
+  children.toString() ? <span className="markdown-content" dangerouslySetInnerHTML={{__html: children.toString()}}></span> : null
 );
 RawHTML.propTypes = {
   children: PropTypes.string.isRequired,
 };
 
 export const Markdown = React.memo(function Markdown({children}) {
-  const rendered = md.render(children || '');
+  const rendered = md.render(children.toString() || '');
   return <RawHTML>{rendered}</RawHTML>;
 });
 Markdown.propTypes = {
@@ -31,7 +31,7 @@ Markdown.propTypes = {
 };
 
 export const TruncatedMarkdown = React.memo(({children, length}) => {
-  const rendered = md.render(children || '');
+  const rendered = md.render(children.toString() || '');
   const truncated = truncate(rendered, length, {ellipsis: '…'});
   return <RawHTML>{truncated}</RawHTML>;
 });

--- a/src/presenters/pages/project.jsx
+++ b/src/presenters/pages/project.jsx
@@ -73,7 +73,7 @@ const ReadmeError = (error) => (
 );
 const ReadmeLoader = ({api, domain}) => (
   <DataLoader get={() => api.get(`projects/${domain}/readme`)} renderError={ReadmeError}>
-    {({data}) => <Expander height={250}><Markdown>{data}</Markdown></Expander>}
+    {({data}) => <Expander height={250}><Markdown>{data.toString()}</Markdown></Expander>}
   </DataLoader>
 );
 ReadmeLoader.propTypes = {


### PR DESCRIPTION
from case 3327802 https://glitch.manuscript.com/f/cases/3327802/

this was a fun one. if a project's readme only contains a number, it breaks the markdown component which requires a string and therefore breaks the whole project page. the project page's readme call is the only one that gets the data from an api call and not a prop, so i'm casting the data as a string now.

bug in action: https://glitch.com/~wide-lan
fixed: https://puddle-slip.glitch.me/~wide-lan