### PR TITLE
Text / Heading

### DIFF
--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -15,18 +15,17 @@ const TAGS_AND_SIZES = {
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName, className }) => {
+const Heading = ({ children, tagName: TagName, className }) => {
   // In the future we might want tag names and sizes to be different
 
   // For now, we're keeping them 1-1,
   // and also specifically setting 'h1' and 'h2' headings to be bold
   // which should match the current styles on production for switching to this
 
-  const size = TAGS_AND_SIZES[tagName];
-  const bold = tagName === 'h1' || tagName === 'h2';
-
+  const size = TAGS_AND_SIZES[TagName];
+  const bold = TagName === 'h1' || TagName === 'h2';
   return (
-    <tagName
+    <TagName
       className={cx({
         [size]: true,
         bold,
@@ -34,7 +33,7 @@ const Heading = ({ children, tagName, className }) => {
       })}
     >
       {children}
-    </tagName>
+    </TagName>
   );
 };
 

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -30,7 +30,7 @@ const Heading = ({ children, tagName, className }) => {
     [className]: className !== undefined,
   });
 
-  return <tagName className={className}>{children}</tagName>;
+  return <tagName className={classNames}>{children}</tagName>;
 };
 
 Heading.propTypes = {

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -11,27 +11,20 @@ export const SIZES = ['small']; // I'm into sizes being different from tagNames 
 /**
  * Heading Component
  */
-const Heading = ({ children, length }) => {
+const Heading = ({ children, tagName }) => {
   const className = cx({
-    btn: true,
-    cta: type === 'cta',
-    small: size === 'small',
-    tertiary: ['tertiary', 'dangerZone'].includes(type),
-    dangerZone: type === 'dangerZone',
-    hover,
+    heading: true,
   });
-  return <TAG_NAMES className={className}> /;
+  const HeadingTag = TAG_NAMES[tagName];
+  return <HeadingTag className={className}>{children}</HeadingTag>;
 };
 
 Heading.propTypes = {
   /** element(s) to display in the button */
   children: PropTypes.node.isRequired,
   /** length to truncate rendered Heading to */
-  length: PropTypes.number,
+  tagName: PropTypes.oneOf(TAG_NAMES).isRequired,
 };
 
-Heading.defaultProps = {
-  length: -1,
-};
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -15,7 +15,7 @@ const TAGS_AND_SIZES = {
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName }) => {
+const Heading = ({ children, tagName, className }) => {
   // In the future we might want tag names and sizes to be different
 
   // For now, we're keeping them 1-1,
@@ -24,12 +24,13 @@ const Heading = ({ children, tagName }) => {
 
   const size = TAGS_AND_SIZES[tagName];
   const bold = tagName === 'h1' || tagName === 'h2';
-  console.log({bold, tagName})
-  const className = cx({
+  const classNames = cx({
     [size]: true,
     bold,
+    [className]: className !== undefined,
   });
-  return <tagName className={[className]}>{children}</tagName>;
+
+  return <tagName className={className}>{children}</tagName>;
 };
 
 Heading.propTypes = {
@@ -39,6 +40,10 @@ Heading.propTypes = {
   tagName: PropTypes.oneOf(Object.keys(TAGS_AND_SIZES)).isRequired,
   /** additional className to add to the heading */
   className: PropTypes.string,
+};
+
+Heading.defaultProps = {
+  className: undefined,
 };
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -24,13 +24,18 @@ const Heading = ({ children, tagName, className }) => {
 
   const size = TAGS_AND_SIZES[tagName];
   const bold = tagName === 'h1' || tagName === 'h2';
-  const classNames = cx({
-    [size]: true,
-    bold,
-    [className]: className !== undefined,
-  });
 
-  return <tagName className={classNames}>{children}</tagName>;
+  return (
+    <tagName
+      className={cx({
+        [size]: true,
+        bold,
+        [className]: className !== undefined,
+      })}
+    >
+      {children}
+    </tagName>
+  );
 };
 
 Heading.propTypes = {

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -10,18 +10,25 @@ const TAGS_AND_SIZES = {
   h2: 'large',
   h3: 'medium',
   h4: 'small',
-}
+};
 
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName}) => {
+const Heading = ({ children, tagName }) => {
+  // In the future we might want tag names and sizes to be different
+
+  // For now, we're keeping them 1-1,
+  // and also specifically setting 'xlarge' and 'large' headings to be bold
+  // which should match the current styles on production for switching to this
+
+  const size = TAGS_AND_SIZES[tagName];
+  const bold = tagName === 'xlarge' || tagName === 'large';
   const className = cx({
-    [TAGS_AND_SIZES[tagName]]: true,
-    bold: tagName === 'xlarge' || tagName === 'large'
+    [size]: true,
+    bold,
   });
-  const HeadingTag = tagName
-  return <HeadingTag className={className}>{children}</HeadingTag>;
+  return <tagName className={className}>{children}</tagName>;
 };
 
 Heading.propTypes = {

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -19,12 +19,12 @@ const Heading = ({ children, tagName }) => {
   // In the future we might want tag names and sizes to be different
 
   // For now, we're keeping them 1-1,
-  // and also specifically setting 'xlarge' and 'large' headings to be bold
+  // and also specifically setting 'h1' and 'h2' headings to be bold
   // which should match the current styles on production for switching to this
 
   const size = TAGS_AND_SIZES[tagName];
-  const bold = tagName === 'xlarge' || tagName === 'large';
-  console.log({bold})
+  const bold = tagName === 'h1' || tagName === 'h2';
+  console.log({bold, tagName})
   const className = cx({
     [size]: true,
     bold,

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -2,16 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './heading.styl';
 
+export const TAGS = ['h1', 'h2', 'h3', 'h4'];
+
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName: TagName }) => <TagName>{children}</TagName>;
+const Heading = ({ children, tagName: TagName }) => <TagName className={styles[TagName]}>{children}</TagName>;
 
 Heading.propTypes = {
   /** element(s) to display in the button */
   children: PropTypes.node.isRequired,
-  /** heading tag to be rendered [h1, h2...] */
-  tagName: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4']).isRequired,
+  /** heading tag to be rendered */
+  tagName: PropTypes.oneOf(TAGS).isRequired,
 };
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -5,18 +5,22 @@ import styles from './heading.styl';
 
 const cx = classNames.bind(styles);
 
-export const TAG_NAMES = ['h1', 'h2', 'h3', 'h4'];
-export const SIZES = ['xlarge', 'large', 'medium', 'small']; // I'm into sizes being different from tagNames after I took a nap, maybe?
+const TAGS_AND_SIZES = {
+  h1: 'xlarge',
+  h2: 'large',
+  h3: 'medium',
+  h4: 'small',
+}
 
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName, size, bold }) => {
+const Heading = ({ children, tagName}) => {
   const className = cx({
-    size,
-    bold
+    [TAGS_AND_SIZES[tagName]]: true,
+    bold: tagName === 'xlarge' || tagName === 'large'
   });
-  const HeadingTag = TAG_NAMES[tagName];
+  const HeadingTag = tagName
   return <HeadingTag className={className}>{children}</HeadingTag>;
 };
 
@@ -24,11 +28,7 @@ Heading.propTypes = {
   /** element(s) to display in the button */
   children: PropTypes.node.isRequired,
   /** heading tag to be rendered [h1, h2...] */
-  tagName: PropTypes.oneOf(TAG_NAMES).isRequired,
-  /** size of the heading [xlarge, large...] */
-  size: PropTypes.oneOf(SIZES.keys()).isRequired,
-  /** make the heading bold */
-  bold: PropTypes.bool,
+  tagName: PropTypes.oneOf(TAGS_AND_SIZES.keys()).isRequired,
 };
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -6,19 +6,15 @@ import styles from './heading.styl';
 const cx = classNames.bind(styles);
 
 export const TAG_NAMES = ['h1', 'h2', 'h3', 'h4'];
-export const SIZES = {
-  small: '',
-  medium: '',
-  large: '',
-  xlarge: '',
-}; // I'm into sizes being different from tagNames after I took a nap, maybe?
+export const SIZES = ['xlarge', 'large', 'medium', 'small']; // I'm into sizes being different from tagNames after I took a nap, maybe?
 
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName }) => {
+const Heading = ({ children, tagName, size, bold }) => {
   const className = cx({
-    heading: true,
+    size,
+    bold
   });
   const HeadingTag = TAG_NAMES[tagName];
   return <HeadingTag className={className}>{children}</HeadingTag>;
@@ -27,9 +23,12 @@ const Heading = ({ children, tagName }) => {
 Heading.propTypes = {
   /** element(s) to display in the button */
   children: PropTypes.node.isRequired,
-  /** length to truncate rendered Heading to */
+  /** heading tag to be rendered [h1, h2...] */
   tagName: PropTypes.oneOf(TAG_NAMES).isRequired,
+  /** size of the heading [xlarge, large...] */
   size: PropTypes.oneOf(SIZES.keys()).isRequired,
+  /** make the heading bold */
+  bold: PropTypes.bool,
 };
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -1,53 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames/bind';
 import styles from './heading.styl';
-
-const cx = classNames.bind(styles);
-
-const TAGS_AND_SIZES = {
-  h1: 'xlarge',
-  h2: 'large',
-  h3: 'medium',
-  h4: 'small',
-};
 
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName: TagName, className }) => {
-  // In the future we might want tag names and sizes to be different
-
-  // For now, we're keeping them 1-1,
-  // and also specifically setting 'h1' and 'h2' headings to be bold
-  // which should match the current styles on production for switching to this
-
-  const size = TAGS_AND_SIZES[TagName];
-  const bold = TagName === 'h1' || TagName === 'h2';
-  return (
-    <TagName
-      className={cx({
-        [size]: true,
-        bold,
-        [className]: className !== undefined,
-      })}
-    >
-      {children}
-    </TagName>
-  );
-};
+const Heading = ({ children, tagName: TagName }) => <TagName>{children}</TagName>;
 
 Heading.propTypes = {
   /** element(s) to display in the button */
   children: PropTypes.node.isRequired,
   /** heading tag to be rendered [h1, h2...] */
-  tagName: PropTypes.oneOf(Object.keys(TAGS_AND_SIZES)).isRequired,
-  /** additional className to add to the heading */
-  className: PropTypes.string,
-};
-
-Heading.defaultProps = {
-  className: undefined,
+  tagName: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4']).isRequired,
 };
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import styles from './heading.styl';
+
+const cx = classNames.bind(styles);
+
+/**
+ * Heading Component
+ */
+const Heading = ({ children, length }) => {
+  const className = cx({
+    btn: true,
+    cta: type === 'cta',
+    small: size === 'small',
+    tertiary: ['tertiary', 'dangerZone'].includes(type),
+    dangerZone: type === 'dangerZone',
+    hover,
+  });
+  return <span className={className} />;
+};
+
+Heading.propTypes = {
+  /** element(s) to display in the button */
+  children: PropTypes.node.isRequired,
+  /** length to truncate rendered Heading to */
+  length: PropTypes.number,
+};
+
+Heading.defaultProps = {
+  length: -1,
+};
+
+export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -29,7 +29,7 @@ const Heading = ({ children, tagName }) => {
     [size]: true,
     bold,
   });
-  return <tagName className={className}>{children}</tagName>;
+  return <tagName className={[className]}>{children}</tagName>;
 };
 
 Heading.propTypes = {
@@ -37,6 +37,8 @@ Heading.propTypes = {
   children: PropTypes.node.isRequired,
   /** heading tag to be rendered [h1, h2...] */
   tagName: PropTypes.oneOf(Object.keys(TAGS_AND_SIZES)).isRequired,
+  /** additional className to add to the heading */
+  className: PropTypes.string,
 };
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -5,8 +5,13 @@ import styles from './heading.styl';
 
 const cx = classNames.bind(styles);
 
-export const TAG_NAMES = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
-export const SIZES = ['small']; // I'm into sizes being different from tagNames after I took a nap, maybe?
+export const TAG_NAMES = ['h1', 'h2', 'h3', 'h4'];
+export const SIZES = {
+  small: '',
+  medium: '',
+  large: '',
+  xlarge: '',
+}; // I'm into sizes being different from tagNames after I took a nap, maybe?
 
 /**
  * Heading Component
@@ -24,7 +29,7 @@ Heading.propTypes = {
   children: PropTypes.node.isRequired,
   /** length to truncate rendered Heading to */
   tagName: PropTypes.oneOf(TAG_NAMES).isRequired,
+  size: PropTypes.oneOf(SIZES.keys()).isRequired,
 };
-
 
 export default Heading;

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -5,6 +5,9 @@ import styles from './heading.styl';
 
 const cx = classNames.bind(styles);
 
+export const TAG_NAMES = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+export const SIZES = ['small']; // I'm into sizes being different from tagNames after I took a nap, maybe?
+
 /**
  * Heading Component
  */
@@ -17,7 +20,7 @@ const Heading = ({ children, length }) => {
     dangerZone: type === 'dangerZone',
     hover,
   });
-  return <span className={className} />;
+  return <TAG_NAMES className={className}> /;
 };
 
 Heading.propTypes = {

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -24,6 +24,7 @@ const Heading = ({ children, tagName }) => {
 
   const size = TAGS_AND_SIZES[tagName];
   const bold = tagName === 'xlarge' || tagName === 'large';
+  console.log({bold})
   const className = cx({
     [size]: true,
     bold,

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -35,7 +35,7 @@ Heading.propTypes = {
   /** element(s) to display in the button */
   children: PropTypes.node.isRequired,
   /** heading tag to be rendered [h1, h2...] */
-  tagName: PropTypes.oneOf(TAGS_AND_SIZES.keys()).isRequired,
+  tagName: PropTypes.oneOf(Object.keys(TAGS_AND_SIZES)).isRequired,
 };
 
 export default Heading;

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -1,17 +1,17 @@
 @require '../constants'
 
-h1
+.h1
   font-size: 22px
   font-weight: bold
   
-h2
+.h2
   font-size: 18px
   font-weight: bold
   a
     color: primary
 
-h3
+.h3
   font-size: 16px
 
-h4
+.h4
   font-size: 14px

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -1,18 +1,17 @@
 @require '../constants'
 
-.xlarge
+h1
   font-size: 22px
-
-.large
+  font-weight: bold
+  
+h2
   font-size: 18px
+  font-weight: bold
   a
     color: primary
 
-.medium
+h3
   font-size: 16px
 
-.small
+h4
   font-size: 14px
-  
-.bold
-  font-weight: bold

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -2,11 +2,9 @@
 
 .h1
   font-size: 22px
-  font-weight: bold
   
 .h2
   font-size: 18px
-  font-weight: bold
   a
     color: primary
 

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -1,17 +1,18 @@
 @require '../constants'
 
-h1
-  font-weight: bold
+.xlarge
   font-size: 22px
 
-h2
-  font-weight: bold
+.large
   font-size: 18px
   a
     color: primary
 
-h3
+.medium
   font-size: 16px
 
-h4
+.small
   font-size: 14px
+  
+.bold
+  font-weight: bold

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -1,0 +1,64 @@
+@require '../constants'
+
+.markdownContent
+  text-rendering: optimizeLegibility
+  
+  *:first-child
+    margin-top: 0.5rem !important
+
+  a
+    color: link
+    &:hover
+      text-decoration: underline
+  //p,
+  pre,
+  table,
+  ul
+    margin-left: 1rem
+
+  // code
+  pre
+    background-color: secondary-background
+    padding: 16px
+    border-radius: 5px
+    code
+      border-radius: 0
+      padding: 0
+  code
+    font-family: monospace
+    background-color: secondary-background
+    border-radius: 3px
+    padding: 2px 3px
+    font-size: 14px
+
+  // tables
+  table,
+  th,
+  td
+    border: 1px solid section-line
+    padding: 7px 14px
+  tr:nth-child(even)
+    background-color: secondary-background
+  hr
+    border: 0
+    border-top: 1px solid section-line
+
+  // lists
+  ul,
+  ol
+    margin-bottom: 1rem
+  ul
+    padding-left: 1rem
+    list-style-type: square
+    ul
+      list-style-type: square
+  ol
+    ul
+      list-style-type: square
+  li
+    line-height: 24px
+
+  // images
+  img
+    max-width: 100%
+    border-radius: 3px

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -1,64 +1,17 @@
 @require '../constants'
 
-.markdownContent
-  text-rendering: optimizeLegibility
-  
-  *:first-child
-    margin-top: 0.5rem !important
+h1
+  font-weight: bold
+  font-size: 22px
 
+h2
+  font-weight: bold
+  font-size: 18px
   a
-    color: link
-    &:hover
-      text-decoration: underline
-  //p,
-  pre,
-  table,
-  ul
-    margin-left: 1rem
+    color: primary
 
-  // code
-  pre
-    background-color: secondary-background
-    padding: 16px
-    border-radius: 5px
-    code
-      border-radius: 0
-      padding: 0
-  code
-    font-family: monospace
-    background-color: secondary-background
-    border-radius: 3px
-    padding: 2px 3px
-    font-size: 14px
+h3
+  font-size: 16px
 
-  // tables
-  table,
-  th,
-  td
-    border: 1px solid section-line
-    padding: 7px 14px
-  tr:nth-child(even)
-    background-color: secondary-background
-  hr
-    border: 0
-    border-top: 1px solid section-line
-
-  // lists
-  ul,
-  ol
-    margin-bottom: 1rem
-  ul
-    padding-left: 1rem
-    list-style-type: square
-    ul
-      list-style-type: square
-  ol
-    ul
-      list-style-type: square
-  li
-    line-height: 24px
-
-  // images
-  img
-    max-width: 100%
-    border-radius: 3px
+h4
+  font-size: 14px

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -19,7 +19,7 @@ import CollectionsList from '../collections-list';
 import { ProfileContainer, ImageButtons } from '../includes/profile';
 import ProjectsLoader from '../projects-loader';
 import ReportButton from '../pop-overs/report-abuse-pop';
-import Heading from '../components/text';
+import Heading from '../../components/text/heading';
 
 function syncPageToLogin(login) {
   history.replaceState(null, null, getLink({ login }));
@@ -27,29 +27,41 @@ function syncPageToLogin(login) {
 
 const NameAndLogin = ({ name, login, isAuthorized, updateName, updateLogin }) => {
   if (!login) {
-    return <h1 className="login">Anonymous</h1>;
+    return (
+      <Heading tagName="h1" className="login">
+        Anonymous
+      </Heading>
+    );
   }
 
   if (!isAuthorized) {
     if (!name) {
-      return <h1 className="login">@{login}</h1>;
+      return (
+        <Heading tagName="h1" className="login">
+          @{login}
+        </Heading>
+      );
     }
     return (
       <>
-        <h1 className="username">{name}</h1>
-        <h2 className="login">@{login}</h2>
+        <Heading tagName="h1" className="username">
+          {name}
+        </Heading>
+        <Heading tagName="h2" className="login">
+          @{login}
+        </Heading>
       </>
     );
   }
   const editableName = name !== null ? name : '';
   return (
     <>
-      <h1 className="username">
+      <Heading tagName="h1" className="username">
         <EditableField value={editableName} update={updateName} placeholder="What's your name?" />
-      </h1>
-      <h2 className="login">
+      </Heading>
+      <Heading tagName="h2" className="login">
         <EditableField value={login} update={updateLogin} prefix="@" placeholder="Nickname?" />
-      </h2>
+      </Heading>
     </>
   );
 };

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -28,7 +28,7 @@ function syncPageToLogin(login) {
 const NameAndLogin = ({ name, login, isAuthorized, updateName, updateLogin }) => {
   if (!login) {
     return (
-      <Heading tagName="h1" className="login">
+      <Heading tagName="h1">
         Anonymous
       </Heading>
     );
@@ -37,17 +37,17 @@ const NameAndLogin = ({ name, login, isAuthorized, updateName, updateLogin }) =>
   if (!isAuthorized) {
     if (!name) {
       return (
-        <Heading tagName="h1" className="login">
+        <Heading tagName="h1">
           @{login}
         </Heading>
       );
     }
     return (
       <>
-        <Heading tagName="h1" className="username">
+        <Heading tagName="h1">
           {name}
         </Heading>
-        <Heading tagName="h2" className="login">
+        <Heading tagName="h2">
           @{login}
         </Heading>
       </>
@@ -56,10 +56,10 @@ const NameAndLogin = ({ name, login, isAuthorized, updateName, updateLogin }) =>
   const editableName = name !== null ? name : '';
   return (
     <>
-      <Heading tagName="h1" className="username">
+      <Heading tagName="h1">
         <EditableField value={editableName} update={updateName} placeholder="What's your name?" />
       </Heading>
-      <Heading tagName="h2" className="login">
+      <Heading tagName="h2">
         <EditableField value={login} update={updateLogin} prefix="@" placeholder="Nickname?" />
       </Heading>
     </>

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -27,29 +27,17 @@ function syncPageToLogin(login) {
 
 const NameAndLogin = ({ name, login, isAuthorized, updateName, updateLogin }) => {
   if (!login) {
-    return (
-      <Heading tagName="h1">
-        Anonymous
-      </Heading>
-    );
+    return <Heading tagName="h1">Anonymous</Heading>;
   }
 
   if (!isAuthorized) {
     if (!name) {
-      return (
-        <Heading tagName="h1">
-          @{login}
-        </Heading>
-      );
+      return <Heading tagName="h1">@{login}</Heading>;
     }
     return (
       <>
-        <Heading tagName="h1">
-          {name}
-        </Heading>
-        <Heading tagName="h2">
-          @{login}
-        </Heading>
+        <Heading tagName="h1">{name}</Heading>
+        <Heading tagName="h2">@{login}</Heading>
       </>
     );
   }

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -19,6 +19,7 @@ import CollectionsList from '../collections-list';
 import { ProfileContainer, ImageButtons } from '../includes/profile';
 import ProjectsLoader from '../projects-loader';
 import ReportButton from '../pop-overs/report-abuse-pop';
+import Heading from '../components/text';
 
 function syncPageToLogin(login) {
   history.replaceState(null, null, getLink({ login }));

--- a/stories/index.js
+++ b/stories/index.js
@@ -63,10 +63,10 @@ storiesOf('Text Input', module)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
 storiesOf('Heading', module)
-  .add('h1 xlarge bold ', () => (<Heading tagName="h1">H1, size extra large, bold</Heading>))
-  .add('h2 large bold', () => (<Heading tagName="h2">H2, size large, bold</Heading>))
-  .add('h3 medium customClass', () => (<Heading tagName="h3" className="customClass">H3, size medium</Heading>))
-  .add('h4 small', () => (<Heading tagName="h3">H4, size small</Heading>))
+  .add('h1 ', () => (<Heading tagName="h1">H1, 22px bold</Heading>))
+  .add('h2', () => (<Heading tagName="h2">H2, 18px bold</Heading>))
+  .add('h3', () => (<Heading tagName="h3">H3, 16px</Heading>))
+  .add('h4', () => (<Heading tagName="h4">H4, 14px</Heading>))
 
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)

--- a/stories/index.js
+++ b/stories/index.js
@@ -63,9 +63,9 @@ storiesOf('Text Input', module)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
 storiesOf('Heading', module)
-  .add('h1 xlarge bold', () => (<Heading tagName="h1">H1, size extra large, bold</Heading>))
+  .add('h1 xlarge bold ', () => (<Heading tagName="h1">H1, size extra large, bold</Heading>))
   .add('h2 large bold', () => (<Heading tagName="h2">H2, size large, bold</Heading>))
-  .add('h3 medium', () => (<Heading tagName="h3">H3, size medium</Heading>))
+  .add('h3 medium customClass', () => (<Heading tagName="h3" className="customClass">H3, size medium</Heading>))
   .add('h4 small', () => (<Heading tagName="h3">H4, size small</Heading>))
 
 storiesOf('Markdown', module)

--- a/stories/index.js
+++ b/stories/index.js
@@ -63,10 +63,10 @@ storiesOf('Text Input', module)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
 storiesOf('Heading', module)
-  .add('h1 xlarge', () => (<Heading tagName="h1" size="xlarge">H1 size extra large</Heading>))
-  .add('h2 large', () => (<Heading tagName="h2" size="large">H1 size extra large</Heading>))
-  .add('h3 large', () => (<Heading tagName="h2" size="large">H1 size extra large</Heading>))
-  .add('h4 large', () => (<Heading tagName="h2" size="large">H1 size extra large</Heading>))
+  .add('h1 xlarge bold', () => (<Heading tagName="h1" size="xlarge" bold>H1 size extra large</Heading>))
+  .add('h2 large bold', () => (<Heading tagName="h2" size="large" bold>H2 size large</Heading>))
+  .add('h3 medium', () => (<Heading tagName="h3" size="medium">H3 size medium</Heading>))
+  .add('h4 small', () => (<Heading tagName="h3" size="small">H4 size small</Heading>))
 
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)

--- a/stories/index.js
+++ b/stories/index.js
@@ -63,8 +63,8 @@ storiesOf('Text Input', module)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
 storiesOf('Heading', module)
-  .add('h1 ', () => <Heading tagName="h1">H1, 22px bold</Heading>)
-  .add('h2', () => <Heading tagName="h2">H2, 18px bold</Heading>)
+  .add('h1 ', () => <Heading tagName="h1">H1, 22px</Heading>)
+  .add('h2', () => <Heading tagName="h2">H2, 18px</Heading>)
   .add('h3', () => <Heading tagName="h3">H3, 16px</Heading>)
   .add('h4', () => <Heading tagName="h4">H4, 14px</Heading>);
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -4,6 +4,7 @@ import Button from '../src/components/buttons/button';
 import TooltipContainer from '../src/components/tooltips/tooltip-container';
 import TextInput from '../src/components/fields/text-input';
 import TextArea from '../src/components/fields/text-area';
+import Heading from '../src/components/text/heading';
 import Markdown from '../src/components/text/markdown';
 
 storiesOf('Button', module)
@@ -60,6 +61,12 @@ storiesOf('Text Input', module)
   .add('search', () => <TextInput type="search" opaque={true} search={true} placeholder="bots, apps, users" />)
   .add('with error', () => <TextInput placeholder="glitch" error="That team already exists" />)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
+
+storiesOf('Heading', module)
+  .add('h1 xlarge', () => (<Heading tagName="h1" size="xlarge">H1 size extra large</Heading>))
+  .add('h2 large', () => (<Heading tagName="h2" size="large">H1 size extra large</Heading>))
+  .add('h3 large', () => (<Heading tagName="h2" size="large">H1 size extra large</Heading>))
+  .add('h4 large', () => (<Heading tagName="h2" size="large">H1 size extra large</Heading>))
 
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)

--- a/stories/index.js
+++ b/stories/index.js
@@ -63,10 +63,10 @@ storiesOf('Text Input', module)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
 storiesOf('Heading', module)
-  .add('h1 ', () => (<Heading tagName="h1">H1, 22px bold</Heading>))
-  .add('h2', () => (<Heading tagName="h2">H2, 18px bold</Heading>))
-  .add('h3', () => (<Heading tagName="h3">H3, 16px</Heading>))
-  .add('h4', () => (<Heading tagName="h4">H4, 14px</Heading>))
+  .add('h1 ', () => <Heading tagName="h1">H1, 22px bold</Heading>)
+  .add('h2', () => <Heading tagName="h2">H2, 18px bold</Heading>)
+  .add('h3', () => <Heading tagName="h3">H3, 16px</Heading>)
+  .add('h4', () => <Heading tagName="h4">H4, 14px</Heading>);
 
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)

--- a/stories/index.js
+++ b/stories/index.js
@@ -62,6 +62,12 @@ storiesOf('Text Input', module)
   .add('with error', () => <TextInput placeholder="glitch" error="That team already exists" />)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
+storiesOf('Heading', module)
+  .add('h1 xlarge bold', () => (<Heading tagName="h1">H1, size extra large, bold</Heading>))
+  .add('h2 large bold', () => (<Heading tagName="h2">H2, size large, bold</Heading>))
+  .add('h3 medium', () => (<Heading tagName="h3">H3, size medium</Heading>))
+  .add('h4 small', () => (<Heading tagName="h3">H4, size small</Heading>))
+
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)
   .add('truncated', () => <Markdown length={35}>35 characters of rendered __Markdown__ (and a little **more**)</Markdown>);

--- a/stories/index.js
+++ b/stories/index.js
@@ -63,10 +63,10 @@ storiesOf('Text Input', module)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
 storiesOf('Heading', module)
-  .add('h1 xlarge bold', () => (<Heading tagName="h1" size="xlarge" bold>H1 size extra large</Heading>))
-  .add('h2 large bold', () => (<Heading tagName="h2" size="large" bold>H2 size large</Heading>))
-  .add('h3 medium', () => (<Heading tagName="h3" size="medium">H3 size medium</Heading>))
-  .add('h4 small', () => (<Heading tagName="h3" size="small">H4 size small</Heading>))
+  .add('h1 xlarge bold', () => (<Heading tagName="h1">H1, size extra large, bold</Heading>))
+  .add('h2 large bold', () => (<Heading tagName="h2">H2, size large, bold</Heading>))
+  .add('h3 medium', () => (<Heading tagName="h3">H3, size medium</Heading>))
+  .add('h4 small', () => (<Heading tagName="h3">H4, size small</Heading>))
 
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)

--- a/stories/index.js
+++ b/stories/index.js
@@ -62,12 +62,6 @@ storiesOf('Text Input', module)
   .add('with error', () => <TextInput placeholder="glitch" error="That team already exists" />)
   .add('text area', () => <TextArea placeholder="[Something here] doesn't seem appropriate for Glitch because..." error="Reason is required" />);
 
-storiesOf('Heading', module)
-  .add('h1 xlarge bold', () => (<Heading tagName="h1">H1, size extra large, bold</Heading>))
-  .add('h2 large bold', () => (<Heading tagName="h2">H2, size large, bold</Heading>))
-  .add('h3 medium', () => (<Heading tagName="h3">H3, size medium</Heading>))
-  .add('h4 small', () => (<Heading tagName="h3">H4, size small</Heading>))
-
 storiesOf('Markdown', module)
   .add('regular', () => <Markdown>Some __Markdown__</Markdown>)
   .add('truncated', () => <Markdown length={35}>35 characters of rendered __Markdown__ (and a little **more**)</Markdown>);


### PR DESCRIPTION
Adding a Heading component and using it in the user profile presenter.

- [x] Created new Heading component
- [x] Added to Storybook
- [x] Used in user profile presenter

Areas to check:
- Storybook
- User profiles

Quick links:
- [Olivia's profile with changes](https://kiwi-poinsettia.glitch.me/@oliviacpu)
- [Olivia's profile on production](https://glitch.com/@oliviacpu)

~💁 I decoupled presentation from the tag being used, but for now it can be used as a 1:1 replacement for h1-h4 by just using `tagName`. There's a comment where things are set to default for now.~

I'm going to continue to replace the rest of the header components in small PRs after this is merged to keep the potential for conflicts low.