### PR TITLE
Bug fix for displaying collections from soft-deleted teams

### DIFF
--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -7,7 +7,7 @@ dependencies:
   '@babel/preset-react': 7.0.0
   '@sentry/browser': 4.6.3
   '@sentry/node': 4.6.3
-  '@storybook/react': 4.1.13
+  '@storybook/react': 4.1.12
   autoprefixer-stylus: 0.14.0
   axios: 0.18.0
   babel-eslint: 10.0.1
@@ -30,7 +30,7 @@ dependencies:
   eslint-plugin-import: 2.16.0
   eslint-plugin-jsx-a11y: 6.2.1
   eslint-plugin-react: 7.12.4
-  eslint-plugin-react-hooks: 1.2.0
+  eslint-plugin-react-hooks: 1.0.2
   eslint-scope: 4.0.0
   express: 4.16.4
   express-http-proxy: 1.5.1
@@ -47,15 +47,14 @@ dependencies:
   prop-types: 15.7.2
   quantize: 1.0.2
   randomcolor: 0.5.4
-  react: 16.8.3
-  react-dom: 16.8.3
+  react: 16.8.2
+  react-dom: 16.8.2
   react-helmet: 5.2.0
-  react-is: 16.8.3
+  react-is: 16.8.2
   react-konami: 0.5.0
-  react-onclickoutside: 6.8.0
+  react-onclickoutside: 6.7.1
   react-pluralize: 1.5.0
   react-router-dom: 4.3.1
-  react-select: 2.4.1
   react-svg-inline: 2.1.1
   react-textarea-autosize: 7.1.0
   stats-webpack-plugin: 0.7.0
@@ -1588,7 +1587,7 @@ packages:
       integrity: sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
   /@babel/plugin-transform-regenerator/7.0.0:
     dependencies:
-      regenerator-transform: 0.13.4
+      regenerator-transform: 0.13.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1597,7 +1596,7 @@ packages:
   /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.1.0:
     dependencies:
       '@babel/core': 7.1.0
-      regenerator-transform: 0.13.4
+      regenerator-transform: 0.13.3
     dev: false
     id: registry.npmjs.org/@babel/plugin-transform-regenerator/7.0.0
     peerDependencies:
@@ -1607,7 +1606,7 @@ packages:
   /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.3.3:
     dependencies:
       '@babel/core': 7.3.3
-      regenerator-transform: 0.13.4
+      regenerator-transform: 0.13.3
     dev: false
     id: registry.npmjs.org/@babel/plugin-transform-regenerator/7.0.0
     peerDependencies:
@@ -2079,17 +2078,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==
-  /@emotion/babel-utils/0.6.10:
-    dependencies:
-      '@emotion/hash': 0.6.6
-      '@emotion/memoize': 0.6.6
-      '@emotion/serialize': 0.9.1
-      convert-source-map: 1.6.0
-      find-root: 1.1.0
-      source-map: 0.7.3
-    dev: false
-    resolution:
-      integrity: sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==
   /@emotion/cache/0.8.8:
     dependencies:
       '@emotion/sheet': 0.8.1
@@ -2110,14 +2098,14 @@ packages:
       react: '>=16.3.0'
     resolution:
       integrity: sha512-5qzKP6bTe2Ah7Wvh1sgtzgy6ycdpxwgMAjQ/K/VxvqBxveG9PCpq+Z0GdVg7Houb1AwYjTfNtXstjSk4sqi/7g==
-  /@emotion/core/0.13.1/react@16.8.3:
+  /@emotion/core/0.13.1/react@16.8.2:
     dependencies:
       '@emotion/cache': 0.8.8
       '@emotion/css': 0.9.8
       '@emotion/serialize': 0.9.1
       '@emotion/sheet': 0.8.1
       '@emotion/utils': 0.8.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/@emotion/core/0.13.1
     peerDependencies:
@@ -2145,12 +2133,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
-  /@emotion/provider/0.11.2/60faee46b35feca85a2c98c49e0c699c:
+  /@emotion/provider/0.11.2/@emotion!core@0.13.1:
     dependencies:
       '@emotion/cache': 0.8.8
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
+      '@emotion/core': 0.13.1
       '@emotion/weak-memoize': 0.1.3
-      react: 16.8.3
     dev: false
     id: registry.npmjs.org/@emotion/provider/0.11.2
     peerDependencies:
@@ -2158,11 +2145,12 @@ packages:
       react: '>=16.3.0'
     resolution:
       integrity: sha512-y/BRd6cJ9tyxsy4EK8WheD2X1/RfmudMYILpa8sgI3dKCjVWeEZuQM17wXRVEyhrisaRaIp1qT4h0eWUaaqNLg==
-  /@emotion/provider/0.11.2/@emotion!core@0.13.1:
+  /@emotion/provider/0.11.2/ceaabc59efd008019196dcaba66be890:
     dependencies:
       '@emotion/cache': 0.8.8
-      '@emotion/core': 0.13.1
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
       '@emotion/weak-memoize': 0.1.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/@emotion/provider/0.11.2
     peerDependencies:
@@ -2307,32 +2295,32 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-GNZjIErN99gqJfLMC1L4X4lzu3x1l562UGpuiv3iMQXoNCy8mpNeKtjizoocCGTLHmWB91m6wd2WTHH7P0POjA==
-  /@storybook/addons/4.1.13:
+  /@storybook/addons/4.1.12:
     dependencies:
-      '@storybook/channels': 4.1.13
-      '@storybook/components': 4.1.13
+      '@storybook/channels': 4.1.12
+      '@storybook/components': 4.1.12
       global: 4.3.2
       util-deprecate: 1.0.2
     dev: false
     resolution:
-      integrity: sha512-5WqXwFOc5Oj/ccem7I5FXTWJlCxfgzCgUlWGwkut/ahfuKkcvAPFKuRslReCWLT0sBZl8iap49HgYSNGDztAbA==
-  /@storybook/channel-postmessage/4.1.13:
+      integrity: sha512-W2+bM65LiPWTy22X+B5nVuUs3Eiy0wWY/97AA9mTkDY7lq2/NAeOUQNEoqaRPU9hUE7XFn/ngd+p39+CUSP1zw==
+  /@storybook/channel-postmessage/4.1.12:
     dependencies:
-      '@storybook/channels': 4.1.13
+      '@storybook/channels': 4.1.12
       global: 4.3.2
       json-stringify-safe: 5.0.1
     dev: false
     resolution:
-      integrity: sha512-+PKPRfnqU3sEwZXEWRVzRz26MQYicdw0ZdUxq/Dh5QOk4NSZ0vXtQhW4qOv6pyMfdxfg6D3aIXGqH2P7Nm1pZg==
-  /@storybook/channels/4.1.13:
+      integrity: sha512-AidzY/KuqNei2uoLB0Ny1F/aCUNDAsyiFsG1foyXQpM3rX7VCIy5qC90ouNVwKBKB3fjeDyTjdsgVFCejcM2fQ==
+  /@storybook/channels/4.1.12:
     dev: false
     resolution:
-      integrity: sha512-58GNagdBKagAGDVhdkNVB2cFOLBDAft7Ky2qDdha9pZyyTwJy5VqchvNQokv7kgwCusmic2vYEO35fVY1/v2cQ==
-  /@storybook/client-logger/4.1.13:
+      integrity: sha512-vep5vOmZ3K9/usIGc82tld5af6lQdIpzXGp1VlQ4lG69j09UxO+1H3gQn6dSFEm+9D4hqjp8wj0ZO10N4/xb/w==
+  /@storybook/client-logger/4.1.12:
     dev: false
     resolution:
-      integrity: sha512-L2lPvioMKmPfsLoNJ5NlSVhqpAK8Y3ngnzy+haXQItLsKwu7D+N41i5IAFlEzDzMBaWj/0wKrgMK0QTZWXJIjA==
-  /@storybook/components/4.1.13:
+      integrity: sha512-G/ZzPxURIjTiDaWKlQxxhAhFMT5CR16Twxz8pJzDISi36cbNibf9KtkKf88w6iDB9PRsUcCMXSOqFFiZs+RpFA==
+  /@storybook/components/4.1.12:
     dependencies:
       '@emotion/core': 0.13.1
       '@emotion/provider': /@emotion/provider/0.11.2/@emotion!core@0.13.1
@@ -2349,45 +2337,45 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-EATXdzCJa9UfLcmVTR0TuspOnYHuTCv5wiitDVLPDdpvuqWEDEXxVHBhYOolElo0PeLqC7Dxm2OHLNzh1Su5gQ==
-  /@storybook/components/4.1.13/react-dom@16.8.3+react@16.8.3:
+      integrity: sha512-3s+zvzaUXjsAIFimKFmCUsKUEtQAAZwsNQc501IOE61A+g7LQypM7UWBhlzwaPh33L1Z34WQrEP991ThF9tXUw==
+  /@storybook/components/4.1.12/react-dom@16.8.2+react@16.8.2:
     dependencies:
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
-      '@emotion/provider': /@emotion/provider/0.11.2/60faee46b35feca85a2c98c49e0c699c
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
+      '@emotion/provider': /@emotion/provider/0.11.2/ceaabc59efd008019196dcaba66be890
       '@emotion/styled': 0.10.6
       global: 4.3.2
       lodash: 4.17.11
       prop-types: 15.7.2
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
-      react-inspector: /react-inspector/2.3.1/react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
+      react-inspector: /react-inspector/2.3.1/react@16.8.2
       react-split-pane: 0.1.85
-      react-textarea-autosize: /react-textarea-autosize/7.1.0/react@16.8.3
-      render-fragment: /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.3
+      react-textarea-autosize: /react-textarea-autosize/7.1.0/react@16.8.2
+      render-fragment: /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.2
     dev: false
