### PR TITLE
Flip the logic on shouldsenderror checks, ignore server errors too

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3,12 +3,16 @@ const compression = require("compression");
 
 // https://docs.sentry.io/error-reporting/quickstart/?platform=node
 const Sentry = require("@sentry/node");
+const shouldSendError = process.env.PROJECT_DOMAIN === "community" || process.env.PROJECT_DOMAIN === "community-staging";
 
 try {
   Sentry.init({
     dsn: 'https://4f1a68242b6944738df12eecc34d377c@sentry.io/1246508',
     environment: process.env.NODE_ENV || 'dev',
     beforeSend(event) {
+      if (!shouldSendError) {
+        return null;
+      }
       const json = JSON.stringify(event);
       const scrubbedJSON = json.replace(/"persistentToken":"[^"]+"/g, `"persistentToken":"****"`);
       return JSON.parse(scrubbedJSON);

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -11,12 +11,7 @@
 import * as Sentry from "@sentry/browser";
 export * from "@sentry/browser";
 
-const shouldSendError = () => {
-  return (
-    !PROJECT_DOMAIN ||
-    !(PROJECT_DOMAIN === "community" || PROJECT_DOMAIN === "community-staging")
-  );
-};
+const shouldSendError = PROJECT_DOMAIN === "community" || PROJECT_DOMAIN === "community-staging";
 
 const filterSecrets = jsonEvent => {
   const tokens = ["facebookToken", "githubToken", "persistentToken"];


### PR DESCRIPTION
Bleh, sorry I missed this in review.

We should try to share this config between the client and server, but they use separate npm packages and env variables. What do you think of just a function taking `Sentry` and `PROJECT_DOMAIN`?