### PR TITLE
Profuse tea: Remove a bunch of unused classes

### DIFF
--- a/src/presenters/includes/add-project-to-collection.jsx
+++ b/src/presenters/includes/add-project-to-collection.jsx
@@ -6,7 +6,7 @@ import PopoverWithButton from '../pop-overs/popover-with-button';
 
 const AddProjectToCollection = ({project, ...props}) => {
   return (
-    <PopoverWithButton buttonClass="button button-small has-emoji add-project opens-pop-over"
+    <PopoverWithButton buttonClass="button-small has-emoji add-project"
       buttonText={<>Add to Collection {' '}<span className="emoji framed-picture" role="presentation"></span></>}
       passToggleToPop
     >

--- a/src/presenters/includes/add-team-project.jsx
+++ b/src/presenters/includes/add-team-project.jsx
@@ -13,7 +13,7 @@ const AddTeamProject = ({currentUserIsOnTeam, ...props}) => {
     <section className="add-project-container">
       {/* Add disabled={props.projectLimitIsReached} once billing is ready */}
       <PopoverWithButton
-        buttonClass={`button add-project has-emoji opens-pop-over ${props.extraButtonClass}`}
+        buttonClass={`add-project has-emoji ${props.extraButtonClass}`}
         buttonText={<>Add Project <span className="emoji bento-box" role="img" aria-label="" /></>}
         passToggleToPop
       >

--- a/src/presenters/includes/delete-team.jsx
+++ b/src/presenters/includes/delete-team.jsx
@@ -8,7 +8,7 @@ const DeleteTeam = ({...props}) => {
   
   return (
     <section>
-      <PopoverWithButton buttonClass="button button-small button-tertiary has-emoji opens-pop-over danger-zone"
+      <PopoverWithButton buttonClass="button-small button-tertiary has-emoji danger-zone"
         buttonText={<>Delete {props.teamName}&nbsp;<span className="emoji bomb" role="img" aria-label="" /> </>}
         passToggleToPop
       >

--- a/src/presenters/includes/edit-collection-color.jsx
+++ b/src/presenters/includes/edit-collection-color.jsx
@@ -8,7 +8,7 @@ const EditCollectionColor = ({update, initialColor, ...props}) => {
   return (
     <PopoverWithButton 
       containerClass="edit-collection-color-btn"
-      buttonClass="button add-project opens-pop-over"
+      buttonClass="add-project"
       buttonText="Color"
       passToggleToPop >
       <EditCollectionColorPop {...props} updateColor={update} initialColor={initialColor}/>

--- a/src/presenters/overlays/new-stuff.jsx
+++ b/src/presenters/overlays/new-stuff.jsx
@@ -80,7 +80,7 @@ class NewStuff extends React.Component {
         {children(show)}
         {dogVisible && (
           <div className="new-stuff-footer">
-            <button className="button-unstyled new-stuff opens-pop-over" onClick={show}>
+            <button className="button-unstyled new-stuff" onClick={show}>
               <figure className="new-stuff-avatar" data-tooltip="New" data-tooltip-top="true" data-tooltip-persistent="true" alt="New Stuff"/>
             </button>
           </div>

--- a/src/presenters/pop-overs/collection-options-pop.jsx
+++ b/src/presenters/pop-overs/collection-options-pop.jsx
@@ -43,7 +43,7 @@ export default function CollectionOptions({deleteCollection, collection}) {
     <PopoverWithButton
       buttonText={<div className="down-arrow" aria-label='options' />}
       containerClass='collection-options-pop-btn'
-      buttonClass="collection-options button-borderless opens-pop-over" >
+      buttonClass="collection-options button-borderless" >
       <CurrentUserConsumer>
         {user => <CollectionOptionsPop collection={collection} 
           deleteCollection={deleteCollection} 

--- a/src/presenters/pop-overs/delete-team-pop.jsx
+++ b/src/presenters/pop-overs/delete-team-pop.jsx
@@ -49,7 +49,7 @@ class DeleteTeamPopBase extends React.Component {
           </div>
         </section>
         <section className="pop-over-actions danger-zone">
-          <button className="button button-small has-emoji opens-pop-over" onClick={this.deleteTeam}>
+          <button className="button-small has-emoji" onClick={this.deleteTeam}>
             <span>Delete {this.props.teamName} </span> 
             <span className="emoji bomb" role="img" aria-label="bomb emoji"></span>
             { this.state.teamIsDeleting && <Loader /> }

--- a/src/presenters/pop-overs/featured-project-options-pop.jsx
+++ b/src/presenters/pop-overs/featured-project-options-pop.jsx
@@ -18,7 +18,7 @@ export default function FeaturedProjectOptionsPop({unfeatureProject}) {
     <PopoverContainer>
       {({togglePopover, visible}) => (
         <div>
-          <button className="project-options button-borderless opens-pop-over" onClick={togglePopover}> 
+          <button className="project-options button-borderless" onClick={togglePopover}> 
             <div className="down-arrow" />
           </button>
           { visible && (

--- a/src/presenters/pop-overs/project-options-pop.jsx
+++ b/src/presenters/pop-overs/project-options-pop.jsx
@@ -175,7 +175,7 @@ export default function ProjectOptions({projectOptions={}, project, api, current
 
   return (
     <PopoverWithButton
-      buttonClass="project-options button-borderless opens-pop-over button-small"
+      buttonClass="project-options button-borderless button-small"
       buttonText={<div className="down-arrow" aria-label="options" />}
       containerClass="project-options-pop-btn"
       passToggleToPop


### PR DESCRIPTION
Removed every `opens-pop-over` except for the one in `add-collection-project.jsx` since it's covered by superb-guide. I also removed any redundant button classes I saw along the way.