-    id: registry.npmjs.org/@storybook/components/4.1.13
+    id: registry.npmjs.org/@storybook/components/4.1.12
     peerDependencies:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-EATXdzCJa9UfLcmVTR0TuspOnYHuTCv5wiitDVLPDdpvuqWEDEXxVHBhYOolElo0PeLqC7Dxm2OHLNzh1Su5gQ==
-  /@storybook/core-events/4.1.13:
+      integrity: sha512-3s+zvzaUXjsAIFimKFmCUsKUEtQAAZwsNQc501IOE61A+g7LQypM7UWBhlzwaPh33L1Z34WQrEP991ThF9tXUw==
+  /@storybook/core-events/4.1.12:
     dev: false
     resolution:
-      integrity: sha512-nRado+I9Jxv9CSH/u0qECbaTQpuoBCJ6+9sJm2lg04jjBvczqmjCi7RoY0NTlVp2VbVeAjht74KMOAfPQ2D+IA==
-  /@storybook/core/4.1.13:
+      integrity: sha512-NrZ5k2tsS8Cil99E2M4wzOdkTaxkK0NvicwEPoTcz0utyWrF4T7fThE3qoGBoVTZ+6quWazRFvsvO9MhEnMYnw==
+  /@storybook/core/4.1.12:
     dependencies:
       '@babel/plugin-proposal-class-properties': 7.3.3
       '@babel/preset-env': 7.3.1
       '@emotion/core': 0.13.1
       '@emotion/provider': /@emotion/provider/0.11.2/@emotion!core@0.13.1
       '@emotion/styled': 0.10.6
-      '@storybook/addons': 4.1.13
-      '@storybook/channel-postmessage': 4.1.13
-      '@storybook/client-logger': 4.1.13
-      '@storybook/core-events': 4.1.13
-      '@storybook/node-logger': 4.1.13
-      '@storybook/ui': 4.1.13
+      '@storybook/addons': 4.1.12
+      '@storybook/channel-postmessage': 4.1.12
+      '@storybook/client-logger': 4.1.12
+      '@storybook/core-events': 4.1.12
+      '@storybook/node-logger': 4.1.12
+      '@storybook/ui': 4.1.12
       airbnb-js-shims: 2.1.1
       autoprefixer: 9.4.8
       babel-plugin-macros: 2.5.0
@@ -2447,17 +2435,17 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-HNGv777GnsCs0yo49JANWcIe+qgs4Ms+lLFhCJcVZ6Eq75KayW1kRh8IZOzWnviY0TRW45UKOSZlKQqUipCzMA==
-  /@storybook/mantra-core/1.7.2/react@16.8.3:
+      integrity: sha512-CkV0MOCXO0Py9Tp/WQalatc/p6TM6XICvXkW/oN+6ymnlFHfQio4h/qMFppMeQCXXmuUoNorS6LG8aiIc9bAww==
+  /@storybook/mantra-core/1.7.2/react@16.8.2:
     dependencies:
-      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.3
-      '@storybook/react-simple-di': /@storybook/react-simple-di/1.3.0/react@16.8.3
+      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.2
+      '@storybook/react-simple-di': /@storybook/react-simple-di/1.3.0/react@16.8.2
       babel-runtime: 6.26.0
     dev: false
     id: registry.npmjs.org/@storybook/mantra-core/1.7.2
     resolution:
       integrity: sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==
-  /@storybook/node-logger/4.1.13:
+  /@storybook/node-logger/4.1.12:
     dependencies:
       chalk: 2.4.2
       core-js: 2.6.5
@@ -2466,7 +2454,7 @@ packages:
       regenerator-runtime: 0.12.1
     dev: false
     resolution:
-      integrity: sha512-1sSQen5+Kq1aXE0Ss/evb58XWTciOXGjGh8WQ2Dnaq/sniY/LMxoUxinUqovJv1Z5aarV0HMvWSHyDTeicJeaA==
+      integrity: sha512-t+nS1ZHTGV54PHMhX7WlOkV3xbx19ueBxxl7qkwoqvuUDJ084ZzWuKfTjm4DTzLknBaeY2Dtt6iEFx8TPeQq/Q==
   /@storybook/podda/1.2.3:
     dependencies:
       babel-runtime: 6.26.0
@@ -2476,13 +2464,13 @@ packages:
       npm: '>=3.0.0'
     resolution:
       integrity: sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==
-  /@storybook/react-komposer/2.0.5/react@16.8.3:
+  /@storybook/react-komposer/2.0.5/react@16.8.2:
     dependencies:
-      '@storybook/react-stubber': /@storybook/react-stubber/1.0.1/react@16.8.3
+      '@storybook/react-stubber': /@storybook/react-stubber/1.0.1/react@16.8.2
       babel-runtime: 6.26.0
       hoist-non-react-statics: 1.2.0
       lodash: 4.17.11
-      react: 16.8.3
+      react: 16.8.2
       shallowequal: 1.1.0
     dev: false
     engines:
@@ -2492,23 +2480,23 @@ packages:
       react: ^0.14.7 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-zX5UITgAh37tmD0MWnUFR29S5YM8URMHc/9iwczX/P1f3tM4nPn8VAzxG/UWQecg1xZVphmqkZoux+SDrtTZOQ==
-  /@storybook/react-simple-di/1.3.0/react@16.8.3:
+  /@storybook/react-simple-di/1.3.0/react@16.8.2:
     dependencies:
       babel-runtime: 6.26.0
       create-react-class: 15.6.3
       hoist-non-react-statics: 1.2.0
       prop-types: 15.7.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/@storybook/react-simple-di/1.3.0
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==
-  /@storybook/react-stubber/1.0.1/react@16.8.3:
+  /@storybook/react-stubber/1.0.1/react@16.8.2:
     dependencies:
       babel-runtime: 6.26.0
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     engines:
       npm: '>=3.0.0'
@@ -2517,14 +2505,14 @@ packages:
       react: ^0.14.7 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==
-  /@storybook/react/4.1.13:
+  /@storybook/react/4.1.12:
     dependencies:
       '@babel/plugin-transform-react-constant-elements': 7.2.0
       '@babel/preset-flow': 7.0.0
       '@babel/preset-react': 7.0.0
       '@emotion/styled': 0.10.6
-      '@storybook/core': 4.1.13
-      '@storybook/node-logger': 4.1.13
+      '@storybook/core': 4.1.12
+      '@storybook/node-logger': 4.1.12
       '@svgr/webpack': 4.1.0
       babel-plugin-named-asset-import: 0.2.3
       babel-plugin-react-docgen: 2.0.2
@@ -2546,17 +2534,17 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-JtM7w0wGjRkV3bLbfPscuXi3ecM1McX+PPAO2JheKpbSs2avySky4tAmjkD8mfdc7XasVn/GdAq2ToAww/ibZg==
-  /@storybook/ui/4.1.13:
+      integrity: sha512-6af16BWnQrRyljsITqh/i3qcYs6+FxmWPY70N2gJasMEZOPe9ZEvOSsMTCdq6MN2uDtmca0mAbKLdsCqfMO/Sw==
+  /@storybook/ui/4.1.12:
     dependencies:
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
-      '@emotion/provider': /@emotion/provider/0.11.2/60faee46b35feca85a2c98c49e0c699c
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
+      '@emotion/provider': /@emotion/provider/0.11.2/ceaabc59efd008019196dcaba66be890
       '@emotion/styled': 0.10.6
-      '@storybook/components': /@storybook/components/4.1.13/react-dom@16.8.3+react@16.8.3
-      '@storybook/core-events': 4.1.13
-      '@storybook/mantra-core': /@storybook/mantra-core/1.7.2/react@16.8.3
+      '@storybook/components': /@storybook/components/4.1.12/react-dom@16.8.2+react@16.8.2
+      '@storybook/core-events': 4.1.12
+      '@storybook/mantra-core': /@storybook/mantra-core/1.7.2/react@16.8.2
       '@storybook/podda': 1.2.3
-      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.3
+      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.2
       deep-equal: 1.0.1
       eventemitter3: 3.1.0
       fuse.js: 3.4.2
@@ -2565,15 +2553,15 @@ packages:
       lodash: 4.17.11
       prop-types: 15.7.2
       qs: 6.6.0
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
-      react-fuzzy: /react-fuzzy/0.5.2/react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
+      react-fuzzy: /react-fuzzy/0.5.2/react@16.8.2
       react-lifecycles-compat: 3.0.4
-      react-modal: /react-modal/3.8.1/react-dom@16.8.3+react@16.8.3
-      react-treebeard: /react-treebeard/3.1.0/react-dom@16.8.3+react@16.8.3
+      react-modal: /react-modal/3.8.1/react-dom@16.8.2+react@16.8.2
+      react-treebeard: /react-treebeard/3.1.0/react-dom@16.8.2+react@16.8.2
     dev: false
     resolution:
-      integrity: sha512-GsO9NE8UWGVd5g/Q2Jmw7n7rUQTSog4FcieHwjKb3CmAq56BTgtS+1UnrLJYKSu9UOnA6jV5H7bm/AZ4FQeIsg==
+      integrity: sha512-LmYiS0X4bwdK0drHkKw3uEzfFe1rrARYmTe67IoWiC8+APihVrpJqgdYa4nbcTZgr1pUr5vKWtk0wXr76jbJsg==
   /@svgr/babel-plugin-add-jsx-attribute/4.0.0:
     dev: false
     engines:
