### PR TITLE
Superb guide: Refactors to the current user manager

### DIFF
--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -2,7 +2,7 @@ const onProductionSite = (projectDomain, apiEnvironment) => (projectDomain === '
   apiEnvironment === 'production';
 
 const filterSecrets = function (jsonEvent) {
-  const tokens = ['facebookToken', 'githubToken', 'persistentToken'];
+  const tokens = ['facebookToken', 'gitAccessToken', 'githubToken', 'inviteToken', 'persistentToken'];
   tokens.forEach((token) => {
     const regexp = new RegExp(`"${token}":"[^"]+"`, 'g');
     jsonEvent = jsonEvent.replace(regexp, `"${token}":"****"`);
@@ -12,7 +12,7 @@ const filterSecrets = function (jsonEvent) {
 
 const ignoreErrors = ['Network Error', 'timeout', 'status code 401'];
 
-const beforeSend = function (projectDomain, apiEnv, event, hint) {
+const beforeSend = function (projectDomain, apiEnv, event) {
  if (!onProductionSite(projectDomain, apiEnv)) {
     return null;
   }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -199,7 +199,7 @@ class CurrentUserManager extends React.Component {
       this.props.setSharedUser(sharedUser);
     }
 
-    // Check if we have to clear the cache
+    // Check if we have to clear the cached user
     if (!usersMatch(sharedUser, this.props.cachedUser)) {
       this.props.setCachedUser(undefined);
     }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -193,17 +193,17 @@ class CurrentUserManager extends React.Component {
     this.setState({ working: true });
     let { sharedUser } = this.props;
 
-    // Check if we have to clear the cache
-    if (!usersMatch(sharedUser, this.props.cachedUser)) {
-      this.props.setCachedUser(undefined);
-    }
-
     // If we're signed out create a new anon user
     if (!sharedUser) {
       sharedUser = await this.getAnonUser();
       this.props.setSharedUser(sharedUser);
     }
-    
+
+    // Check if we have to clear the cache
+    if (!usersMatch(sharedUser, this.props.cachedUser)) {
+      this.props.setCachedUser(undefined);
+    }
+
     const newCachedUser = await this.getCachedUser();
     if (newCachedUser === 'error') {
       // Sounds like our shared user is bad

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -186,6 +186,7 @@ class CurrentUserManager extends React.Component {
     if (this.state.working) return;
     this.setState({ working: true });
     const { sharedUser, cachedUser } = this.props;
+      console.log(sharedUser, cachedUser);
     if (!usersMatch(sharedUser, cachedUser)) {
       this.props.setCachedUser(undefined);
     }
@@ -197,6 +198,7 @@ class CurrentUserManager extends React.Component {
         this.setState({ fetched: false });
         const newSharedUser = await this.getSharedUser();
         this.props.setSharedUser(newSharedUser);
+        console.log(`Fixed shared cachedUser from ${sharedUser && sharedUser.id} to ${newSharedUser && newSharedUser.id}`);
         addBreadcrumb({
           level: 'info',
           message: `Fixed shared cachedUser. Was ${JSON.stringify(sharedUser)}`,

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -115,6 +115,7 @@ class CurrentUserManager extends React.Component {
 
   componentDidUpdate(prev) {
     const { cachedUser, sharedUser } = this.props;
+    console.log(sharedUser, cachedUser);
 
     if (!usersMatch(cachedUser, prev.cachedUser)) {
       identifyUser(cachedUser);
@@ -186,10 +187,12 @@ class CurrentUserManager extends React.Component {
     if (this.state.working) return;
     this.setState({ working: true });
     const { sharedUser, cachedUser } = this.props;
-    console.log(sharedUser, cachedUser);
+    
+    // Check if we have to clear the cache
     if (!usersMatch(sharedUser, cachedUser)) {
       this.props.setCachedUser(undefined);
     }
+    
     if (sharedUser) {
       const newCachedUser = await this.getCachedUser();
       if (newCachedUser === 'error') {
@@ -216,6 +219,7 @@ class CurrentUserManager extends React.Component {
       const { data } = await this.api().post('users/anon');
       this.props.setSharedUser(data);
     }
+    
     this.setState({ working: false });
   }
 

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -124,7 +124,8 @@ class CurrentUserManager extends React.Component {
       !usersMatch(cachedUser, sharedUser)
       || !usersMatch(sharedUser, prev.sharedUser)
     ) {
-      this.load();
+      // delay loading a moment so both items from storage have a chance to update
+      setTimeout(() => this.load(), 1);
     }
 
     // hooks for easier debugging

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -254,8 +254,8 @@ CurrentUserManager.defaultProps = {
 };
 
 export const CurrentUserProvider = ({ children }) => {
-  const [cachedUser, setCachedUser] = useLocalStorage('community-cachedUser', null);
   const [sharedUser, setSharedUser] = useLocalStorage('cachedUser', null);
+  const [cachedUser, setCachedUser] = useLocalStorage('community-cachedUser', null);
   return (
     <CurrentUserManager sharedUser={sharedUser} setSharedUser={setSharedUser} cachedUser={cachedUser} setCachedUser={setCachedUser}>
       {({ api, ...props }) => (

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -232,6 +232,13 @@ class CurrentUserManager extends React.Component {
     this.props.setCachedUser(undefined);
   }
 
+  update(changes) {
+    this.props.setCachedUser({
+      ...this.props.cachedUser,
+      ...changes,
+    });
+  }
+
   async logout() {
     this.props.setSharedUser(undefined);
     this.props.setCachedUser(undefined);
@@ -242,8 +249,6 @@ class CurrentUserManager extends React.Component {
       children,
       sharedUser,
       cachedUser,
-      setSharedUser,
-      setCachedUser,
     } = this.props;
     return children({
       api: this.api(),
@@ -251,7 +256,7 @@ class CurrentUserManager extends React.Component {
       fetched: !!cachedUser && this.state.fetched,
       reload: () => this.load(),
       login: user => this.login(user),
-      update: changes => setCachedUser({ ...cachedUser, ...changes }),
+      update: changes => this.update(changes),
       clear: () => this.logout(),
     });
   }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -115,7 +115,6 @@ class CurrentUserManager extends React.Component {
 
   componentDidUpdate(prev) {
     const { cachedUser, sharedUser } = this.props;
-    console.log(sharedUser, cachedUser);
 
     if (!usersMatch(cachedUser, prev.cachedUser)) {
       identifyUser(cachedUser);
@@ -131,6 +130,11 @@ class CurrentUserManager extends React.Component {
     // hooks for easier debugging
     window.currentUser = cachedUser;
     window.api = this.api();
+  }
+
+  async getAnonUser() {
+    const { data } = await this.api().post('users/anon');
+    return data;
   }
 
   async getSharedUser() {
@@ -187,12 +191,12 @@ class CurrentUserManager extends React.Component {
     if (this.state.working) return;
     this.setState({ working: true });
     const { sharedUser, cachedUser } = this.props;
-    
+
     // Check if we have to clear the cache
     if (!usersMatch(sharedUser, cachedUser)) {
       this.props.setCachedUser(undefined);
     }
-    
+
     if (sharedUser) {
       const newCachedUser = await this.getCachedUser();
       if (newCachedUser === 'error') {
@@ -216,10 +220,10 @@ class CurrentUserManager extends React.Component {
         this.setState({ fetched: true });
       }
     } else {
-      const { data } = await this.api().post('users/anon');
-      this.props.setSharedUser(data);
+      const newAnonUser = await this.getAnonUser();
+      this.props.setSharedUser(newAnonUser);
     }
-    
+
     this.setState({ working: false });
   }
 
@@ -238,7 +242,7 @@ class CurrentUserManager extends React.Component {
       reload: () => this.load(),
       login: user => setSharedUser(user),
       update: changes => setCachedUser({ ...cachedUser, ...changes }),
-      clear: () => setSharedUser(undefined),
+      clear: async () => setSharedUser(await this.getAnonUser()),
     });
   }
 }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -191,6 +191,7 @@ class CurrentUserManager extends React.Component {
     if (this.state.working) return;
     this.setState({ working: true });
     const { sharedUser, cachedUser } = this.props;
+    console.log(sharedUser, cachedUser);
 
     // Check if we have to clear the cache
     if (!usersMatch(sharedUser, cachedUser)) {
@@ -242,7 +243,7 @@ class CurrentUserManager extends React.Component {
       reload: () => this.load(),
       login: user => setSharedUser(user),
       update: changes => setCachedUser({ ...cachedUser, ...changes }),
-      clear: async () => setSharedUser(await this.getAnonUser()),
+      clear: () => setSharedUser(undefined),
     });
   }
 }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -190,10 +190,10 @@ class CurrentUserManager extends React.Component {
   async load() {
     if (this.state.working) return;
     this.setState({ working: true });
-    const { sharedUser, cachedUser } = this.props;
+    const { sharedUser } = this.props;
 
     // Check if we have to clear the cache
-    if (!usersMatch(sharedUser, cachedUser)) {
+    if (!usersMatch(sharedUser, this.props.cachedUser)) {
       this.props.setCachedUser(undefined);
     }
 

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -252,7 +252,7 @@ class CurrentUserManager extends React.Component {
       reload: () => this.load(),
       login: user => this.login(user),
       update: changes => setCachedUser({ ...cachedUser, ...changes }),
-      clear: () => setSharedUser(undefined),
+      clear: () => this.logout(),
     });
   }
 }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -186,7 +186,7 @@ class CurrentUserManager extends React.Component {
     if (this.state.working) return;
     this.setState({ working: true });
     const { sharedUser, cachedUser } = this.props;
-      console.log(sharedUser, cachedUser);
+    console.log(sharedUser, cachedUser);
     if (!usersMatch(sharedUser, cachedUser)) {
       this.props.setCachedUser(undefined);
     }

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -191,7 +191,6 @@ class CurrentUserManager extends React.Component {
     if (this.state.working) return;
     this.setState({ working: true });
     const { sharedUser, cachedUser } = this.props;
-    console.log(sharedUser, cachedUser);
 
     // Check if we have to clear the cache
     if (!usersMatch(sharedUser, cachedUser)) {
@@ -228,6 +227,16 @@ class CurrentUserManager extends React.Component {
     this.setState({ working: false });
   }
 
+  async login(user) {
+    this.props.setSharedUser(user);
+    this.props.setCachedUser(undefined);
+  }
+
+  async logout() {
+    this.props.setSharedUser(undefined);
+    this.props.setCachedUser(undefined);
+  }
+
   render() {
     const {
       children,
@@ -241,7 +250,7 @@ class CurrentUserManager extends React.Component {
       currentUser: { ...defaultUser, ...sharedUser, ...cachedUser },
       fetched: !!cachedUser && this.state.fetched,
       reload: () => this.load(),
-      login: user => setSharedUser(user),
+      login: user => this.login(user),
       update: changes => setCachedUser({ ...cachedUser, ...changes }),
       clear: () => setSharedUser(undefined),
     });

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -4,7 +4,6 @@ const readFromStorage = (storage, name) => {
   try {
     const raw = storage.getItem(name);
     if (raw !== null) {
-      console.log('read',name,'as',raw,'at',Date.now());
       return JSON.parse(raw);
     }
   } catch (error) {
@@ -14,7 +13,6 @@ const readFromStorage = (storage, name) => {
 };
 
 const writeToStorage = (storage, name, value) => {
-  console.log('set',name,'to',value,'at',Date.now());
   try {
     if (value !== undefined) {
       storage.setItem(name, JSON.stringify(value));

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -13,6 +13,7 @@ const readFromStorage = (storage, name) => {
 };
 
 const writeToStorage = (storage, name, value) => {
+  console.log('write ' + name);
   try {
     if (value !== undefined) {
       storage.setItem(name, JSON.stringify(value));
@@ -39,7 +40,7 @@ const useLocalStorage = (name, defaultValue) => {
     return () => {
       window.removeEventListener('storage', reload, { passive: true });
     };
-  }, [name]);
+  }, [storage, name]);
 
   const value = rawValue !== undefined ? rawValue : defaultValue;
   const setValue = (newValue) => {

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -25,13 +25,13 @@ const writeToStorage = (storage, name, value) => {
 };
 
 const useLocalStorage = (name, defaultValue) => {
-const storage = window.localStorage;
-  
+  const storage = window.localStorage;
+
   const [rawValue, setValueInMemory] = React.useState(() => readFromStorage(storage, name));
 
   React.useEffect(() => {
     const reload = (event) => {
-      if (event.storaevent.key === name) {
+      if (event.storageArea === storage && event.key === name) {
         setValueInMemory(readFromStorage(storage, name));
       }
     };

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const readFromStorage = (name) => {
+const readFromStorage = (storage, name) => {
   try {
-    const raw = window.localStorage.getItem(name);
+    const raw = storage.getItem(name);
     if (raw !== null) {
       return JSON.parse(raw);
     }
@@ -12,12 +12,12 @@ const readFromStorage = (name) => {
   return undefined;
 };
 
-const writeToStorage = (name, value) => {
+const writeToStorage = (storage, name, value) => {
   try {
     if (value !== undefined) {
-      window.localStorage.setItem(name, JSON.stringify(value));
+      storage.setItem(name, JSON.stringify(value));
     } else {
-      window.localStorage.removeItem(name);
+      storage.removeItem(name);
     }
   } catch (error) {
     console.warn('Failed to write to localStorage!', error);
@@ -25,10 +25,16 @@ const writeToStorage = (name, value) => {
 };
 
 const useLocalStorage = (name, defaultValue) => {
-  const [rawValue, setValueInMemory] = React.useState(() => readFromStorage(name));
+const storage = window.localStorage;
+  
+  const [rawValue, setValueInMemory] = React.useState(() => readFromStorage(storage, name));
 
   React.useEffect(() => {
-    const reload = () => setValueInMemory(readFromStorage(name));
+    const reload = (event) => {
+      if (event.storaevent.key === name) {
+        setValueInMemory(readFromStorage(storage, name));
+      }
+    };
     window.addEventListener('storage', reload, { passive: true });
     return () => {
       window.removeEventListener('storage', reload, { passive: true });
@@ -38,7 +44,7 @@ const useLocalStorage = (name, defaultValue) => {
   const value = rawValue !== undefined ? rawValue : defaultValue;
   const setValue = (newValue) => {
     setValueInMemory(newValue);
-    writeToStorage(name, newValue);
+    writeToStorage(storage, name, newValue);
   };
 
   return [value, setValue];

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -4,6 +4,7 @@ const readFromStorage = (storage, name) => {
   try {
     const raw = storage.getItem(name);
     if (raw !== null) {
+      console.log('read',name,'as',raw,'at',Date.now());
       return JSON.parse(raw);
     }
   } catch (error) {
@@ -13,6 +14,7 @@ const readFromStorage = (storage, name) => {
 };
 
 const writeToStorage = (storage, name, value) => {
+  console.log('set',name,'to',value,'at',Date.now());
   try {
     if (value !== undefined) {
       storage.setItem(name, JSON.stringify(value));

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -13,7 +13,6 @@ const readFromStorage = (storage, name) => {
 };
 
 const writeToStorage = (storage, name, value) => {
-  console.log('write ' + name);
   try {
     if (value !== undefined) {
       storage.setItem(name, JSON.stringify(value));


### PR DESCRIPTION
This should fix the main cause of invalid cached user errors. It happens because when you log in with a second glitch.com window open the other window tries to reload the no longer valid anon user. While the reload request is in progress it gets updated props with the signed in user. The request fails because the anon user was merged, and the user fix gets applied to the updated signed in user, showing as a correction from the anon user to the signed in user.