### PR TITLE
Team admin bugfixes

### DIFF
--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -2,9 +2,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'just-face-it' },
-  { owner: 'glitch', name: 'souped-up-spotify' },
-  { owner: 'glitch', name: 'discover-modern-art' }
+  { owner: 'glitch', name: 'glitch-flix' },
+  { owner: 'glitch', name: 'relish-the-randomosity' },
+  { owner: 'glitch', name: 'so-useful' }
 ];
 
 // More ideas is populated from this team

--- a/src/curated/featured.js
+++ b/src/curated/featured.js
@@ -14,16 +14,16 @@ Example:
 // make sure image urls use https
 export default [
   {
-    title: 'Make Inkle Patterns',
-    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Ftracery-inkle.gif?1549879572651",
-    link: 'https://tracery-inkle.glitch.me/'
+    title: 'Check Yo\' Contrast',
+    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fcontrast-checker.gif?1549879573206",
+    link: 'http://contrast-checker.glitch.me/'
   },{
-    title: 'Hello, World!',
-    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fhello-around-the-world.gif?1549879571293",
-    link: 'https://hello-around-the-world.glitch.me/'
+    title: 'How Many Pencils?',
+    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fpencil-distance.gif?1549879571534",
+    link: 'https://pencil-distance.glitch.me/'
   },{
-    title: 'Springy Particles',
-    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fimages-to-particles.gif?1549879572018",
-    link: 'https://image-to-particles.glitch.me/'
+    title: 'Un, Deux, Twist',
+    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fvera-memphis.gif?1549879573380",
+    link: 'https://vera-memphis.glitch.me/'
   } 
 ];

--- a/src/presenters/includes/team-users.jsx
+++ b/src/presenters/includes/team-users.jsx
@@ -1,29 +1,37 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-import {getDisplayName} from '../../models/user';
-import {TrackClick} from '../analytics';
-import {WhitelistedDomainIcon} from './team-elements.jsx';
-import {UserAvatar} from '../includes/avatar.jsx';
-import AddTeamUserPop from '../pop-overs/add-team-user-pop.jsx';
-import PopoverWithButton from '../pop-overs/popover-with-button.jsx';
-import PopoverContainer from '../pop-overs/popover-container.jsx';
-import TeamUserInfoPop from '../pop-overs/team-user-info-pop.jsx';
-import UsersList from '../users-list.jsx';
+import { getDisplayName } from "../../models/user";
+import { TrackClick } from "../analytics";
+import { WhitelistedDomainIcon } from "./team-elements.jsx";
+import { UserAvatar } from "../includes/avatar.jsx";
+import AddTeamUserPop from "../pop-overs/add-team-user-pop.jsx";
+import PopoverWithButton from "../pop-overs/popover-with-button.jsx";
+import PopoverContainer from "../pop-overs/popover-container.jsx";
+import TeamUserInfoPop from "../pop-overs/team-user-info-pop.jsx";
+import UsersList from "../users-list.jsx";
 
 // Team Users list (in profile container)
 
-export const TeamUsers = (props) => (
+export const TeamUsers = props => (
   <ul className="users">
     {props.users.map(user => (
       <li key={user.id}>
-        <PopoverWithButton 
-          buttonClass="user button-unstyled" 
-          buttonText={<UserAvatar user={user} suffix={adminStatusDisplay(props.adminIds, user)}/>}
-          passToggleToPop 
+        <PopoverWithButton
+          buttonClass="user button-unstyled"
+          buttonText={
+            <UserAvatar
+              user={user}
+              suffix={adminStatusDisplay(props.adminIds, user)}
+            />
+          }
+          passToggleToPop
         >
           <TeamUserInfoPop
             userIsTeamAdmin={props.adminIds.includes(user.id)}
+            userIsTheOnlyAdmin={
+              props.adminIds.length === 1 && props.adminIds.includes(user.id)
+            }
             userIsTheOnlyMember={props.users.length === 1}
             user={user}
             {...props}
@@ -41,11 +49,12 @@ const adminStatusDisplay = (adminIds, user) => {
   return "";
 };
 
-
 TeamUsers.propTypes = {
-  users: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
-  })).isRequired,
+  users: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired
+    })
+  ).isRequired,
   currentUserIsOnTeam: PropTypes.bool.isRequired,
   removeUserFromTeam: PropTypes.func.isRequired,
   updateUserPermissions: PropTypes.func.isRequired,