@@ -3345,23 +3333,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==
-  /babel-plugin-emotion/9.2.11:
-    dependencies:
-      '@babel/helper-module-imports': 7.0.0
-      '@emotion/babel-utils': 0.6.10
-      '@emotion/hash': 0.6.6
-      '@emotion/memoize': 0.6.6
-      '@emotion/stylis': 0.7.1
-      babel-plugin-macros: 2.5.0
-      babel-plugin-syntax-jsx: 6.18.0
-      convert-source-map: 1.6.0
-      find-root: 1.1.0
-      mkdirp: 0.5.1
-      source-map: 0.5.7
-      touch: 2.0.2
-    dev: false
-    resolution:
-      integrity: sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==
   /babel-plugin-lodash/3.3.4:
     dependencies:
       '@babel/helper-module-imports': 7.0.0
@@ -3463,10 +3434,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fFendfUUU2KqqE1ki2NyQoZm4uHPoEWPUgBZiPBiowcPZos+4q+chdQh0nlwY5hxs08AMHSH4Pp98RQL0VFS/g==
-  /babel-plugin-syntax-jsx/6.18.0:
-    dev: false
-    resolution:
-      integrity: sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
   /babel-plugin-transform-inline-consecutive-adds/0.4.3:
     dev: false
     resolution:
@@ -4195,7 +4162,7 @@ packages:
       bytes: 3.0.0
       compressible: 2.0.16
       debug: 2.6.9
-      on-headers: 1.0.2
+      on-headers: 1.0.1
       safe-buffer: 5.1.2
       vary: 1.1.2
     dev: false
@@ -4338,18 +4305,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
-  /create-emotion/9.2.12:
-    dependencies:
-      '@emotion/hash': 0.6.6
-      '@emotion/memoize': 0.6.6
-      '@emotion/stylis': 0.7.1
-      '@emotion/unitless': 0.6.7
-      csstype: 2.6.2
-      stylis: 3.5.4
-      stylis-rule-sheet: /stylis-rule-sheet/0.0.10/stylis@3.5.4
-    dev: false
-    resolution:
-      integrity: sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==
   /create-error-class/3.0.2:
     dependencies:
       capture-stack-trace: 1.0.1
@@ -4551,10 +4506,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==
-  /csstype/2.6.2:
-    dev: false
-    resolution:
-      integrity: sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==
   /cyclist/0.2.2:
     dev: false
     resolution:
@@ -4995,12 +4946,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-  /domhandler/2.4.2:
+  /domhandler/2.1.0:
     dependencies:
       domelementtype: 1.3.1
     dev: false
     resolution:
-      integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+      integrity: sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
+  /domutils/1.1.6:
+    dependencies:
+      domelementtype: 1.3.1
+    dev: false
+    resolution:
+      integrity: sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
   /domutils/1.5.1:
     dependencies:
       dom-serializer: 0.1.1
@@ -5106,13 +5063,6 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
-  /emotion/9.2.12:
-    dependencies:
-      babel-plugin-emotion: 9.2.11
-      create-emotion: 9.2.12
-    dev: false
-    resolution:
-      integrity: sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
   /encodeurl/1.0.2:
     dev: false
     engines:
@@ -5304,14 +5254,14 @@ packages:
       eslint: ^3 || ^4 || ^5
     resolution:
       integrity: sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==
-  /eslint-plugin-react-hooks/1.2.0:
+  /eslint-plugin-react-hooks/1.0.2:
     dev: false
     engines:
       node: '>=6'
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0
     resolution:
-      integrity: sha512-pb/pwyHg0K3Ss/8loSwCGRSXIsvPBHWfzcP/6jeei0SgWBOyXRbcKFpGxolg0xSmph0jQKLyM27B74clbZM/YQ==
+      integrity: sha512-pY1RSD3CGkGOV+e+rzjfs+JXKRum7VlJKPHznhU0GnFWfDm6zKLmOmg/lKcwNRH3LTSnF2PbfF8x3w90tyHlYw==
   /eslint-plugin-react/7.12.4:
     dependencies:
       array-includes: 3.0.3
@@ -5530,7 +5480,7 @@ packages:
       integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
   /expand-tilde/2.0.2:
     dependencies:
-      homedir-polyfill: 1.0.3
+      homedir-polyfill: 1.0.1
     dev: false
     engines:
       node: '>=0.10.0'
@@ -5793,10 +5743,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==
-  /find-root/1.1.0:
-    dev: false
-    resolution:
-      integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
   /find-up/1.1.2:
     dependencies:
       path-exists: 2.1.0
@@ -6067,7 +6013,7 @@ packages:
   /global-prefix/1.0.2:
     dependencies:
       expand-tilde: 2.0.2
-      homedir-polyfill: 1.0.3
+      homedir-polyfill: 1.0.1
       ini: 1.3.5
       is-windows: 1.0.2
       which: 1.3.1
@@ -6283,14 +6229,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-  /homedir-polyfill/1.0.3:
+  /homedir-polyfill/1.0.1:
     dependencies:
       parse-passwd: 1.0.0
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+      integrity: sha1-TCu8inWJmP7r9e1oWA921GdotLw=
   /hosted-git-info/2.7.1:
     dev: false
     resolution:
@@ -6337,17 +6283,15 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==
-  /htmlparser2/3.10.1:
+  /htmlparser2/3.3.0:
     dependencies:
       domelementtype: 1.3.1
-      domhandler: 2.4.2
-      domutils: 1.7.0
-      entities: 1.1.2
-      inherits: 2.0.3
-      readable-stream: 3.1.1
+      domhandler: 2.1.0
+      domutils: 1.1.6
+      readable-stream: 1.0.34
     dev: false
     resolution:
-      integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+      integrity: sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
   /http-errors/1.6.3:
     dependencies:
       depd: 1.1.2
@@ -7486,10 +7430,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==
-  /memoize-one/5.0.0:
-    dev: false
-    resolution:
-      integrity: sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==
   /memory-cache/0.2.0:
     dev: false
     resolution:
@@ -8024,12 +7964,12 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
-  /on-headers/1.0.2:
+  /on-headers/1.0.1:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+      integrity: sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -8320,10 +8260,6 @@ packages:
       node: '>=0.12'
     resolution:
       integrity: sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
-  /performance-now/2.1.0:
-    dev: false
-    resolution:
-      integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
   /pify/2.3.0:
     dev: false
     engines:
@@ -8523,7 +8459,7 @@ packages:
       integrity: sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
   /pretty-error/2.1.1:
     dependencies:
-      renderkid: 2.0.3
+      renderkid: 2.0.2
       utila: 0.4.0
     dev: false
     resolution:
@@ -8590,7 +8526,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 16.8.3
+      react-is: 16.8.2
     dev: false
     resolution:
       integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8709,12 +8645,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
-  /raf/3.4.1:
-    dependencies:
-      performance-now: 2.1.0
-    dev: false
-    resolution:
-      integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   /ramda/0.21.0:
     dev: false
     resolution:
@@ -8813,41 +8743,41 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-2UseoLWabFNXuk1Foz4VDPSIAkxz+1Hmmq4qijzUmYHDq0ZSloKDLXtGLpQRcAi/M76hRpPtH1rV4BI5jNAOnQ==
-  /react-dom/16.8.3:
+  /react-dom/16.8.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-      scheduler: 0.13.3
+      scheduler: 0.13.2
     dev: false
     peerDependencies:
       react: ^16.0.0
     resolution:
-      integrity: sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
-  /react-dom/16.8.3/react@16.8.3:
+      integrity: sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==
+  /react-dom/16.8.2/react@16.8.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-      react: 16.8.3
-      scheduler: 0.13.3
+      react: 16.8.2
+      scheduler: 0.13.2
     dev: false
-    id: registry.npmjs.org/react-dom/16.8.3
+    id: registry.npmjs.org/react-dom/16.8.2
     peerDependencies:
       react: ^16.0.0
     resolution:
-      integrity: sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
+      integrity: sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==
   /react-error-overlay/5.1.3:
     dev: false
     resolution:
       integrity: sha512-GoqeM3Xadie7XUApXOjkY3Qhs8RkwB/Za4WMedBGrOKH1eTuKGyoAECff7jiVonJchOx6KZ9i8ILO5XIoHB+Tg==
-  /react-fuzzy/0.5.2/react@16.8.3:
+  /react-fuzzy/0.5.2/react@16.8.2:
     dependencies:
       babel-runtime: 6.26.0
       classnames: 2.2.6
       fuse.js: 3.4.2
       prop-types: 15.7.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/react-fuzzy/0.5.2
     peerDependencies:
@@ -8865,14 +8795,6 @@ packages:
       react: '>=15.0.0'
     resolution:
       integrity: sha1-qBgR3yExOm1VxfBYxK66XW89l6c=
-  /react-input-autosize/2.2.1:
-    dependencies:
-      prop-types: 15.7.2
-    dev: false
-    peerDependencies:
-      react: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
-    resolution:
-      integrity: sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==
   /react-inspector/2.3.1:
     dependencies:
       babel-runtime: 6.26.0
@@ -8883,26 +8805,26 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==
-  /react-inspector/2.3.1/react@16.8.3:
+  /react-inspector/2.3.1/react@16.8.2:
     dependencies:
       babel-runtime: 6.26.0
       is-dom: 1.0.9
       prop-types: 15.7.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/react-inspector/2.3.1
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==
-  /react-is/16.8.3:
+  /react-is/16.8.2:
     dev: false
     resolution:
-      integrity: sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
+      integrity: sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==
   /react-konami/0.5.0:
     dependencies:
       prop-types: 15.7.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     resolution:
       integrity: sha512-z8jSYVIwN3V9N/HXG8PCgvgFNpxj1dyXZBR83vBaiF9Pru8peOqxFfAW2bbX+NtgjhF204rBqXoptpKH87ocrQ==
