### PR TITLE
Put undeleted project to top of projects list 

### DIFF
--- a/src/presenters/user-editor.js
+++ b/src/presenters/user-editor.js
@@ -125,7 +125,7 @@ class UserEditor extends React.Component {
       }
     }
     this.setState(({ projects, _deletedProjects }) => ({
-      projects: [...projects, data],
+      projects: [data, ...projects],
       _deletedProjects: _deletedProjects.filter(p => p.id !== id),
     }));
   }


### PR DESCRIPTION
available at https://undeleted-project-goes-first.glitch.me/

The goal of this PR is to make it obvious to the person who has undeleted a project that it is back in their projects list. 

Currently when someone undeletes a project it is added to the end of their projects list and is not visible on the page if they have more than 12 projects. This could cause concern that the project has not been undeleted. By putting it to the top of the list it is clear to the person that it is safely back.

Gifs showing behaviour.
Current:
https://cl.ly/16de2cc116d0

New:
https://cl.ly/c1c0dec365b3


One potential issue is that on refresh the project will go back to its previous place in the list (based on last updated?). This may be confusing in a different way ("where did my project that was on the top go?").  

I still think this approach of putting an undeleted project to the top of the list (even if only temporarily) on undelete is preferable to adding to the end or even putting back to its original location which again may not be visible. 

