### PR TITLE
Change getDominantColor to match the api

### DIFF
--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -116,7 +116,7 @@ export function getDominantColor(image) {
     colors = outlyingColors;
   }
   if (transparentPixels) {
-    return null;
+    return '';
   } 
   const colorMap = quantize(colors, 5);
   const [r, g, b] = Array.from(colorMap.palette()[0]);

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -73,6 +73,11 @@ export function resizeImage(file, max) {
     });
 }
 
+// Takes an image object and returns an approximate average color
+// Used to set background colors as an avatar image fallback
+// Works by sampling the top-left 11x11 pixels and quantizing
+// them into 5 colors and returning the most common color
+// Returns '' if any pixels were transparent
 export function getDominantColor(image) {
   const {width, height} = image;
   const PIXELS_FROM_EDGE = 11;

--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -81,7 +81,6 @@ export function getDominantColor(image) {
   canvas.height = height;
   const context = canvas.getContext('2d');
   context.drawImage(image, 0, 0, width, height);
-  let transparentPixels = false;
   let colors = [];
   const outlyingColors = [];
   const outlyingColorsList = JSON.stringify([
@@ -92,32 +91,33 @@ export function getDominantColor(image) {
   Iterate through edge pixels and get the average color, then conditionally
   handle edge colors and transparent images
   */
-  for (let x = 0; x < PIXELS_FROM_EDGE; x++) {
-    for (let y = 0; y < PIXELS_FROM_EDGE; y++) {
-      const pixelData = context.getImageData(x, y, 1, 1).data;
+  for (let x = -PIXELS_FROM_EDGE; x < PIXELS_FROM_EDGE; x++) {
+    for (let y = -PIXELS_FROM_EDGE; y < PIXELS_FROM_EDGE; y++) {
+      const boundedX = (x + width) % width;
+      const boundedY = (y + height) % height;
+      const pixelData = context.getImageData(boundedX, boundedY, 1, 1).data;
       const color = [
         pixelData[0], // r
         pixelData[1], // g
         pixelData[2], // b
       ];
-      const colorRegExObject = new RegExp(`(${color})`, 'g');
       if (pixelData[3] < 255) { // alpha pixels
-        transparentPixels = true;
-        break;
+        continue;
       }
-      if (outlyingColorsList.match(colorRegExObject)) {
+      if (outlyingColorsList.includes(JSON.stringify(color))) {
         outlyingColors.push(color);
       } else {
         colors.push(color);
       }
     }
   }
+  if (colors.length === 0 && outlyingColors.length === 0) {
+    // every pixel we checked was transparent
+    return '';
+  }
   if (outlyingColors.length > colors.length) {
     colors = outlyingColors;
   }
-  if (transparentPixels) {
-    return '';
-  } 
   const colorMap = quantize(colors, 5);
   const [r, g, b] = Array.from(colorMap.palette()[0]);
   return `rgb(${r},${g},${b})`;


### PR DESCRIPTION
getDominantColor returns null if it finds any transparency in the image. That upsets the api which wants empty colors to be specified as an empty string.
I also did some very minor cleanup to make it more obvious what's happening