@@ -8910,12 +8832,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-  /react-modal/3.8.1/react-dom@16.8.3+react@16.8.3:
+  /react-modal/3.8.1/react-dom@16.8.2+react@16.8.2:
     dependencies:
       exenv: 1.2.2
       prop-types: 15.7.2
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
       react-lifecycles-compat: 3.0.4
       warning: 3.0.0
     dev: false
@@ -8925,13 +8847,13 @@ packages:
       react-dom: ^0.14.0 || ^15.0.0 || ^16
     resolution:
       integrity: sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
-  /react-onclickoutside/6.8.0:
+  /react-onclickoutside/6.7.1:
     dev: false
     peerDependencies:
       react: ^15.5.x || ^16.x
       react-dom: ^15.5.x || ^16.x
     resolution:
-      integrity: sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA==
+      integrity: sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
   /react-pluralize/1.5.0:
     dependencies:
       react: 15.6.2
@@ -8965,21 +8887,6 @@ packages:
       react: '>=15'
     resolution:
       integrity: sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==
-  /react-select/2.4.1:
-    dependencies:
-      classnames: 2.2.6
-      emotion: 9.2.12
-      memoize-one: 5.0.0
-      prop-types: 15.7.2
-      raf: 3.4.1
-      react-input-autosize: 2.2.1
-      react-transition-group: 2.5.3
-    dev: false
-    peerDependencies:
-      react: ^15.3.0 || ^16.0.0
-      react-dom: ^15.3.0 || ^16.0.0
-    resolution:
-      integrity: sha512-je1cVAFsyQrGxkruQnNCuwo3+P0+1dyq7M4/gTlSwhO4ptPeTjf0eNrvCJ9iurVyorrnI88zgx2/yxrr2/oLLQ==
   /react-side-effect/1.1.5:
     dependencies:
       exenv: 1.2.2
@@ -8992,8 +8899,8 @@ packages:
   /react-split-pane/0.1.85:
     dependencies:
       prop-types: 15.7.2
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
       react-lifecycles-compat: 3.0.4
       react-style-proptype: 3.2.2
     dev: false
@@ -9023,36 +8930,24 @@ packages:
       react: '>=0.14.0 <17.0.0'
     resolution:
       integrity: sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==
-  /react-textarea-autosize/7.1.0/react@16.8.3:
+  /react-textarea-autosize/7.1.0/react@16.8.2:
     dependencies:
       '@babel/runtime': 7.3.1
       prop-types: 15.7.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/react-textarea-autosize/7.1.0
     peerDependencies:
       react: '>=0.14.0 <17.0.0'
     resolution:
       integrity: sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==
-  /react-transition-group/2.5.3:
+  /react-transition-group/2.5.3/react-dom@16.8.2+react@16.8.2:
     dependencies:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.7.2
-      react-lifecycles-compat: 3.0.4
-    dev: false
-    peerDependencies:
-      react: '>=15.0.0'
-      react-dom: '>=15.0.0'
-    resolution:
-      integrity: sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
-  /react-transition-group/2.5.3/react-dom@16.8.3+react@16.8.3:
-    dependencies:
-      dom-helpers: 3.4.0
-      loose-envify: 1.4.0
-      prop-types: 15.7.2
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
       react-lifecycles-compat: 3.0.4
     dev: false
     id: registry.npmjs.org/react-transition-group/2.5.3
@@ -9061,17 +8956,17 @@ packages:
       react-dom: '>=15.0.0'
     resolution:
       integrity: sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
-  /react-treebeard/3.1.0/react-dom@16.8.3+react@16.8.3:
+  /react-treebeard/3.1.0/react-dom@16.8.2+react@16.8.2:
     dependencies:
       '@babel/runtime': 7.3.1
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
       '@emotion/styled': 0.10.6
       deep-equal: 1.0.1
       prop-types: 15.7.2
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
       shallowequal: 1.1.0
-      velocity-react: /velocity-react/1.4.1/react-dom@16.8.3+react@16.8.3
+      velocity-react: /velocity-react/1.4.1/react-dom@16.8.2+react@16.8.2
     dev: false
     id: registry.npmjs.org/react-treebeard/3.1.0
     peerDependencies:
@@ -9091,17 +8986,17 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=
-  /react/16.8.3:
+  /react/16.8.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-      scheduler: 0.13.3
+      scheduler: 0.13.2
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
+      integrity: sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==
   /read-pkg-up/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -9121,6 +9016,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  /readable-stream/1.0.34:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.3
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+    dev: false
+    resolution:
+      integrity: sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
   /readable-stream/2.3.6:
     dependencies:
       core-util-is: 1.0.2
@@ -9133,16 +9037,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
-  /readable-stream/3.1.1:
-    dependencies:
-      inherits: 2.0.3
-      string_decoder: 1.2.0
-      util-deprecate: 1.0.2
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
   /readdirp/2.2.1:
     dependencies:
       graceful-fs: 4.1.15
@@ -9218,12 +9112,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
-  /regenerator-transform/0.13.4:
+  /regenerator-transform/0.13.3:
     dependencies:
       private: 0.1.8
     dev: false
     resolution:
-      integrity: sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==
+      integrity: sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==
   /regex-not/1.0.2:
     dependencies:
       extend-shallow: 3.0.2
@@ -9338,10 +9232,10 @@ packages:
       react: ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-+DnAcalJYR8GE5VRuQGGu78Q0GDe8EXnkuk4DF8gbAhIeS6LRt4j+aaggLLj4PtQVfXNC61McXvXI58WqmRleQ==
-  /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.3:
+  /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.2:
     dependencies:
       prop-types: 15.7.2
-      react: 16.8.3
+      react: 16.8.2
     dev: false
     id: registry.npmjs.org/render-fragment/0.1.1
     peerDependencies:
@@ -9349,16 +9243,16 @@ packages:
       react: ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-+DnAcalJYR8GE5VRuQGGu78Q0GDe8EXnkuk4DF8gbAhIeS6LRt4j+aaggLLj4PtQVfXNC61McXvXI58WqmRleQ==
-  /renderkid/2.0.3:
+  /renderkid/2.0.2:
     dependencies:
       css-select: 1.2.0
       dom-converter: 0.2.0
-      htmlparser2: 3.10.1
+      htmlparser2: 3.3.0
       strip-ansi: 3.0.1
       utila: 0.4.0
     dev: false
     resolution:
-      integrity: sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==
+      integrity: sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==
   /repeat-element/1.1.3:
     dev: false
     engines:
@@ -9525,13 +9419,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-  /scheduler/0.13.3:
+  /scheduler/0.13.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
     resolution:
-      integrity: sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
+      integrity: sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==
   /schema-utils/0.4.7:
     dependencies:
       ajv: 6.9.1
@@ -9811,12 +9705,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-  /source-map/0.7.3:
-    dev: false
-    engines:
-      node: '>= 8'
-    resolution:
-      integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
   /space-separated-tokens/1.1.2:
     dependencies:
       trim: 0.0.1
@@ -9993,6 +9881,10 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=
+  /string_decoder/0.10.31:
+    dev: false
+    resolution:
+      integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -10056,19 +9948,6 @@ packages:
       node: '>= 0.12.0'
     resolution:
       integrity: sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==
-  /stylis-rule-sheet/0.0.10/stylis@3.5.4:
-    dependencies:
-      stylis: 3.5.4
-    dev: false
-    id: registry.npmjs.org/stylis-rule-sheet/0.0.10
-    peerDependencies:
-      stylis: ^3.5.0
-    resolution:
-      integrity: sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
-  /stylis/3.5.4:
-    dev: false
-    resolution:
-      integrity: sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
   /stylus-loader/3.0.2:
     dependencies:
       loader-utils: 1.2.3
@@ -10312,15 +10191,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
-  /touch/2.0.2:
-    dependencies:
-      nopt: 1.0.10
-    dev: false
-    engines:
-      node: '>=0.6'
-    hasBin: true
-    resolution:
-      integrity: sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==
   /touch/3.1.0:
     dependencies:
       nopt: 1.0.10
@@ -10647,13 +10517,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==
-  /velocity-react/1.4.1/react-dom@16.8.3+react@16.8.3:
+  /velocity-react/1.4.1/react-dom@16.8.2+react@16.8.2:
     dependencies:
       lodash: 4.17.11
       prop-types: 15.7.2
-      react: 16.8.3
-      react-dom: /react-dom/16.8.3/react@16.8.3
-      react-transition-group: /react-transition-group/2.5.3/react-dom@16.8.3+react@16.8.3
+      react: 16.8.2
+      react-dom: /react-dom/16.8.2/react@16.8.2
+      react-transition-group: /react-transition-group/2.5.3/react-dom@16.8.2+react@16.8.2
       velocity-animate: 1.5.2
     dev: false
     id: registry.npmjs.org/velocity-react/1.4.1
@@ -11045,7 +10915,6 @@ specifiers:
   react-onclickoutside: ^6.7.1
   react-pluralize: ^1.5.0
   react-router-dom: ^4.3.1
-  react-select: ^2.4.0
   react-svg-inline: ^2.1.1
   react-textarea-autosize: ^7.1.0
   stats-webpack-plugin: ^0.7.0

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -7,7 +7,7 @@ dependencies:
   '@babel/preset-react': 7.0.0
   '@sentry/browser': 4.6.3
   '@sentry/node': 4.6.3
-  '@storybook/react': 4.1.12
+  '@storybook/react': 4.1.13
   autoprefixer-stylus: 0.14.0
   axios: 0.18.0
   babel-eslint: 10.0.1
@@ -30,7 +30,7 @@ dependencies:
   eslint-plugin-import: 2.16.0
   eslint-plugin-jsx-a11y: 6.2.1
   eslint-plugin-react: 7.12.4
