### PR TITLE
Update link color in collection headers

### DIFF
--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -2,9 +2,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'just-face-it' },
-  { owner: 'glitch', name: 'souped-up-spotify' },
-  { owner: 'glitch', name: 'discover-modern-art' }
+  { owner: 'glitch', name: 'glitch-flix' },
+  { owner: 'glitch', name: 'relish-the-randomosity' },
+  { owner: 'glitch', name: 'so-useful' }
 ];
 
 // More ideas is populated from this team

--- a/src/curated/featured.js
+++ b/src/curated/featured.js
@@ -14,16 +14,16 @@ Example:
 // make sure image urls use https
 export default [
   {
-    title: 'Make Inkle Patterns',
-    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Ftracery-inkle.gif?1549879572651",
-    link: 'https://tracery-inkle.glitch.me/'
+    title: 'Check Yo\' Contrast',
+    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fcontrast-checker.gif?1549879573206",
+    link: 'http://contrast-checker.glitch.me/'
   },{
-    title: 'Hello, World!',
-    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fhello-around-the-world.gif?1549879571293",
-    link: 'https://hello-around-the-world.glitch.me/'
+    title: 'How Many Pencils?',
+    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fpencil-distance.gif?1549879571534",
+    link: 'https://pencil-distance.glitch.me/'
   },{
-    title: 'Springy Particles',
-    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fimages-to-particles.gif?1549879572018",
-    link: 'https://image-to-particles.glitch.me/'
+    title: 'Un, Deux, Twist',
+    img: "https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fvera-memphis.gif?1549879573380",
+    link: 'https://vera-memphis.glitch.me/'
   } 
 ];

--- a/styles/collections.styl
+++ b/styles/collections.styl
@@ -94,6 +94,8 @@ collection-avatar-size = 55px
         svg
           width: 100%
           height: 100%
+      a
+        color: inherit
       
     .avatar
       border-radius: 5px


### PR DESCRIPTION
This is a tiny change to link colors in collection headers. See it in action on my Glitch collection:

**Before** [glitch.com/@taravancil](https://glitch.com/taravancil)
**After** [successful-stoat.glitch.me/@taravancil](https://successful-stoat.glitch.me/@taravancil)