@@ -53,31 +62,35 @@ TeamUsers.propTypes = {
   teamId: PropTypes.number.isRequired,
   currentUserIsTeamAdmin: PropTypes.bool.isRequired,
   adminIds: PropTypes.array.isRequired,
-  team: PropTypes.object.isRequired,
+  team: PropTypes.object.isRequired
 };
-
 
 // Whitelisted domain icon
 
-export const WhitelistedDomain = ({domain, setDomain}) => {
+export const WhitelistedDomain = ({ domain, setDomain }) => {
   const tooltip = `Anyone with an @${domain} email can join`;
   return (
     <PopoverContainer>
-      {({visible, setVisible}) => (
-        <details onToggle={evt => setVisible(evt.target.open)} open={visible} className="popover-container whitelisted-domain-container">
+      {({ visible, setVisible }) => (
+        <details
+          onToggle={evt => setVisible(evt.target.open)}
+          open={visible}
+          className="popover-container whitelisted-domain-container"
+        >
           <summary data-tooltip={!visible ? tooltip : null}>
-            <WhitelistedDomainIcon domain={domain}/>
+            <WhitelistedDomainIcon domain={domain} />
           </summary>
           <dialog className="pop-over">
             <section className="pop-over-info">
-              <p className="info-description">
-                {tooltip}
-              </p>
+              <p className="info-description">{tooltip}</p>
             </section>
             {!!setDomain && (
               <section className="pop-over-actions danger-zone">
-                <button className="button button-small button-tertiary button-on-secondary-background has-emoji" onClick={() => setDomain(null)}>
-                  Remove {domain} <span className="emoji bomb"></span>
+                <button
+                  className="button button-small button-tertiary button-on-secondary-background has-emoji"
+                  onClick={() => setDomain(null)}
+                >
+                  Remove {domain} <span className="emoji bomb" />
                 </button>
               </section>
             )}
@@ -90,9 +103,8 @@ export const WhitelistedDomain = ({domain, setDomain}) => {
 
 WhitelistedDomain.propTypes = {
   domain: PropTypes.string.isRequired,
-  setDomain: PropTypes.func,
+  setDomain: PropTypes.func
 };
-
 
 // Add Team User
 
@@ -100,65 +112,90 @@ export class AddTeamUser extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      invitee: '',
-      alreadyInvited: [],
+      invitee: "",
+      alreadyInvited: []
     };
     this.removeNotifyInvited = this.removeNotifyInvited.bind(this);
   }
-  
+
   async setWhitelistedDomain(togglePopover, domain) {
     togglePopover();
     await this.props.setWhitelistedDomain(domain);
   }
-  
+
   async inviteUser(togglePopover, user) {
     togglePopover();
-    this.setState((state) => ({
+    this.setState(state => ({
       invitee: getDisplayName(user),
-      alreadyInvited: [...state.alreadyInvited, user],
+      alreadyInvited: [...state.alreadyInvited, user]
     }));
     await this.props.inviteUser(user);
   }
-  
+
   async inviteEmail(togglePopover, email) {
     togglePopover();
     this.setState({
-      invitee: email,
+      invitee: email
     });
     await this.props.inviteEmail(email);
   }
 
   removeNotifyInvited() {
     this.setState({
-      invitee: '',
+      invitee: ""
     });
   }
 
   render() {
-    const {inviteEmail, inviteUser, setWhitelistedDomain, ...props} = this.props;
+    const {
+      inviteEmail,
+      inviteUser,
+      setWhitelistedDomain,
+      ...props
+    } = this.props;
     return (
       <PopoverContainer>
-        {({visible, togglePopover}) => (
+        {({ visible, togglePopover }) => (
           <span className="add-user-container">
-            {!!this.state.alreadyInvited.length && 
-              <UsersList users={this.state.alreadyInvited}/>
-            }
+            {!!this.state.alreadyInvited.length && (
+              <UsersList users={this.state.alreadyInvited} />
+            )}
             <TrackClick name="Add to Team clicked">
-              <button onClick={togglePopover} className="button button-small button-tertiary add-user">Add</button>
+              <button
+                onClick={togglePopover}
+                className="button button-small button-tertiary add-user"
+              >
+                Add
+              </button>
             </TrackClick>
-            {!!this.state.invitee &&
-              <div className="notification notifySuccess inline-notification" onAnimationEnd={this.removeNotifyInvited}>
+            {!!this.state.invitee && (
+              <div
+                className="notification notifySuccess inline-notification"
+                onAnimationEnd={this.removeNotifyInvited}
+              >
                 Invited {this.state.invitee}
               </div>
-            }
-            {visible && 
-              <AddTeamUserPop 
+            )}
+            {visible && (
+              <AddTeamUserPop
                 {...props}
-                setWhitelistedDomain={setWhitelistedDomain ? domain => this.setWhitelistedDomain(togglePopover, domain) : null}
-                inviteUser={inviteUser ? user => this.inviteUser(togglePopover, user) : null}
-                inviteEmail={inviteEmail ? email => this.inviteEmail(togglePopover, email) : null}
+                setWhitelistedDomain={
+                  setWhitelistedDomain
+                    ? domain => this.setWhitelistedDomain(togglePopover, domain)
+                    : null
+                }
+                inviteUser={
+                  inviteUser
+                    ? user => this.inviteUser(togglePopover, user)
+                    : null
+                }
+                inviteEmail={
+                  inviteEmail
+                    ? email => this.inviteEmail(togglePopover, email)
+                    : null
+                }
               />
-            }
+            )}
           </span>
         )}
       </PopoverContainer>
@@ -168,13 +205,16 @@ export class AddTeamUser extends React.Component {
 AddTeamUser.propTypes = {
   inviteEmail: PropTypes.func,
   inviteUser: PropTypes.func,
-  setWhitelistedDomain: PropTypes.func,
+  setWhitelistedDomain: PropTypes.func
 };
 
 // Join Team
 
-export const JoinTeam = ({onClick}) => (
-  <button className="button button-small button-cta join-team-button" onClick={onClick}>
+export const JoinTeam = ({ onClick }) => (
+  <button
+    className="button button-small button-cta join-team-button"
+    onClick={onClick}
+  >
     Join Team
   </button>
 );

--- a/src/presenters/includes/team-users.jsx
+++ b/src/presenters/includes/team-users.jsx
@@ -15,30 +15,32 @@ import UsersList from "../users-list.jsx";
 
 export const TeamUsers = props => (
   <ul className="users">
-    {props.users.map(user => (
-      <li key={user.id}>
-        <PopoverWithButton
-          buttonClass="user button-unstyled"
-          buttonText={
-            <UserAvatar
-              user={user}
-              suffix={adminStatusDisplay(props.adminIds, user)}
-            />
-          }
-          passToggleToPop
-        >
-          <TeamUserInfoPop
-            userIsTeamAdmin={props.adminIds.includes(user.id)}
-            userIsTheOnlyAdmin={
-              props.adminIds.length === 1 && props.adminIds.includes(user.id)
+    {props.users.map(user => {
+      const userIsTeamAdmin = props.adminIds.includes(user.id);
+      
+      return (
+        <li key={user.id}>
+          <PopoverWithButton
+            buttonClass="user button-unstyled"
+            buttonText={
+              <UserAvatar
+                user={user}
+                suffix={adminStatusDisplay(props.adminIds, user)}
+              />
             }
-            userIsTheOnlyMember={props.users.length === 1}
-            user={user}
-            {...props}
-          />
-        </PopoverWithButton>
-      </li>
-    ))}
+            passToggleToPop
+          >
+            <TeamUserInfoPop
+              userIsTeamAdmin={userIsTeamAdmin}
+              userIsTheOnlyAdmin={userIsTeamAdmin && props.adminIds.length === 1}
+              userIsTheOnlyMember={props.users.length === 1}
+              user={user}
+              {...props}
+            />
+          </PopoverWithButton>
+        </li>
+      );
+    })}
   </ul>
 );
 

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -36,38 +36,33 @@ const AdminActions = ({
   userIsTeamAdmin,
   updateUserPermissions,
   canChangeUserAdminStatus
-}) => {
-  return (
-    canChangeUserAdminStatus && (
-      <section className="pop-over-actions admin-actions">
-        <p className="action-description">
-          Admins can update team info, billing, and remove users
-        </p>
-        {userIsTeamAdmin ? (
-          <TrackClick name="Remove Admin Status clicked">
-            <button
-              className="button-small button-tertiary has-emoji"
-              onClick={() =>
-                updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)
-              }
-            >
-              Remove Admin Status <span className="emoji fast-down" />
-            </button>
-          </TrackClick>
-        ) : (
-          <TrackClick name="Make an Admin clicked">
-            <button
-              className="button-small button-tertiary has-emoji"
-              onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}
-            >
-              Make an Admin <span className="emoji fast-up" />
-            </button>
-          </TrackClick>
-        )}
-      </section>
-    )
-  );
-};
+}) =>
+  canChangeUserAdminStatus ? (
+    <section className="pop-over-actions admin-actions">
+      <p className="action-description">
+        Admins can update team info, billing, and remove users
+      </p>
+      {userIsTeamAdmin ? (
+        <TrackClick name="Remove Admin Status clicked">
+          <button
+            className="button-small button-tertiary has-emoji"
+            onClick={() => updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)}
+          >
+            Remove Admin Status <span className="emoji fast-down" />
+          </button>
+        </TrackClick>
+      ) : (
+        <TrackClick name="Make an Admin clicked">
+          <button
+            className="button-small button-tertiary has-emoji"
+            onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}
+          >
+            Make an Admin <span className="emoji fast-up" />
+          </button>
+        </TrackClick>
+      )}
+    </section>
+  ) : null;
 
 AdminActions.propTypes = {
   user: PropTypes.shape({

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -36,8 +36,9 @@ const AdminActions = ({
   userIsTeamAdmin,
   updateUserPermissions,
   canChangeUserAdminStatus
-}) =>
-  canChangeUserAdminStatus ? (
+}) => {
+  if (!canChangeUserAdminStatus) return null;
+  return (
     <section className="pop-over-actions admin-actions">
       <p className="action-description">
         Admins can update team info, billing, and remove users
@@ -62,7 +63,8 @@ const AdminActions = ({
         </TrackClick>
       )}
     </section>
-  ) : null;
+  );
+};
 
 AdminActions.propTypes = {
   user: PropTypes.shape({
@@ -83,12 +85,12 @@ const ThanksCount = ({ count }) => (
 
 // Team User Info 😍
 
-const TeamUserInfo = ({ currentUser, showRemove, ...props }) => {
+const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, ...props }) => {
   const userAvatarStyle = { backgroundColor: props.user.color };
-  const canRemoveUser =
-    !(props.userIsTheOnlyMember || props.userIsTheOnlyAdmin) &&
-    (props.currentUserIsTeamAdmin ||
-      (currentUser && currentUser.id === props.user.id));
+  
+  const hasRemovePrivelegesForUser = currentUserIsTeamAdmin || currentUser && currentUser.id === props.user.id
+  const canRemoveUser = hasRemovePrivelegesForUser && !(props.userIsTheOnlyMember || props.userIsTheOnlyAdmin)
+    
   return (
     <dialog className="pop-over team-user-info-pop">
       <section className="pop-over-info user-info">

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -37,7 +37,10 @@ const AdminActions = ({
   updateUserPermissions,
   canChangeUserAdminStatus
 }) => {
-  if (!canChangeUserAdminStatus) return null;
+  if (!canChangeUserAdminStatus) {
+    console.log("test");
+    return null;
+  }
   return (
     <section className="pop-over-actions admin-actions">
       <p className="action-description">
@@ -85,12 +88,22 @@ const ThanksCount = ({ count }) => (
 
 // Team User Info 😍
 
-const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, ...props }) => {
+const TeamUserInfo = ({
+  currentUser,
+  currentUserIsTeamAdmin,
+  showRemove,
+  ...props
+}) => {
   const userAvatarStyle = { backgroundColor: props.user.color };
-  
-  const hasRemovePrivelegesForUser = currentUserIsTeamAdmin || currentUser && currentUser.id === props.user.id
-  const canRemoveUser = hasRemovePrivelegesForUser && !(props.userIsTheOnlyMember || props.userIsTheOnlyAdmin)
-    
+
+  const currentUserHasRemovePriveleges =
+    currentUserIsTeamAdmin || (currentUser && currentUser.id === props.user.id);
+  const canRemoveUser = !(
+    props.userIsTheOnlyMember || props.userIsTheOnlyAdmin
+  );
+  const canCurrentUserRemoveUser =
+    canRemoveUser && currentUserHasRemovePriveleges;
+
   return (
     <dialog className="pop-over team-user-info-pop">
       <section className="pop-over-info user-info">
@@ -126,7 +139,7 @@ const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, ...prop
       {props.user.thanksCount > 0 && (
         <ThanksCount count={props.user.thanksCount} />
       )}
-      {props.currentUserIsTeamAdmin && (
+      {currentUserIsTeamAdmin && (
         <AdminActions
           user={props.user}
           userIsTeamAdmin={props.userIsTeamAdmin}
@@ -134,7 +147,7 @@ const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, ...prop
           canChangeUserAdminStatus={!props.userIsTheOnlyAdmin}
         />
       )}
-      {canRemoveUser && <RemoveFromTeam onClick={showRemove} />}
+      {canCurrentUserRemoveUser && <RemoveFromTeam onClick={showRemove} />}
     </dialog>
   );
 };

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -37,10 +37,7 @@ const AdminActions = ({
   updateUserPermissions,
   canChangeUserAdminStatus
 }) => {
-  if (!canChangeUserAdminStatus) {
-    console.log("test");
-    return null;
-  }
+  if (!canChangeUserAdminStatus) return null;
   return (
     <section className="pop-over-actions admin-actions">
       <p className="action-description">

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -37,31 +37,35 @@ const AdminActions = ({
   updateUserPermissions,
   canChangeUserAdminStatus
 }) => {
-  canChangeUserAdminStatus && (
-    <section className="pop-over-actions admin-actions">
-      <p className="action-description">
-        Admins can update team info, billing, and remove users
-      </p>
-      {userIsTeamAdmin ? (
-        <TrackClick name="Remove Admin Status clicked">
-          <button
-            className="button-small button-tertiary has-emoji"
-            onClick={() => updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)}
-          >
-            Remove Admin Status <span className="emoji fast-down" />
-          </button>
-        </TrackClick>
-      ) : (
-        <TrackClick name="Make an Admin clicked">
-          <button
-            className="button-small button-tertiary has-emoji"
-            onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}
-          >
-            Make an Admin <span className="emoji fast-up" />
-          </button>
-        </TrackClick>
-      )}
-    </section>
+  return (
+    canChangeUserAdminStatus && (
+      <section className="pop-over-actions admin-actions">
+        <p className="action-description">
+          Admins can update team info, billing, and remove users
+        </p>
+        {userIsTeamAdmin ? (
+          <TrackClick name="Remove Admin Status clicked">
+            <button
+              className="button-small button-tertiary has-emoji"
+              onClick={() =>
+                updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)
+              }
+            >
+              Remove Admin Status <span className="emoji fast-down" />
+            </button>
+          </TrackClick>
+        ) : (
+          <TrackClick name="Make an Admin clicked">
+            <button
+              className="button-small button-tertiary has-emoji"
+              onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}
+            >
+              Make an Admin <span className="emoji fast-up" />
+            </button>
+          </TrackClick>
+        )}
+      </section>
+    )
   );
 };
 
@@ -87,8 +91,9 @@ const ThanksCount = ({ count }) => (
 const TeamUserInfo = ({ currentUser, showRemove, ...props }) => {
   const userAvatarStyle = { backgroundColor: props.user.color };
   const canRemoveUser =
-    props.currentUserIsTeamAdmin ||
-    (currentUser && currentUser.id === props.user.id);
+    !(props.userIsTheOnlyMember || props.userIsTheOnlyAdmin) &&
+    (props.currentUserIsTeamAdmin ||
+      (currentUser && currentUser.id === props.user.id));
   return (
     <dialog className="pop-over team-user-info-pop">
       <section className="pop-over-info user-info">
@@ -129,11 +134,10 @@ const TeamUserInfo = ({ currentUser, showRemove, ...props }) => {
           user={props.user}
           userIsTeamAdmin={props.userIsTeamAdmin}
           updateUserPermissions={props.updateUserPermissions}
+          canChangeUserAdminStatus={!props.userIsTheOnlyAdmin}
         />
       )}
-      {canRemoveUser && !props.userIsTheOnlyMember && (
-        <RemoveFromTeam onClick={showRemove} />
-      )}
+      {canRemoveUser && <RemoveFromTeam onClick={showRemove} />}
     </dialog>
   );
 };

--- a/src/presenters/pop-overs/team-user-info-pop.jsx
+++ b/src/presenters/pop-overs/team-user-info-pop.jsx
@@ -1,48 +1,62 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-import {getAvatarThumbnailUrl} from '../../models/user';
+import { getAvatarThumbnailUrl } from "../../models/user";
 
-import {TrackClick} from '../analytics';
-import {NestedPopover} from './popover-nested.jsx';
-import {UserLink} from '../includes/link.jsx';
-import Thanks from '../includes/thanks.jsx';
+import { TrackClick } from "../analytics";
+import { NestedPopover } from "./popover-nested.jsx";
+import { UserLink } from "../includes/link.jsx";
+import Thanks from "../includes/thanks.jsx";
 
-import TeamUserRemovePop from './team-user-remove-pop.jsx';
+import TeamUserRemovePop from "./team-user-remove-pop.jsx";
 
 const MEMBER_ACCESS_LEVEL = 20;
 const ADMIN_ACCESS_LEVEL = 30;
 
 // Remove from Team 👋
 
-const RemoveFromTeam = (props) => (
+const RemoveFromTeam = props => (
   <section className="pop-over-actions danger-zone">
     <TrackClick name="Remove from Team clicked">
-      <button className="button-small has-emoji button-tertiary button-on-secondary-background" {...props}>
-        Remove from Team <span className="emoji wave" role="img" aria-label=""/>
+      <button
+        className="button-small has-emoji button-tertiary button-on-secondary-background"
+        {...props}
+      >
+        Remove from Team{" "}
+        <span className="emoji wave" role="img" aria-label="" />
       </button>
     </TrackClick>
   </section>
 );
 
-
 // Admin Actions Section ⏫⏬
 
-const AdminActions = ({user, userIsTeamAdmin, updateUserPermissions}) => {
-  return (
+const AdminActions = ({
+  user,
+  userIsTeamAdmin,
+  updateUserPermissions,
+  canChangeUserAdminStatus
+}) => {
+  canChangeUserAdminStatus && (
     <section className="pop-over-actions admin-actions">
       <p className="action-description">
         Admins can update team info, billing, and remove users
       </p>
       {userIsTeamAdmin ? (
         <TrackClick name="Remove Admin Status clicked">
-          <button className="button-small button-tertiary has-emoji" onClick={() => updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)}>
+          <button
+            className="button-small button-tertiary has-emoji"
+            onClick={() => updateUserPermissions(user.id, MEMBER_ACCESS_LEVEL)}
+          >
             Remove Admin Status <span className="emoji fast-down" />
           </button>
         </TrackClick>
       ) : (
         <TrackClick name="Make an Admin clicked">
-          <button className="button-small button-tertiary has-emoji" onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}>
+          <button
+            className="button-small button-tertiary has-emoji"
+            onClick={() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL)}
+          >
             Make an Admin <span className="emoji fast-up" />
           </button>
         </TrackClick>
@@ -53,72 +67,85 @@ const AdminActions = ({user, userIsTeamAdmin, updateUserPermissions}) => {
 
 AdminActions.propTypes = {
   user: PropTypes.shape({
-    id: PropTypes.number.isRequired,
+    id: PropTypes.number.isRequired
   }).isRequired,
   userIsTeamAdmin: PropTypes.bool.isRequired,
   updateUserPermissions: PropTypes.func.isRequired,
+  canChangeUserAdminStatus: PropTypes.bool.isRequired
 };
-
 
 // Thanks 💖
 
-const ThanksCount = ({count}) => (
+const ThanksCount = ({ count }) => (
   <section className="pop-over-info">
     <Thanks count={count} />
   </section>
 );
 
-
 // Team User Info 😍
 
-const TeamUserInfo = ({currentUser, showRemove, ...props}) => {
-  const userAvatarStyle = {backgroundColor: props.user.color};
-  const canRemoveUser = props.currentUserIsTeamAdmin || (currentUser && currentUser.id === props.user.id);
+const TeamUserInfo = ({ currentUser, showRemove, ...props }) => {
+  const userAvatarStyle = { backgroundColor: props.user.color };
+  const canRemoveUser =
+    props.currentUserIsTeamAdmin ||
+    (currentUser && currentUser.id === props.user.id);
   return (
     <dialog className="pop-over team-user-info-pop">
       <section className="pop-over-info user-info">
         <UserLink user={props.user}>
-          <img className="avatar" src={getAvatarThumbnailUrl(props.user)} alt={props.user.login} style={userAvatarStyle}/>
+          <img
+            className="avatar"
+            src={getAvatarThumbnailUrl(props.user)}
+            alt={props.user.login}
+            style={userAvatarStyle}
+          />
         </UserLink>
         <div className="info-container">
-          <p className="name" title={props.user.name}>{props.user.name || "Anonymous"}</p>
-          { props.user.login &&
-            <p className="user-login" title={props.user.login}>@{props.user.login}</p>
-          }
-          { props.userIsTeamAdmin && 
+          <p className="name" title={props.user.name}>
+            {props.user.name || "Anonymous"}
+          </p>
+          {props.user.login && (
+            <p className="user-login" title={props.user.login}>
+              @{props.user.login}
+            </p>
+          )}
+          {props.userIsTeamAdmin && (
             <div className="status-badge">
-              <span className="status admin" data-tooltip="Can edit team info and billing">
+              <span
+                className="status admin"
+                data-tooltip="Can edit team info and billing"
+              >
                 Team Admin
               </span>
             </div>
-          }
+          )}
         </div>
       </section>
-      { props.user.thanksCount > 0 && <ThanksCount count={props.user.thanksCount} /> }
-      { props.currentUserIsTeamAdmin &&
-        <AdminActions 
+      {props.user.thanksCount > 0 && (
+        <ThanksCount count={props.user.thanksCount} />
+      )}
+      {props.currentUserIsTeamAdmin && (
+        <AdminActions
           user={props.user}
           userIsTeamAdmin={props.userIsTeamAdmin}
           updateUserPermissions={props.updateUserPermissions}
         />
-      }
-      { canRemoveUser && !props.userIsTheOnlyMember && <RemoveFromTeam onClick={showRemove}/> }
+      )}
+      {canRemoveUser && !props.userIsTheOnlyMember && (
+        <RemoveFromTeam onClick={showRemove} />
+      )}
     </dialog>
   );
 };
 
-
 // Team User Remove 💣
-
 
 // Team User Info or Remove
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
-const TeamUserInfoAndRemovePop = (props) => (
-  <NestedPopover alternateContent={() => <TeamUserRemovePop {...props}/>}>
-    {showRemove => (
-      <TeamUserInfo {...props} showRemove={showRemove}/>
-    )}
+const TeamUserInfoAndRemovePop = props => (
+  <NestedPopover alternateContent={() => <TeamUserRemovePop {...props} />}>
+    {showRemove => <TeamUserInfo {...props} showRemove={showRemove} />}
   </NestedPopover>
 );
 
@@ -127,7 +154,7 @@ TeamUserInfoAndRemovePop.propTypes = {
     name: PropTypes.string,
     login: PropTypes.string,
     thanksCount: PropTypes.number.isRequired,
-    color: PropTypes.string,
+    color: PropTypes.string
   }).isRequired,
   currentUserIsOnTeam: PropTypes.bool.isRequired,
   currentUserIsTeamAdmin: PropTypes.bool.isRequired,
@@ -138,12 +165,12 @@ TeamUserInfoAndRemovePop.propTypes = {
   teamId: PropTypes.number.isRequired,
   updateUserPermissions: PropTypes.func.isRequired,
   team: PropTypes.shape({
-    projects: PropTypes.array.isRequired,
-  }),
+    projects: PropTypes.array.isRequired
+  })
 };
 
 TeamUserInfoAndRemovePop.defaultProps = {
-  currentUserIsOnTeam: false,
+  currentUserIsOnTeam: false
 };
 
 export default TeamUserInfoAndRemovePop;


### PR DESCRIPTION
**Case** [3327689](https://glitch.manuscript.com/f/cases/3327689/Trying-to-remove-myself-as-the-only-admin-from-a-team-needs-a-clearer-error-message)
**Remix** https://team-admin-bugfixes.glitch.me

This fixes when you're the only admin on a team and try to remove yourself or demote your admin status. Instead of updating the error message when an admin tries to do something they shouldn't, I decided to hide those controls entirely so they can't do forbidden things!

Most of these changes are Prettier changes, the meaningful changes are on the following lines:
- [`userIsTheOnlyAdmin`](https://github.com/FogCreek/Glitch-Community/compare/team-admin-bugfixes?expand=1#diff-5efa2e8a59389e5b21ef386d07506282R32)
- [`38`-`41`: `canChangeUserAdminStatus`](https://github.com/FogCreek/Glitch-Community/compare/team-admin-bugfixes?expand=1#diff-b9d4bc0e6c46070efd4b9cb6e5638827R38)
- [`canRemoveUser`](https://github.com/FogCreek/Glitch-Community/compare/team-admin-bugfixes?expand=1#diff-b9d4bc0e6c46070efd4b9cb6e5638827R93)
- [remove user rendering](https://github.com/FogCreek/Glitch-Community/compare/team-admin-bugfixes?expand=1#diff-b9d4bc0e6c46070efd4b9cb6e5638827R140)

## Testing

1. Be on a team where you're the only admin
2. Click your avi
3. You should not see either the admin or remove user controls

Then
1. Be on a team where you and others are admins
2. Click your avi
3. You should see both admin and remove user controls