-  eslint-plugin-react-hooks: 1.0.2
+  eslint-plugin-react-hooks: 1.2.0
   eslint-scope: 4.0.0
   express: 4.16.4
   express-http-proxy: 1.5.1
@@ -47,12 +47,12 @@ dependencies:
   prop-types: 15.7.2
   quantize: 1.0.2
   randomcolor: 0.5.4
-  react: 16.8.2
-  react-dom: 16.8.2
+  react: 16.8.3
+  react-dom: 16.8.3
   react-helmet: 5.2.0
-  react-is: 16.8.2
+  react-is: 16.8.3
   react-konami: 0.5.0
-  react-onclickoutside: 6.7.1
+  react-onclickoutside: 6.8.0
   react-pluralize: 1.5.0
   react-router-dom: 4.3.1
   react-select: 2.4.1
@@ -1588,7 +1588,7 @@ packages:
       integrity: sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
   /@babel/plugin-transform-regenerator/7.0.0:
     dependencies:
-      regenerator-transform: 0.13.3
+      regenerator-transform: 0.13.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1597,7 +1597,7 @@ packages:
   /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.1.0:
     dependencies:
       '@babel/core': 7.1.0
-      regenerator-transform: 0.13.3
+      regenerator-transform: 0.13.4
     dev: false
     id: registry.npmjs.org/@babel/plugin-transform-regenerator/7.0.0
     peerDependencies:
@@ -1607,7 +1607,7 @@ packages:
   /@babel/plugin-transform-regenerator/7.0.0/@babel!core@7.3.3:
     dependencies:
       '@babel/core': 7.3.3
-      regenerator-transform: 0.13.3
+      regenerator-transform: 0.13.4
     dev: false
     id: registry.npmjs.org/@babel/plugin-transform-regenerator/7.0.0
     peerDependencies:
@@ -2110,14 +2110,14 @@ packages:
       react: '>=16.3.0'
     resolution:
       integrity: sha512-5qzKP6bTe2Ah7Wvh1sgtzgy6ycdpxwgMAjQ/K/VxvqBxveG9PCpq+Z0GdVg7Houb1AwYjTfNtXstjSk4sqi/7g==
-  /@emotion/core/0.13.1/react@16.8.2:
+  /@emotion/core/0.13.1/react@16.8.3:
     dependencies:
       '@emotion/cache': 0.8.8
       '@emotion/css': 0.9.8
       '@emotion/serialize': 0.9.1
       '@emotion/sheet': 0.8.1
       '@emotion/utils': 0.8.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/@emotion/core/0.13.1
     peerDependencies:
@@ -2145,11 +2145,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
-  /@emotion/provider/0.11.2/@emotion!core@0.13.1:
+  /@emotion/provider/0.11.2/60faee46b35feca85a2c98c49e0c699c:
     dependencies:
       '@emotion/cache': 0.8.8
-      '@emotion/core': 0.13.1
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
       '@emotion/weak-memoize': 0.1.3
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/@emotion/provider/0.11.2
     peerDependencies:
@@ -2157,12 +2158,11 @@ packages:
       react: '>=16.3.0'
     resolution:
       integrity: sha512-y/BRd6cJ9tyxsy4EK8WheD2X1/RfmudMYILpa8sgI3dKCjVWeEZuQM17wXRVEyhrisaRaIp1qT4h0eWUaaqNLg==
-  /@emotion/provider/0.11.2/ceaabc59efd008019196dcaba66be890:
+  /@emotion/provider/0.11.2/@emotion!core@0.13.1:
     dependencies:
       '@emotion/cache': 0.8.8
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
+      '@emotion/core': 0.13.1
       '@emotion/weak-memoize': 0.1.3
-      react: 16.8.2
     dev: false
     id: registry.npmjs.org/@emotion/provider/0.11.2
     peerDependencies:
@@ -2307,32 +2307,32 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-GNZjIErN99gqJfLMC1L4X4lzu3x1l562UGpuiv3iMQXoNCy8mpNeKtjizoocCGTLHmWB91m6wd2WTHH7P0POjA==
-  /@storybook/addons/4.1.12:
+  /@storybook/addons/4.1.13:
     dependencies:
-      '@storybook/channels': 4.1.12
-      '@storybook/components': 4.1.12
+      '@storybook/channels': 4.1.13
+      '@storybook/components': 4.1.13
       global: 4.3.2
       util-deprecate: 1.0.2
     dev: false
     resolution:
-      integrity: sha512-W2+bM65LiPWTy22X+B5nVuUs3Eiy0wWY/97AA9mTkDY7lq2/NAeOUQNEoqaRPU9hUE7XFn/ngd+p39+CUSP1zw==
-  /@storybook/channel-postmessage/4.1.12:
+      integrity: sha512-5WqXwFOc5Oj/ccem7I5FXTWJlCxfgzCgUlWGwkut/ahfuKkcvAPFKuRslReCWLT0sBZl8iap49HgYSNGDztAbA==
+  /@storybook/channel-postmessage/4.1.13:
     dependencies:
-      '@storybook/channels': 4.1.12
+      '@storybook/channels': 4.1.13
       global: 4.3.2
       json-stringify-safe: 5.0.1
     dev: false
     resolution:
-      integrity: sha512-AidzY/KuqNei2uoLB0Ny1F/aCUNDAsyiFsG1foyXQpM3rX7VCIy5qC90ouNVwKBKB3fjeDyTjdsgVFCejcM2fQ==
-  /@storybook/channels/4.1.12:
+      integrity: sha512-+PKPRfnqU3sEwZXEWRVzRz26MQYicdw0ZdUxq/Dh5QOk4NSZ0vXtQhW4qOv6pyMfdxfg6D3aIXGqH2P7Nm1pZg==
+  /@storybook/channels/4.1.13:
     dev: false
     resolution:
-      integrity: sha512-vep5vOmZ3K9/usIGc82tld5af6lQdIpzXGp1VlQ4lG69j09UxO+1H3gQn6dSFEm+9D4hqjp8wj0ZO10N4/xb/w==
-  /@storybook/client-logger/4.1.12:
+      integrity: sha512-58GNagdBKagAGDVhdkNVB2cFOLBDAft7Ky2qDdha9pZyyTwJy5VqchvNQokv7kgwCusmic2vYEO35fVY1/v2cQ==
+  /@storybook/client-logger/4.1.13:
     dev: false
     resolution:
-      integrity: sha512-G/ZzPxURIjTiDaWKlQxxhAhFMT5CR16Twxz8pJzDISi36cbNibf9KtkKf88w6iDB9PRsUcCMXSOqFFiZs+RpFA==
-  /@storybook/components/4.1.12:
+      integrity: sha512-L2lPvioMKmPfsLoNJ5NlSVhqpAK8Y3ngnzy+haXQItLsKwu7D+N41i5IAFlEzDzMBaWj/0wKrgMK0QTZWXJIjA==
+  /@storybook/components/4.1.13:
     dependencies:
       '@emotion/core': 0.13.1
       '@emotion/provider': /@emotion/provider/0.11.2/@emotion!core@0.13.1
@@ -2349,45 +2349,45 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-3s+zvzaUXjsAIFimKFmCUsKUEtQAAZwsNQc501IOE61A+g7LQypM7UWBhlzwaPh33L1Z34WQrEP991ThF9tXUw==
-  /@storybook/components/4.1.12/react-dom@16.8.2+react@16.8.2:
+      integrity: sha512-EATXdzCJa9UfLcmVTR0TuspOnYHuTCv5wiitDVLPDdpvuqWEDEXxVHBhYOolElo0PeLqC7Dxm2OHLNzh1Su5gQ==
+  /@storybook/components/4.1.13/react-dom@16.8.3+react@16.8.3:
     dependencies:
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
-      '@emotion/provider': /@emotion/provider/0.11.2/ceaabc59efd008019196dcaba66be890
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
+      '@emotion/provider': /@emotion/provider/0.11.2/60faee46b35feca85a2c98c49e0c699c
       '@emotion/styled': 0.10.6
       global: 4.3.2
       lodash: 4.17.11
       prop-types: 15.7.2
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
-      react-inspector: /react-inspector/2.3.1/react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
+      react-inspector: /react-inspector/2.3.1/react@16.8.3
       react-split-pane: 0.1.85
-      react-textarea-autosize: /react-textarea-autosize/7.1.0/react@16.8.2
-      render-fragment: /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.2
+      react-textarea-autosize: /react-textarea-autosize/7.1.0/react@16.8.3
+      render-fragment: /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.3
     dev: false
-    id: registry.npmjs.org/@storybook/components/4.1.12
+    id: registry.npmjs.org/@storybook/components/4.1.13
     peerDependencies:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-3s+zvzaUXjsAIFimKFmCUsKUEtQAAZwsNQc501IOE61A+g7LQypM7UWBhlzwaPh33L1Z34WQrEP991ThF9tXUw==
-  /@storybook/core-events/4.1.12:
+      integrity: sha512-EATXdzCJa9UfLcmVTR0TuspOnYHuTCv5wiitDVLPDdpvuqWEDEXxVHBhYOolElo0PeLqC7Dxm2OHLNzh1Su5gQ==
+  /@storybook/core-events/4.1.13:
     dev: false
     resolution:
-      integrity: sha512-NrZ5k2tsS8Cil99E2M4wzOdkTaxkK0NvicwEPoTcz0utyWrF4T7fThE3qoGBoVTZ+6quWazRFvsvO9MhEnMYnw==
-  /@storybook/core/4.1.12:
+      integrity: sha512-nRado+I9Jxv9CSH/u0qECbaTQpuoBCJ6+9sJm2lg04jjBvczqmjCi7RoY0NTlVp2VbVeAjht74KMOAfPQ2D+IA==
+  /@storybook/core/4.1.13:
     dependencies:
       '@babel/plugin-proposal-class-properties': 7.3.3
       '@babel/preset-env': 7.3.1
       '@emotion/core': 0.13.1
       '@emotion/provider': /@emotion/provider/0.11.2/@emotion!core@0.13.1
       '@emotion/styled': 0.10.6
