### PR TITLE
Superb guide: Probably fix the remaining cachedUser errors

### DIFF
--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -206,11 +206,11 @@ class CurrentUserManager extends React.Component {
 
     const newCachedUser = await this.getCachedUser();
     if (newCachedUser === 'error') {
-      // Looks like our sharedUser is bad, make sure it wasn't overwritten since we last checked
+      // Looks like our sharedUser is bad, make sure it wasn't changed since we read it
       // Anon users get their token and id deleted when they're merged into a user on sign in
       // If it did change then quit out and let componentDidUpdate sort it out
       if (usersMatch(sharedUser, this.props.sharedUser)) {
-        // The user wasn't changed externally, so we do need to fix it
+        // The user wasn't changed, so we need to fix it
         this.setState({ fetched: false });
         const newSharedUser = await this.getSharedUser();
         this.props.setSharedUser(newSharedUser);

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -206,21 +206,25 @@ class CurrentUserManager extends React.Component {
 
     const newCachedUser = await this.getCachedUser();
     if (newCachedUser === 'error') {
-      // Sounds like our shared user is bad
-      // Fix it and componentDidUpdate will start a new loading cycle
-      this.setState({ fetched: false });
-      const newSharedUser = await this.getSharedUser();
-      this.props.setSharedUser(newSharedUser);
-      console.log(`Fixed shared cachedUser from ${sharedUser.id} to ${newSharedUser && newSharedUser.id}`);
-      addBreadcrumb({
-        level: 'info',
-        message: `Fixed shared cachedUser. Was ${JSON.stringify(sharedUser)}`,
-      });
-      addBreadcrumb({
-        level: 'info',
-        message: `New shared cachedUser: ${JSON.stringify(newSharedUser)}`,
-      });
-      captureMessage('Invalid cachedUser');
+      // Looks like our sharedUser is bad, make sure it wasn't overwritten since we last checked
+      // If we were anon and just signed in the token would have been invalidated
+      // If it changed then restart the cycle and if see if the new user is ok
+      if (usersMatch(sharedUser, this.props.sharedUser)) {
+        // Fix it and componentDidUpdate will start a new loading cycle
+        this.setState({ fetched: false });
+        const newSharedUser = await this.getSharedUser();
+        this.props.setSharedUser(newSharedUser);
+        console.log(`Fixed shared cachedUser from ${sharedUser.id} to ${newSharedUser && newSharedUser.id}`);
+        addBreadcrumb({
+          level: 'info',
+          message: `Fixed shared cachedUser. Was ${JSON.stringify(sharedUser)}`,
+        });
+        addBreadcrumb({
+          level: 'info',
+          message: `New shared cachedUser: ${JSON.stringify(newSharedUser)}`,
+        });
+        captureMessage('Invalid cachedUser');
+      }
     } else {
       // The shared user is good, store it
       this.props.setCachedUser(newCachedUser);

--- a/src/presenters/current-user.js
+++ b/src/presenters/current-user.js
@@ -207,10 +207,10 @@ class CurrentUserManager extends React.Component {
     const newCachedUser = await this.getCachedUser();
     if (newCachedUser === 'error') {
       // Looks like our sharedUser is bad, make sure it wasn't overwritten since we last checked
-      // If we were anon and just signed in the token would have been invalidated
-      // If it changed then restart the cycle and if see if the new user is ok
+      // Anon users get their token and id deleted when they're merged into a user on sign in
+      // If it did change then quit out and let componentDidUpdate sort it out
       if (usersMatch(sharedUser, this.props.sharedUser)) {
-        // Fix it and componentDidUpdate will start a new loading cycle
+        // The user wasn't changed externally, so we do need to fix it
         this.setState({ fetched: false });
         const newSharedUser = await this.getSharedUser();
         this.props.setSharedUser(newSharedUser);

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -49,6 +49,7 @@ const useLocalStorage = (name, defaultValue) => {
   React.useEffect(() => {
     const reload = (event) => {
       if (event.storageArea === storage && event.key === name) {
+        console.log(name,readFromStorage(name));
         setValueInMemory(readFromStorage(name));
       }
     };

--- a/src/presenters/includes/local-storage.js
+++ b/src/presenters/includes/local-storage.js
@@ -49,7 +49,6 @@ const useLocalStorage = (name, defaultValue) => {
   React.useEffect(() => {
     const reload = (event) => {
       if (event.storageArea === storage && event.key === name) {
-        console.log(name,readFromStorage(name));
         setValueInMemory(readFromStorage(name));
       }
     };

--- a/src/presenters/pages/login.js
+++ b/src/presenters/pages/login.js
@@ -51,7 +51,7 @@ class LoginPage extends React.Component {
         throw new Error(`Bad user id (${data.id}) after ${provider} login`);
       }
 
-      console.log('LOGGED IN', data);
+      console.log('LOGGED IN', data.id);
       this.props.setUser(data);
 
       if (destination && destination.expires > new Date().toISOString()) {


### PR DESCRIPTION
We send the load user request on page load, even if you're on the signin page. Based on the remaining events, it looks like the anon user's load request sometimes gets queued after the sign in. When it goes through the anon user doesn't exist. That triggers a user fix even though the anon user isn't relevant any more.

Before we try to fix the user, check if the user was changed. If they changed try loading the new user instead of doing a fix.