### PR TITLE
Tiny fixes 

### DIFF
--- a/src/presenters/includes/embed.jsx
+++ b/src/presenters/includes/embed.jsx
@@ -39,6 +39,7 @@ export class Embed extends React.Component {
           height="100%" 
           width="100%"
           border="0"
+          allowvr="yes"
         ></iframe> :
         // Error message if JS not supported
         // TODO(sheridan): Refactor this once we have a true error component

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: mode !== 'production', // no css source maps in production
             },
           },
           {


### PR DESCRIPTION
- Only build/send CSS Source Maps in non-production builds to help with production build time and bundle size
- `allowvr=yes` on the embed iframes - Fixes an issue with some chromium browsers when displaying vr content https://github.com/aframevr/aframe/issues/1979 

https://glitch.com/~absorbing-thing 