-      '@storybook/addons': 4.1.12
-      '@storybook/channel-postmessage': 4.1.12
-      '@storybook/client-logger': 4.1.12
-      '@storybook/core-events': 4.1.12
-      '@storybook/node-logger': 4.1.12
-      '@storybook/ui': 4.1.12
+      '@storybook/addons': 4.1.13
+      '@storybook/channel-postmessage': 4.1.13
+      '@storybook/client-logger': 4.1.13
+      '@storybook/core-events': 4.1.13
+      '@storybook/node-logger': 4.1.13
+      '@storybook/ui': 4.1.13
       airbnb-js-shims: 2.1.1
       autoprefixer: 9.4.8
       babel-plugin-macros: 2.5.0
@@ -2447,17 +2447,17 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-CkV0MOCXO0Py9Tp/WQalatc/p6TM6XICvXkW/oN+6ymnlFHfQio4h/qMFppMeQCXXmuUoNorS6LG8aiIc9bAww==
-  /@storybook/mantra-core/1.7.2/react@16.8.2:
+      integrity: sha512-HNGv777GnsCs0yo49JANWcIe+qgs4Ms+lLFhCJcVZ6Eq75KayW1kRh8IZOzWnviY0TRW45UKOSZlKQqUipCzMA==
+  /@storybook/mantra-core/1.7.2/react@16.8.3:
     dependencies:
-      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.2
-      '@storybook/react-simple-di': /@storybook/react-simple-di/1.3.0/react@16.8.2
+      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.3
+      '@storybook/react-simple-di': /@storybook/react-simple-di/1.3.0/react@16.8.3
       babel-runtime: 6.26.0
     dev: false
     id: registry.npmjs.org/@storybook/mantra-core/1.7.2
     resolution:
       integrity: sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==
-  /@storybook/node-logger/4.1.12:
+  /@storybook/node-logger/4.1.13:
     dependencies:
       chalk: 2.4.2
       core-js: 2.6.5
@@ -2466,7 +2466,7 @@ packages:
       regenerator-runtime: 0.12.1
     dev: false
     resolution:
-      integrity: sha512-t+nS1ZHTGV54PHMhX7WlOkV3xbx19ueBxxl7qkwoqvuUDJ084ZzWuKfTjm4DTzLknBaeY2Dtt6iEFx8TPeQq/Q==
+      integrity: sha512-1sSQen5+Kq1aXE0Ss/evb58XWTciOXGjGh8WQ2Dnaq/sniY/LMxoUxinUqovJv1Z5aarV0HMvWSHyDTeicJeaA==
   /@storybook/podda/1.2.3:
     dependencies:
       babel-runtime: 6.26.0
@@ -2476,13 +2476,13 @@ packages:
       npm: '>=3.0.0'
     resolution:
       integrity: sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==
-  /@storybook/react-komposer/2.0.5/react@16.8.2:
+  /@storybook/react-komposer/2.0.5/react@16.8.3:
     dependencies:
-      '@storybook/react-stubber': /@storybook/react-stubber/1.0.1/react@16.8.2
+      '@storybook/react-stubber': /@storybook/react-stubber/1.0.1/react@16.8.3
       babel-runtime: 6.26.0
       hoist-non-react-statics: 1.2.0
       lodash: 4.17.11
-      react: 16.8.2
+      react: 16.8.3
       shallowequal: 1.1.0
     dev: false
     engines:
@@ -2492,23 +2492,23 @@ packages:
       react: ^0.14.7 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-zX5UITgAh37tmD0MWnUFR29S5YM8URMHc/9iwczX/P1f3tM4nPn8VAzxG/UWQecg1xZVphmqkZoux+SDrtTZOQ==
-  /@storybook/react-simple-di/1.3.0/react@16.8.2:
+  /@storybook/react-simple-di/1.3.0/react@16.8.3:
     dependencies:
       babel-runtime: 6.26.0
       create-react-class: 15.6.3
       hoist-non-react-statics: 1.2.0
       prop-types: 15.7.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/@storybook/react-simple-di/1.3.0
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==
-  /@storybook/react-stubber/1.0.1/react@16.8.2:
+  /@storybook/react-stubber/1.0.1/react@16.8.3:
     dependencies:
       babel-runtime: 6.26.0
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     engines:
       npm: '>=3.0.0'
@@ -2517,14 +2517,14 @@ packages:
       react: ^0.14.7 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==
-  /@storybook/react/4.1.12:
+  /@storybook/react/4.1.13:
     dependencies:
       '@babel/plugin-transform-react-constant-elements': 7.2.0
       '@babel/preset-flow': 7.0.0
       '@babel/preset-react': 7.0.0
       '@emotion/styled': 0.10.6
-      '@storybook/core': 4.1.12
-      '@storybook/node-logger': 4.1.12
+      '@storybook/core': 4.1.13
+      '@storybook/node-logger': 4.1.13
       '@svgr/webpack': 4.1.0
       babel-plugin-named-asset-import: 0.2.3
       babel-plugin-react-docgen: 2.0.2
@@ -2546,17 +2546,17 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-6af16BWnQrRyljsITqh/i3qcYs6+FxmWPY70N2gJasMEZOPe9ZEvOSsMTCdq6MN2uDtmca0mAbKLdsCqfMO/Sw==
-  /@storybook/ui/4.1.12:
+      integrity: sha512-JtM7w0wGjRkV3bLbfPscuXi3ecM1McX+PPAO2JheKpbSs2avySky4tAmjkD8mfdc7XasVn/GdAq2ToAww/ibZg==
+  /@storybook/ui/4.1.13:
     dependencies:
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
-      '@emotion/provider': /@emotion/provider/0.11.2/ceaabc59efd008019196dcaba66be890
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
+      '@emotion/provider': /@emotion/provider/0.11.2/60faee46b35feca85a2c98c49e0c699c
       '@emotion/styled': 0.10.6
-      '@storybook/components': /@storybook/components/4.1.12/react-dom@16.8.2+react@16.8.2
-      '@storybook/core-events': 4.1.12
-      '@storybook/mantra-core': /@storybook/mantra-core/1.7.2/react@16.8.2
+      '@storybook/components': /@storybook/components/4.1.13/react-dom@16.8.3+react@16.8.3
+      '@storybook/core-events': 4.1.13
+      '@storybook/mantra-core': /@storybook/mantra-core/1.7.2/react@16.8.3
       '@storybook/podda': 1.2.3
-      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.2
+      '@storybook/react-komposer': /@storybook/react-komposer/2.0.5/react@16.8.3
       deep-equal: 1.0.1
       eventemitter3: 3.1.0
       fuse.js: 3.4.2
@@ -2565,15 +2565,15 @@ packages:
       lodash: 4.17.11
       prop-types: 15.7.2
       qs: 6.6.0
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
-      react-fuzzy: /react-fuzzy/0.5.2/react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
+      react-fuzzy: /react-fuzzy/0.5.2/react@16.8.3
       react-lifecycles-compat: 3.0.4
-      react-modal: /react-modal/3.8.1/react-dom@16.8.2+react@16.8.2
-      react-treebeard: /react-treebeard/3.1.0/react-dom@16.8.2+react@16.8.2
+      react-modal: /react-modal/3.8.1/react-dom@16.8.3+react@16.8.3
+      react-treebeard: /react-treebeard/3.1.0/react-dom@16.8.3+react@16.8.3
     dev: false
     resolution:
-      integrity: sha512-LmYiS0X4bwdK0drHkKw3uEzfFe1rrARYmTe67IoWiC8+APihVrpJqgdYa4nbcTZgr1pUr5vKWtk0wXr76jbJsg==
+      integrity: sha512-GsO9NE8UWGVd5g/Q2Jmw7n7rUQTSog4FcieHwjKb3CmAq56BTgtS+1UnrLJYKSu9UOnA6jV5H7bm/AZ4FQeIsg==
   /@svgr/babel-plugin-add-jsx-attribute/4.0.0:
     dev: false
     engines:
@@ -4195,7 +4195,7 @@ packages:
       bytes: 3.0.0
       compressible: 2.0.16
       debug: 2.6.9
-      on-headers: 1.0.1
+      on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
     dev: false
@@ -4995,18 +4995,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-  /domhandler/2.1.0:
+  /domhandler/2.4.2:
     dependencies:
       domelementtype: 1.3.1
     dev: false
     resolution:
-      integrity: sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
-  /domutils/1.1.6:
-    dependencies:
-      domelementtype: 1.3.1
-    dev: false
-    resolution:
-      integrity: sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
+      integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   /domutils/1.5.1:
     dependencies:
       dom-serializer: 0.1.1
@@ -5310,14 +5304,14 @@ packages:
       eslint: ^3 || ^4 || ^5
     resolution:
       integrity: sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==
-  /eslint-plugin-react-hooks/1.0.2:
+  /eslint-plugin-react-hooks/1.2.0:
     dev: false
     engines:
       node: '>=6'
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0
     resolution:
-      integrity: sha512-pY1RSD3CGkGOV+e+rzjfs+JXKRum7VlJKPHznhU0GnFWfDm6zKLmOmg/lKcwNRH3LTSnF2PbfF8x3w90tyHlYw==
+      integrity: sha512-pb/pwyHg0K3Ss/8loSwCGRSXIsvPBHWfzcP/6jeei0SgWBOyXRbcKFpGxolg0xSmph0jQKLyM27B74clbZM/YQ==
   /eslint-plugin-react/7.12.4:
     dependencies:
       array-includes: 3.0.3
