### PR TITLE
Dented supernova - handle sorting of undeleted projects + sorting of user projects by updatedAt on profile pages

### DIFF
--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Helmet from 'react-helmet';
-import { partition } from 'lodash';
+import { orderBy, partition } from 'lodash';
 import { getAvatarStyle, getLink, getProfileStyle } from '../../models/user';
 
 import { AnalyticsContext } from '../analytics';
@@ -272,7 +272,7 @@ const UserPageContainer = ({ api, user }) => (
 
           <CurrentUserConsumer>
             {maybeCurrentUser => (
-              <ProjectsLoader api={api} projects={userFromEditor.projects}>
+              <ProjectsLoader api={api} projects={orderBy(userFromEditor.projects, project => project.updatedAt, ['desc'])}>
                 {projects => (
                   <UserPage
                     {...{ api, isAuthorized, maybeCurrentUser }}

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -272,7 +272,8 @@ const UserPageContainer = ({ api, user }) => (
 
           <CurrentUserConsumer>
             {maybeCurrentUser => (
-              <ProjectsLoader api={api} projects={orderBy(userFromEditor.projects, project => project.updatedAt, ['desc'])}>
+              <ProjectsLoader api={api} projects={orderBy(userFromEditor.projects, project => project.updatedAt, ['desc'])>
+ 
                 {projects => (
                   <UserPage
                     {...{ api, isAuthorized, maybeCurrentUser }}
@@ -290,3 +291,4 @@ const UserPageContainer = ({ api, user }) => (
 );
 
 export default UserPageContainer;
+t

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -272,8 +272,7 @@ const UserPageContainer = ({ api, user }) => (
 
           <CurrentUserConsumer>
             {maybeCurrentUser => (
-              <ProjectsLoader api={api} projects={orderBy(userFromEditor.projects, project => project.updatedAt, ['desc'])>
- 
+              <ProjectsLoader api={api} projects={orderBy(userFromEditor.projects, project => project.updatedAt, ['desc'])}>
                 {projects => (
                   <UserPage
                     {...{ api, isAuthorized, maybeCurrentUser }}
@@ -291,4 +290,3 @@ const UserPageContainer = ({ api, user }) => (
 );
 
 export default UserPageContainer;
-t

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -20,8 +20,7 @@ const NoCollectionPlaceholder = <p className="info-description">Create collectio
 
 const AddProjectPopoverTitle = ({ project }) => (
   <NestedPopoverTitle>
-    <img src={getAvatarUrl(project.id)} alt="" />
-    Add {project.domain} to collection
+    <img src={getAvatarUrl(project.id)} alt="" /> {'  '} Add {project.domain} to collection
   </NestedPopoverTitle>
 );
 AddProjectPopoverTitle.propTypes = {
@@ -99,14 +98,10 @@ class AddProjectToCollectionPopContents extends React.Component {
 
         {filteredCollections.length ? (
           <section className="pop-over-actions results-list">
-            <ul className="results">
-              {filteredCollections.map(this.renderCollectionsThatDontHaveProject)}
-            </ul>
+            <ul className="results">{filteredCollections.map(this.renderCollectionsThatDontHaveProject)}</ul>
           </section>
         ) : (
-          <section className="pop-over-info">
-            {query ? NoSearchResultsPlaceholder : NoCollectionPlaceholder}
-          </section>
+          <section className="pop-over-info">{query ? NoSearchResultsPlaceholder : NoCollectionPlaceholder}</section>
         )}
 
         <section className="pop-over-actions">

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -20,7 +20,7 @@ const NoCollectionPlaceholder = <p className="info-description">Create collectio
 
 const AddProjectPopoverTitle = ({ project }) => (
   <NestedPopoverTitle>
-    <img src={getAvatarUrl(project.id)} alt="" /> {'  '} Add {project.domain} to collection
+    <img src={getAvatarUrl(project.id)} alt="" /> {' '} Add {project.domain} to collection
   </NestedPopoverTitle>
 );
 AddProjectPopoverTitle.propTypes = {

--- a/src/presenters/user-editor.js
+++ b/src/presenters/user-editor.js
@@ -124,6 +124,7 @@ class UserEditor extends React.Component {
         console.warn('failed to rename project on undelete', e);
       }
     }
+    console.log('undeleted ', data);
     this.setState(({ projects, _deletedProjects }) => ({
       projects: [data, ...projects],
       _deletedProjects: _deletedProjects.filter(p => p.id !== id),

--- a/src/presenters/user-editor.js
+++ b/src/presenters/user-editor.js
@@ -124,7 +124,8 @@ class UserEditor extends React.Component {
         console.warn('failed to rename project on undelete', e);
       }
     }
-    console.log('undeleted ', data);
+    // temp set undeleted project updatedAt to now, while it's actually updating behind the scenes
+    data.updatedAt = Date.now();
     this.setState(({ projects, _deletedProjects }) => ({
       projects: [data, ...projects],
       _deletedProjects: _deletedProjects.filter(p => p.id !== id),


### PR DESCRIPTION
https://dented-supernova.glitch.me/

Currently, when the user undeletes a project, the undeleted project is shown as their most recent project.  However, upon refreshing the page, the undeleted project is no longer seen at the top of the list as user projects on the profile page are not automatically sorted by when they are last updated.

To test:
* open https://dented-supernova.glitch.me/ and try undeleting one of your projects.  Then refresh the page and check that the undeleted project still appears at the top of the list.

Manuscript case: https://glitch.manuscript.com/f/cases/3327976