### PR TITLE
Superb guide: use hooks to make editors way more readable

### DIFF
--- a/src/presenters/collection-editor.jsx
+++ b/src/presenters/collection-editor.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { CurrentUserConsumer } from './current-user';
-import ErrorHandlers from './error-handlers';
+import { useCurrentUser } from './current-user';
+import { useErrorHandlers } from './error-handlers';
 
 class CollectionEditor extends React.Component {
   constructor(props) {
@@ -86,30 +86,22 @@ CollectionEditor.defaultProps = {
   api: null,
 };
 
-const CollectionEditorContainer = ({ api, children, initialCollection }) => (
-  <ErrorHandlers>
-    {errorFuncs => (
-      <CurrentUserConsumer>
-        {currentUser => (
-          <CollectionEditor
-            {...{ api, currentUser, initialCollection }}
-            {...errorFuncs}
-          >
-            {children}
-          </CollectionEditor>
-        )}
-      </CurrentUserConsumer>
-    )}
-  </ErrorHandlers>
-);
+const CollectionEditorContainer = ({ api, children, initialCollection }) => {
+  const { currentUser } = useCurrentUser();
+  const errorFuncs = useErrorHandlers();
+  return (
+    <CollectionEditor
+      {...{ api, currentUser, initialCollection }}
+      {...errorFuncs}
+    >
+      {children}
+    </CollectionEditor>
+  );
+};
 CollectionEditorContainer.propTypes = {
-  api: PropTypes.any,
+  api: PropTypes.any.isRequired,
   children: PropTypes.func.isRequired,
   initialCollection: PropTypes.object.isRequired,
-};
-
-CollectionEditorContainer.defaultProps = {
-  api: null,
 };
 
 export default CollectionEditorContainer;

--- a/src/presenters/collection-editor.jsx
+++ b/src/presenters/collection-editor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useCurrentUser } from './current-user';
-import { useErrorHandlers } from './error-handlers';
+import useErrorHandlers from './error-handlers';
 
 class CollectionEditor extends React.Component {
   constructor(props) {

--- a/src/presenters/error-handlers.jsx
+++ b/src/presenters/error-handlers.jsx
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 import { useNotifications } from './notifications';
 
 function handleError(notify, error) {
@@ -17,7 +15,7 @@ function handleErrorForInput(notify, error) {
   return Promise.reject();
 }
 
-export const useErrorHandlers = () => {
+const useErrorHandlers = () => {
   const { createErrorNotification } = useNotifications();
   return {
     handleError: error => handleError(createErrorNotification, error),
@@ -25,12 +23,4 @@ export const useErrorHandlers = () => {
   };
 };
 
-export const ErrorHandler = ({ children }) => {
-  const errorHandlers = useErrorHandlers();
-  return children(errorHandlers);
-};
-ErrorHandler.propTypes = {
-  children: PropTypes.func.isRequired,
-};
-
-export default ErrorHandler;
+export default useErrorHandlers;

--- a/src/presenters/error-handlers.jsx
+++ b/src/presenters/error-handlers.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
-import { NotificationConsumer } from './notifications';
+import { useNotifications } from './notifications';
 
 function handleError(notify, error) {
   console.error(error);
@@ -18,15 +17,18 @@ function handleErrorForInput(notify, error) {
   return Promise.reject();
 }
 
-const ErrorHandler = ({ children }) => (
-  <NotificationConsumer>
-    {({ createErrorNotification }) => children({
-      handleError: error => handleError(createErrorNotification, error),
-      handleErrorForInput: error => handleErrorForInput(createErrorNotification, error),
-    })
-    }
-  </NotificationConsumer>
-);
+export const useErrorHandlers = () => {
+  const { createErrorNotification } = useNotifications();
+  return {
+    handleError: error => handleError(createErrorNotification, error),
+    handleErrorForInput: error => handleErrorForInput(createErrorNotification, error),
+  };
+};
+
+export const ErrorHandler = ({ children }) => {
+  const errorHandlers = useErrorHandlers();
+  return children(errorHandlers);
+};
 ErrorHandler.propTypes = {
   children: PropTypes.func.isRequired,
 };

--- a/src/presenters/includes/uploader.jsx
+++ b/src/presenters/includes/uploader.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { uploadAsset, uploadAssetSizes } from '../../utils/assets';
-import { NotificationConsumer } from '../notifications';
+import { useNotifications } from '../notifications';
 
 const NotifyUploading = ({ progress }) => (
   <>
@@ -41,16 +40,12 @@ async function uploadWrapper(notifications, upload) {
   return result;
 }
 
-const Uploader = ({ children }) => (
-  <NotificationConsumer>
-    {notifications => children({
-      uploadAsset: (blob, policy, key) => uploadWrapper(notifications, cb => uploadAsset(blob, policy, key, cb)),
-      uploadAssetSizes: (blob, policy, sizes) => uploadWrapper(notifications, cb => uploadAssetSizes(blob, policy, sizes, cb)),
-    })
-    }
-  </NotificationConsumer>
-);
-Uploader.propTypes = {
-  children: PropTypes.func.isRequired,
+const useUploader = () => {
+  const notifications = useNotifications();
+  return {
+    uploadAsset: (blob, policy, key) => uploadWrapper(notifications, cb => uploadAsset(blob, policy, key, cb)),
+    uploadAssetSizes: (blob, policy, sizes) => uploadWrapper(notifications, cb => uploadAssetSizes(blob, policy, sizes, cb)),
+  };
 };
-export default Uploader;
+
+export default useUploader;

--- a/src/presenters/notifications.jsx
+++ b/src/presenters/notifications.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 const context = React.createContext();
 const { Provider } = context;
 export const NotificationConsumer = context.Consumer;
+export const useNotifications = () => React.useContext(context);
 
 const Notification = ({ children, className, remove }) => (
   <aside className={`notification ${className}`} onAnimationEnd={remove}>

--- a/src/presenters/pages/search.jsx
+++ b/src/presenters/pages/search.jsx
@@ -6,7 +6,7 @@ import Layout from '../layout';
 
 import { useCurrentUser } from '../current-user';
 
-import { useErrorHandlers } from '../error-handlers';
+import useErrorHandlers from '../error-handlers';
 import { Loader } from '../includes/loader';
 import MoreIdeas from '../more-ideas';
 import NotFound from '../includes/not-found';

--- a/src/presenters/pages/search.jsx
+++ b/src/presenters/pages/search.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import Layout from '../layout';
 
-import { CurrentUserConsumer } from '../current-user';
+import { useCurrentUser } from '../current-user';
 
-import ErrorHandlers from '../error-handlers';
+import { useErrorHandlers } from '../error-handlers';
 import { Loader } from '../includes/loader';
 import MoreIdeas from '../more-ideas';
 import NotFound from '../includes/not-found';
@@ -158,45 +158,39 @@ SearchResults.defaultProps = {
   api: null,
 };
 
-const SearchPage = ({ api, query }) => (
-  <Layout api={api} searchQuery={query}>
-    <Helmet>
-      {!!query && (
-        <title>
-          Search for
-          {query}
-        </title>
-      )}
-    </Helmet>
-    {query ? (
-      <ErrorHandlers>
-        {errorFuncs => (
-          <CurrentUserConsumer>
-            {currentUser => (
-              <SearchResults
-                {...errorFuncs}
-                api={api}
-                query={query}
-                currentUser={currentUser}
-              />
-            )}
-          </CurrentUserConsumer>
+const SearchPage = ({ api, query }) => {
+  const { currentUser } = useCurrentUser();
+  const errorFuncs = useErrorHandlers();
+  return (
+    <Layout api={api} searchQuery={query}>
+      <Helmet>
+        {!!query && (
+          <title>
+            Search for
+            {query}
+          </title>
         )}
-      </ErrorHandlers>
-    ) : (
-      <NotFound name="anything" />
-    )}
-    <MoreIdeas api={api} />
-  </Layout>
-);
+      </Helmet>
+      {query ? (
+        <SearchResults
+          {...errorFuncs}
+          api={api}
+          query={query}
+          currentUser={currentUser}
+        />
+      ) : (
+        <NotFound name="anything" />
+      )}
+      <MoreIdeas api={api} />
+    </Layout>
+  );
+};
 SearchPage.propTypes = {
-  api: PropTypes.any,
+  api: PropTypes.any.isRequired,
   query: PropTypes.string,
 };
-
 SearchPage.defaultProps = {
   query: '',
-  api: null,
 };
 
 export default SearchPage;

--- a/src/presenters/project-editor.jsx
+++ b/src/presenters/project-editor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useCurrentUser } from './current-user';
-import { useErrorHandlers } from './error-handlers';
+import useErrorHandlers from './error-handlers';
 
 class ProjectEditor extends React.Component {
   constructor(props) {

--- a/src/presenters/project-editor.jsx
+++ b/src/presenters/project-editor.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { CurrentUserConsumer } from './current-user';
-import ErrorHandlers from './error-handlers';
+import { useCurrentUser } from './current-user';
+import { useErrorHandlers } from './error-handlers';
 
 class ProjectEditor extends React.Component {
   constructor(props) {
@@ -55,31 +55,24 @@ ProjectEditor.defaultProps = {
   api: null,
 };
 
-const ProjectEditorContainer = ({ api, children, initialProject }) => (
-  <ErrorHandlers>
-    {wrapErrors => (
-      <CurrentUserConsumer>
-        {currentUser => (
-          <ProjectEditor
-            api={api}
-            currentUser={currentUser}
-            initialProject={initialProject}
-            {...wrapErrors}
-          >
-            {children}
-          </ProjectEditor>
-        )}
-      </CurrentUserConsumer>
-    )}
-  </ErrorHandlers>
-);
+const ProjectEditorContainer = ({ api, children, initialProject }) => {
+  const { currentUser } = useCurrentUser();
+  const wrapErrors = useErrorHandlers();
+  return (
+    <ProjectEditor
+      api={api}
+      currentUser={currentUser}
+      initialProject={initialProject}
+      {...wrapErrors}
+    >
+      {children}
+    </ProjectEditor>
+  );
+};
 ProjectEditorContainer.propTypes = {
-  api: PropTypes.any,
+  api: PropTypes.any.isRequired,
   children: PropTypes.func.isRequired,
   initialProject: PropTypes.object.isRequired,
-};
-ProjectEditorContainer.defaultProps = {
-  api: null,
 };
 
 export default ProjectEditorContainer;

--- a/src/presenters/project-editor.jsx
+++ b/src/presenters/project-editor.jsx
@@ -57,13 +57,13 @@ ProjectEditor.defaultProps = {
 
 const ProjectEditorContainer = ({ api, children, initialProject }) => {
   const { currentUser } = useCurrentUser();
-  const wrapErrors = useErrorHandlers();
+  const errorFuncs = useErrorHandlers();
   return (
     <ProjectEditor
       api={api}
       currentUser={currentUser}
       initialProject={initialProject}
-      {...wrapErrors}
+      {...errorFuncs}
     >
       {children}
     </ProjectEditor>

--- a/src/presenters/team-editor.jsx
+++ b/src/presenters/team-editor.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import * as assets from '../utils/assets';
 
 import { useCurrentUser } from './current-user';
-import { useErrorHandlers } from './error-handlers';
+import useErrorHandlers from './error-handlers';
 import { useNotifications } from './notifications';
-import Uploader from './includes/uploader';
+import useUploader from './includes/uploader';
 
 const MEMBER_ACCESS_LEVEL = 20;
 const ADMIN_ACCESS_LEVEL = 30;
@@ -275,22 +275,19 @@ TeamEditor.defaultProps = {
 
 const TeamEditorContainer = ({ api, children, initialTeam }) => {
   const { currentUser, update } = useCurrentUser();
+  const uploadFuncs = useUploader();
   const notificationFuncs = useNotifications();
   const errorFuncs = useErrorHandlers();
   return (
-    <Uploader>
-      {uploadFuncs => (
-        <TeamEditor
-          {...{ api, currentUser, initialTeam }}
-          updateCurrentUser={update}
-          {...uploadFuncs}
-          {...notificationFuncs}
-          {...errorFuncs}
-        >
-          {children}
-        </TeamEditor>
-      )}
-    </Uploader>
+    <TeamEditor
+      {...{ api, currentUser, initialTeam }}
+      updateCurrentUser={update}
+      {...uploadFuncs}
+      {...notificationFuncs}
+      {...errorFuncs}
+    >
+      {children}
+    </TeamEditor>
   );
 };
 TeamEditorContainer.propTypes = {

--- a/src/presenters/team-editor.jsx
+++ b/src/presenters/team-editor.jsx
@@ -294,12 +294,9 @@ const TeamEditorContainer = ({ api, children, initialTeam }) => {
   );
 };
 TeamEditorContainer.propTypes = {
-  api: PropTypes.any,
+  api: PropTypes.any.isRequired,
   children: PropTypes.func.isRequired,
   initialTeam: PropTypes.object.isRequired,
-};
-TeamEditorContainer.defaultProps = {
-  api: null,
 };
 
 export default TeamEditorContainer;

--- a/src/presenters/team-editor.jsx
+++ b/src/presenters/team-editor.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 
 import * as assets from '../utils/assets';
 
-import { CurrentUserConsumer } from './current-user';
-import ErrorHandlers from './error-handlers';
+import { useCurrentUser } from './current-user';
+import { useErrorHandlers } from './error-handlers';
+import { useNotifications } from './notifications';
 import Uploader from './includes/uploader';
-import { NotificationConsumer } from './notifications';
 
 const MEMBER_ACCESS_LEVEL = 20;
 const ADMIN_ACCESS_LEVEL = 30;
@@ -264,7 +264,6 @@ TeamEditor.propTypes = {
   children: PropTypes.func.isRequired,
   currentUser: PropTypes.object,
   updateCurrentUser: PropTypes.func.isRequired,
-  handleError: PropTypes.func.isRequired,
   initialTeam: PropTypes.object.isRequired,
   uploadAssetSizes: PropTypes.func.isRequired,
 };
@@ -274,33 +273,26 @@ TeamEditor.defaultProps = {
   api: null,
 };
 
-const TeamEditorContainer = ({ api, children, initialTeam }) => (
-  <ErrorHandlers>
-    {errorFuncs => (
-      <Uploader>
-        {uploadFuncs => (
-          <NotificationConsumer>
-            {notificationFuncs => (
-              <CurrentUserConsumer>
-                {(currentUser, fetched, { update }) => (
-                  <TeamEditor
-                    {...{ api, currentUser, initialTeam }}
-                    updateCurrentUser={update}
-                    {...uploadFuncs}
-                    {...errorFuncs}
-                    {...notificationFuncs}
-                  >
-                    {children}
-                  </TeamEditor>
-                )}
-              </CurrentUserConsumer>
-            )}
-          </NotificationConsumer>
-        )}
-      </Uploader>
-    )}
-  </ErrorHandlers>
-);
+const TeamEditorContainer = ({ api, children, initialTeam }) => {
+  const { currentUser, update } = useCurrentUser();
+  const notificationFuncs = useNotifications();
+  const errorFuncs = useErrorHandlers();
+  return (
+    <Uploader>
+      {uploadFuncs => (
+        <TeamEditor
+          {...{ api, currentUser, initialTeam }}
+          updateCurrentUser={update}
+          {...uploadFuncs}
+          {...notificationFuncs}
+          {...errorFuncs}
+        >
+          {children}
+        </TeamEditor>
+      )}
+    </Uploader>
+  );
+};
 TeamEditorContainer.propTypes = {
   api: PropTypes.any,
   children: PropTypes.func.isRequired,

--- a/src/presenters/user-editor.jsx
+++ b/src/presenters/user-editor.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import * as assets from '../utils/assets';
 
 import { useCurrentUser } from './current-user';
-import { useErrorHandlers } from './error-handlers';
-import Uploader from './includes/uploader';
+import useErrorHandlers from './error-handlers';
+import useUploader from './includes/uploader';
 
 class UserEditor extends React.Component {
   constructor(props) {
@@ -189,20 +189,17 @@ UserEditor.propTypes = {
 
 const UserEditorContainer = ({ api, children, initialUser }) => {
   const { currentUser, update } = useCurrentUser();
+  const uploadFuncs = useUploader();
   const errorFuncs = useErrorHandlers();
   return (
-    <Uploader>
-      {uploadFuncs => (
-        <UserEditor
-          {...{ api, currentUser, initialUser }}
-          updateCurrentUser={update}
-          {...uploadFuncs}
-          {...errorFuncs}
-        >
-          {children}
-        </UserEditor>
-      )}
-    </Uploader>
+    <UserEditor
+      {...{ api, currentUser, initialUser }}
+      updateCurrentUser={update}
+      {...uploadFuncs}
+      {...errorFuncs}
+    >
+      {children}
+    </UserEditor>
   );
 };
 UserEditorContainer.propTypes = {

--- a/src/presenters/user-editor.jsx
+++ b/src/presenters/user-editor.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import * as assets from '../utils/assets';
 
-import { CurrentUserConsumer } from './current-user';
-import ErrorHandlers from './error-handlers';
+import { useCurrentUser } from './current-user';
+import { useErrorHandlers } from './error-handlers';
 import Uploader from './includes/uploader';
 
 class UserEditor extends React.Component {
@@ -187,28 +187,24 @@ UserEditor.propTypes = {
   uploadAssetSizes: PropTypes.func.isRequired,
 };
 
-const UserEditorContainer = ({ api, children, initialUser }) => (
-  <ErrorHandlers>
-    {errorFuncs => (
-      <Uploader>
-        {uploadFuncs => (
-          <CurrentUserConsumer>
-            {(currentUser, fetched, { update }) => (
-              <UserEditor
-                {...{ api, currentUser, initialUser }}
-                updateCurrentUser={update}
-                {...uploadFuncs}
-                {...errorFuncs}
-              >
-                {children}
-              </UserEditor>
-            )}
-          </CurrentUserConsumer>
-        )}
-      </Uploader>
-    )}
-  </ErrorHandlers>
-);
+const UserEditorContainer = ({ api, children, initialUser }) => {
+  const { currentUser, update } = useCurrentUser();
+  const errorFuncs = useErrorHandlers();
+  return (
+    <Uploader>
+      {uploadFuncs => (
+        <UserEditor
+          {...{ api, currentUser, initialUser }}
+          updateCurrentUser={update}
+          {...uploadFuncs}
+          {...errorFuncs}
+        >
+          {children}
+        </UserEditor>
+      )}
+    </Uploader>
+  );
+};
 UserEditorContainer.propTypes = {
   api: PropTypes.any.isRequired,
   children: PropTypes.func.isRequired,


### PR DESCRIPTION
`useCurrentUser()` `useNotifications()` `useErrorHandlers()` and `useUploader()` are all equivalent to the their `<BlahConsumer>` versions but don't require tons of nesting to use (you can't use hooks in class components though, so there is still one layer of wrapping to gather them up)

I also cleaned up some props that are marked as optional but aren't.