@@ -5536,7 +5530,7 @@ packages:
       integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
   /expand-tilde/2.0.2:
     dependencies:
-      homedir-polyfill: 1.0.1
+      homedir-polyfill: 1.0.3
     dev: false
     engines:
       node: '>=0.10.0'
@@ -6073,7 +6067,7 @@ packages:
   /global-prefix/1.0.2:
     dependencies:
       expand-tilde: 2.0.2
-      homedir-polyfill: 1.0.1
+      homedir-polyfill: 1.0.3
       ini: 1.3.5
       is-windows: 1.0.2
       which: 1.3.1
@@ -6289,14 +6283,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-  /homedir-polyfill/1.0.1:
+  /homedir-polyfill/1.0.3:
     dependencies:
       parse-passwd: 1.0.0
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-TCu8inWJmP7r9e1oWA921GdotLw=
+      integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   /hosted-git-info/2.7.1:
     dev: false
     resolution:
@@ -6343,15 +6337,17 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==
-  /htmlparser2/3.3.0:
+  /htmlparser2/3.10.1:
     dependencies:
       domelementtype: 1.3.1
-      domhandler: 2.1.0
-      domutils: 1.1.6
-      readable-stream: 1.0.34
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.3
+      readable-stream: 3.1.1
     dev: false
     resolution:
-      integrity: sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
+      integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
   /http-errors/1.6.3:
     dependencies:
       depd: 1.1.2
@@ -8028,12 +8024,12 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
-  /on-headers/1.0.1:
+  /on-headers/1.0.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=
+      integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -8527,7 +8523,7 @@ packages:
       integrity: sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
   /pretty-error/2.1.1:
     dependencies:
-      renderkid: 2.0.2
+      renderkid: 2.0.3
       utila: 0.4.0
     dev: false
     resolution:
@@ -8594,7 +8590,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 16.8.2
+      react-is: 16.8.3
     dev: false
     resolution:
       integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8817,41 +8813,41 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-2UseoLWabFNXuk1Foz4VDPSIAkxz+1Hmmq4qijzUmYHDq0ZSloKDLXtGLpQRcAi/M76hRpPtH1rV4BI5jNAOnQ==
-  /react-dom/16.8.2:
+  /react-dom/16.8.3:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-      scheduler: 0.13.2
+      scheduler: 0.13.3
     dev: false
     peerDependencies:
       react: ^16.0.0
     resolution:
-      integrity: sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==
-  /react-dom/16.8.2/react@16.8.2:
+      integrity: sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
+  /react-dom/16.8.3/react@16.8.3:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-      react: 16.8.2
-      scheduler: 0.13.2
+      react: 16.8.3
+      scheduler: 0.13.3
     dev: false
-    id: registry.npmjs.org/react-dom/16.8.2
+    id: registry.npmjs.org/react-dom/16.8.3
     peerDependencies:
       react: ^16.0.0
     resolution:
-      integrity: sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==
+      integrity: sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
   /react-error-overlay/5.1.3:
     dev: false
     resolution:
       integrity: sha512-GoqeM3Xadie7XUApXOjkY3Qhs8RkwB/Za4WMedBGrOKH1eTuKGyoAECff7jiVonJchOx6KZ9i8ILO5XIoHB+Tg==
-  /react-fuzzy/0.5.2/react@16.8.2:
+  /react-fuzzy/0.5.2/react@16.8.3:
     dependencies:
       babel-runtime: 6.26.0
       classnames: 2.2.6
       fuse.js: 3.4.2
       prop-types: 15.7.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/react-fuzzy/0.5.2
     peerDependencies:
@@ -8887,26 +8883,26 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==
-  /react-inspector/2.3.1/react@16.8.2:
+  /react-inspector/2.3.1/react@16.8.3:
     dependencies:
       babel-runtime: 6.26.0
       is-dom: 1.0.9
       prop-types: 15.7.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/react-inspector/2.3.1
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==
-  /react-is/16.8.2:
+  /react-is/16.8.3:
     dev: false
     resolution:
-      integrity: sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==
+      integrity: sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
   /react-konami/0.5.0:
     dependencies:
       prop-types: 15.7.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     resolution:
       integrity: sha512-z8jSYVIwN3V9N/HXG8PCgvgFNpxj1dyXZBR83vBaiF9Pru8peOqxFfAW2bbX+NtgjhF204rBqXoptpKH87ocrQ==
@@ -8914,12 +8910,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-  /react-modal/3.8.1/react-dom@16.8.2+react@16.8.2:
+  /react-modal/3.8.1/react-dom@16.8.3+react@16.8.3:
     dependencies:
       exenv: 1.2.2
       prop-types: 15.7.2
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
       react-lifecycles-compat: 3.0.4
       warning: 3.0.0
     dev: false
@@ -8929,13 +8925,13 @@ packages:
       react-dom: ^0.14.0 || ^15.0.0 || ^16
     resolution:
       integrity: sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
-  /react-onclickoutside/6.7.1:
+  /react-onclickoutside/6.8.0:
     dev: false
     peerDependencies:
       react: ^15.5.x || ^16.x
       react-dom: ^15.5.x || ^16.x
     resolution:
-      integrity: sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
+      integrity: sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA==
   /react-pluralize/1.5.0:
     dependencies:
       react: 15.6.2
@@ -8996,8 +8992,8 @@ packages:
   /react-split-pane/0.1.85:
     dependencies:
       prop-types: 15.7.2
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
       react-lifecycles-compat: 3.0.4
       react-style-proptype: 3.2.2
     dev: false
@@ -9027,11 +9023,11 @@ packages:
       react: '>=0.14.0 <17.0.0'
     resolution:
       integrity: sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==
-  /react-textarea-autosize/7.1.0/react@16.8.2:
+  /react-textarea-autosize/7.1.0/react@16.8.3:
     dependencies:
       '@babel/runtime': 7.3.1
       prop-types: 15.7.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/react-textarea-autosize/7.1.0
     peerDependencies:
@@ -9050,13 +9046,13 @@ packages:
       react-dom: '>=15.0.0'
     resolution:
       integrity: sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
-  /react-transition-group/2.5.3/react-dom@16.8.2+react@16.8.2:
+  /react-transition-group/2.5.3/react-dom@16.8.3+react@16.8.3:
     dependencies:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.7.2
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
       react-lifecycles-compat: 3.0.4
     dev: false
     id: registry.npmjs.org/react-transition-group/2.5.3
@@ -9065,17 +9061,17 @@ packages:
       react-dom: '>=15.0.0'
     resolution:
       integrity: sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
-  /react-treebeard/3.1.0/react-dom@16.8.2+react@16.8.2:
+  /react-treebeard/3.1.0/react-dom@16.8.3+react@16.8.3:
     dependencies:
       '@babel/runtime': 7.3.1
-      '@emotion/core': /@emotion/core/0.13.1/react@16.8.2
+      '@emotion/core': /@emotion/core/0.13.1/react@16.8.3
       '@emotion/styled': 0.10.6
       deep-equal: 1.0.1
       prop-types: 15.7.2
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
       shallowequal: 1.1.0
-      velocity-react: /velocity-react/1.4.1/react-dom@16.8.2+react@16.8.2
+      velocity-react: /velocity-react/1.4.1/react-dom@16.8.3+react@16.8.3
     dev: false
     id: registry.npmjs.org/react-treebeard/3.1.0
     peerDependencies:
@@ -9095,17 +9091,17 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=
-  /react/16.8.2:
+  /react/16.8.3:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-      scheduler: 0.13.2
+      scheduler: 0.13.3
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==
+      integrity: sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
   /read-pkg-up/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -9125,15 +9121,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
-  /readable-stream/1.0.34:
-    dependencies:
-      core-util-is: 1.0.2
-      inherits: 2.0.3
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-    resolution:
-      integrity: sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
   /readable-stream/2.3.6:
     dependencies:
       core-util-is: 1.0.2
@@ -9146,6 +9133,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  /readable-stream/3.1.1:
+    dependencies:
+      inherits: 2.0.3
+      string_decoder: 1.2.0
+      util-deprecate: 1.0.2
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
   /readdirp/2.2.1:
     dependencies:
       graceful-fs: 4.1.15
@@ -9221,12 +9218,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
-  /regenerator-transform/0.13.3:
+  /regenerator-transform/0.13.4:
     dependencies:
       private: 0.1.8
     dev: false
     resolution:
-      integrity: sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==
+      integrity: sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==
   /regex-not/1.0.2:
     dependencies:
       extend-shallow: 3.0.2
@@ -9341,10 +9338,10 @@ packages:
       react: ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-+DnAcalJYR8GE5VRuQGGu78Q0GDe8EXnkuk4DF8gbAhIeS6LRt4j+aaggLLj4PtQVfXNC61McXvXI58WqmRleQ==
-  /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.2:
+  /render-fragment/0.1.1/prop-types@15.7.2+react@16.8.3:
     dependencies:
       prop-types: 15.7.2
-      react: 16.8.2
+      react: 16.8.3
     dev: false
     id: registry.npmjs.org/render-fragment/0.1.1
     peerDependencies:
@@ -9352,16 +9349,16 @@ packages:
       react: ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-+DnAcalJYR8GE5VRuQGGu78Q0GDe8EXnkuk4DF8gbAhIeS6LRt4j+aaggLLj4PtQVfXNC61McXvXI58WqmRleQ==
-  /renderkid/2.0.2:
+  /renderkid/2.0.3:
     dependencies:
       css-select: 1.2.0
       dom-converter: 0.2.0
-      htmlparser2: 3.3.0
+      htmlparser2: 3.10.1
       strip-ansi: 3.0.1
       utila: 0.4.0
     dev: false
     resolution:
-      integrity: sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==
+      integrity: sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==
   /repeat-element/1.1.3:
     dev: false
     engines:
@@ -9528,13 +9525,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-  /scheduler/0.13.2:
+  /scheduler/0.13.3:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
     resolution:
-      integrity: sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==
+      integrity: sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
   /schema-utils/0.4.7:
     dependencies:
       ajv: 6.9.1
@@ -9996,10 +9993,6 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=
-  /string_decoder/0.10.31:
-    dev: false
-    resolution:
-      integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -10654,13 +10647,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==
-  /velocity-react/1.4.1/react-dom@16.8.2+react@16.8.2:
+  /velocity-react/1.4.1/react-dom@16.8.3+react@16.8.3:
     dependencies:
       lodash: 4.17.11
       prop-types: 15.7.2
-      react: 16.8.2
-      react-dom: /react-dom/16.8.2/react@16.8.2
-      react-transition-group: /react-transition-group/2.5.3/react-dom@16.8.2+react@16.8.2
+      react: 16.8.3
+      react-dom: /react-dom/16.8.3/react@16.8.3
+      react-transition-group: /react-transition-group/2.5.3/react-dom@16.8.3+react@16.8.3
       velocity-animate: 1.5.2
     dev: false
     id: registry.npmjs.org/velocity-react/1.4.1

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -151,8 +151,8 @@ class AddProjectToCollectionPop extends React.Component {
 
   async loadCollections() {
     try {
-      const{ data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
-      let deletedCollections = []; //collections from deleted teams
+      const { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
+      const deletedCollectionIds = []; // collections from deleted teams
       // add user / team to each collection
       allCollections.forEach((collection) => {
         if (collection.teamId === -1) {
@@ -160,16 +160,13 @@ class AddProjectToCollectionPop extends React.Component {
         } else {
           collection.team = this.props.currentUser.teams.find(userTeam => userTeam.id === collection.teamId);
           if (!collection.team) {
-            deletedCollections.push(collection.id);
+            deletedCollectionIds.push(collection.id);
           }
         }
       });
-      
-      console.log('deletedCollections', deletedCollections);
-      console.log(allCollections);
 
       // remove deleted collections
-      allCollections.pull(deleteCollections);
+      remove(allCollections, collection => deletedCollectionIds.includes(collection.id));
 
       const orderedCollections = orderBy(allCollections, collection => collection.updatedAt, ['desc']);
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -216,4 +216,3 @@ AddProjectToCollectionPop.propTypes = {
 };
 
 export default AddProjectToCollectionPop;
-gi

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -1,7 +1,7 @@
 // add-project-to-collection-pop -> Add a project to a collection via a project item's menu
 import React from 'react';
 import PropTypes from 'prop-types';
-import { orderBy, remove } from 'lodash';
+import { orderBy, reject } from 'lodash';
 import { captureException } from '../../utils/sentry';
 
 import { TrackClick } from '../analytics';
@@ -154,15 +154,16 @@ class AddProjectToCollectionPop extends React.Component {
       let { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
       // add user / team to each collection
       console.log('all collections length at start', allCollections.length);
+      console.log(allCollections);
       allCollections.forEach((collection, index) => {
         if (collection.teamId === -1) {
           collection.user = this.props.currentUser;
         } else {
           collection.team = this.props.currentUser.teams.find(userTeam => userTeam.id === collection.teamId);
           if(!collection.team){
-            console.log('attempt to remove team');
+            console.log('attempt to remove team at index', index);
             // team has been soft-deleted - remove from results
-            allCollections.remove(collection);
+            allCollections.splice(index, 1);
             console.log(allCollections.length);
           }
         }

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -153,11 +153,18 @@ class AddProjectToCollectionPop extends React.Component {
     try {
       const { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
       // add user / team to each collection
-      allCollections.forEach((collection) => {
+      console.log('allCollections', allCollections);
+      allCollections.forEach((collection, index) => {
         if (collection.teamId === -1) {
           collection.user = this.props.currentUser;
         } else {
           collection.team = this.props.currentUser.teams.find(userTeam => userTeam.id === collection.teamId);
+          if(!collection.team){
+            console.log(collection);
+            console.log(index);
+            // team has been soft-deleted - remove from results
+            
+          }
         }
       });
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -216,3 +216,4 @@ AddProjectToCollectionPop.propTypes = {
 };
 
 export default AddProjectToCollectionPop;
+gi

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -1,7 +1,7 @@
 // add-project-to-collection-pop -> Add a project to a collection via a project item's menu
 import React from 'react';
 import PropTypes from 'prop-types';
-import { orderBy } from 'lodash';
+import { orderBy, remove } from 'lodash';
 import { captureException } from '../../utils/sentry';
 
 import { TrackClick } from '../analytics';
@@ -151,19 +151,17 @@ class AddProjectToCollectionPop extends React.Component {
 
   async loadCollections() {
     try {
-      const { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
+      let { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
       // add user / team to each collection
-      console.log('allCollections', allCollections);
       allCollections.forEach((collection, index) => {
         if (collection.teamId === -1) {
           collection.user = this.props.currentUser;
         } else {
           collection.team = this.props.currentUser.teams.find(userTeam => userTeam.id === collection.teamId);
           if(!collection.team){
-            console.log(collection);
-            console.log(index);
+            console.log('attempt to remove team');
             // team has been soft-deleted - remove from results
-            
+            allCollections.remove(collection);
           }
         }
       });

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -151,7 +151,7 @@ class AddProjectToCollectionPop extends React.Component {
 
   async loadCollections() {
     try {
-      const { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
+      const{ data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
       let deletedCollections = []; //collections from deleted teams
       // add user / team to each collection
       allCollections.forEach((collection) => {
@@ -160,15 +160,16 @@ class AddProjectToCollectionPop extends React.Component {
         } else {
           collection.team = this.props.currentUser.teams.find(userTeam => userTeam.id === collection.teamId);
           if (!collection.team) {
-            deletedCollections.push(collection);
+            deletedCollections.push(collection.id);
           }
         }
       });
       
-      console.log('deletedCollections', deletedCollections
+      console.log('deletedCollections', deletedCollections);
+      console.log(allCollections);
 
       // remove deleted collections
-      deletedCollections.forEach(collection => allCollections.remove(collection));
+      allCollections.pull(deleteCollections);
 
       const orderedCollections = orderBy(allCollections, collection => collection.updatedAt, ['desc']);
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -153,6 +153,7 @@ class AddProjectToCollectionPop extends React.Component {
     try {
       let { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
       // add user / team to each collection
+      console.log('all collections length at start', allCollections.length);
       allCollections.forEach((collection, index) => {
         if (collection.teamId === -1) {
           collection.user = this.props.currentUser;
@@ -162,6 +163,7 @@ class AddProjectToCollectionPop extends React.Component {
             console.log('attempt to remove team');
             // team has been soft-deleted - remove from results
             allCollections.remove(collection);
+            console.log(allCollections.length);
           }
         }
       });

--- a/src/presenters/pop-overs/add-project-to-collection-pop.jsx
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.jsx
@@ -1,7 +1,7 @@
 // add-project-to-collection-pop -> Add a project to a collection via a project item's menu
 import React from 'react';
 import PropTypes from 'prop-types';
-import { orderBy, reject } from 'lodash';
+import { orderBy, remove } from 'lodash';
 import { captureException } from '../../utils/sentry';
 
 import { TrackClick } from '../analytics';
@@ -151,23 +151,24 @@ class AddProjectToCollectionPop extends React.Component {
 
   async loadCollections() {
     try {
-      let { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
+      const { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
+      let deletedCollections = []; //collections from deleted teams
       // add user / team to each collection
-      console.log('all collections length at start', allCollections.length);
-      console.log(allCollections);
-      allCollections.forEach((collection, index) => {
+      allCollections.forEach((collection) => {
         if (collection.teamId === -1) {
           collection.user = this.props.currentUser;
         } else {
           collection.team = this.props.currentUser.teams.find(userTeam => userTeam.id === collection.teamId);
-          if(!collection.team){
-            console.log('attempt to remove team at index', index);
-            // team has been soft-deleted - remove from results
-            allCollections.splice(index, 1);
-            console.log(allCollections.length);
+          if (!collection.team) {
+            deletedCollections.push(collection);
           }
         }
       });
+      
+      console.log('deletedCollections', deletedCollections
+
+      // remove deleted collections
+      deletedCollections.forEach(collection => allCollections.remove(collection));
 
       const orderedCollections = orderBy(allCollections, collection => collection.updatedAt, ['desc']);
 

--- a/src/presenters/pop-overs/project-options-pop.jsx
+++ b/src/presenters/pop-overs/project-options-pop.jsx
@@ -107,7 +107,7 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
           <PopoverButton
             onClick={addToCollectionPopover}
             {...props}
-            text="Add to My Collection "
+            text="Add to Collection "
             emoji="framed-picture"
           />
         </section>


### PR DESCRIPTION
Changes are in https://glitch.com/edit/#!/excellent-root?path=src/presenters/pop-overs/add-project-to-collection-pop.jsx:169:89

I check to see any instances where there is no corresponding user team for a collection\ (an indication that the team has been deleted) and prevent the collection from being displayed in the pop-over.

to replicate the bug on production - create a team, add a collection to that team, and then delete said team.  then, if you try to add a project to a collection, you get an error.

then go to https://excellent-root.glitch.me/ and check that the add-to-collection pop works for you.

(note, isaac is working on fixing the API endpoint to remove collections from deleted teams from the get collections response)