### PR TITLE
Tree odometer: put new collection items at beginning of collection

### DIFF
--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { orderBy } from 'lodash';
 
 import { useCurrentUser } from './current-user';
 import useErrorHandlers from './error-handlers';
@@ -33,7 +34,7 @@ class CollectionEditor extends React.Component {
     if (collection.id === this.state.id) {
       // add project to collection page
       this.setState(({ projects }) => ({
-        projects: [...projects, project],
+        projects: orderBy([...projects, project], (p) => p.updatedAt),
       }));
     }
     await this.props.api.patch(`collections/${collection.id}/add/${project.id}`);

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { orderBy } from 'lodash';
 
 import { useCurrentUser } from './current-user';
 import useErrorHandlers from './error-handlers';
@@ -34,7 +33,7 @@ class CollectionEditor extends React.Component {
     if (collection.id === this.state.id) {
       // add project to collection page
       this.setState(({ projects }) => ({
-        projects: orderBy([...projects, project], (p) => p.updatedAt),
+        projects: [project, ...projects],
       }));
     }
     await this.props.api.patch(`collections/${collection.id}/add/${project.id}`);

--- a/src/presenters/collections-list.js
+++ b/src/presenters/collections-list.js
@@ -144,7 +144,7 @@ export class CreateCollectionButton extends React.Component {
 CreateCollectionButton.propTypes = {
   api: PropTypes.any.isRequired,
   currentUser: PropTypes.object.isRequired,
-  maybeTeam: PropTypes.object,
+maybeTeam: PropTypes.object,
 };
 
 CreateCollectionButton.defaultProps = {

--- a/src/presenters/collections-list.js
+++ b/src/presenters/collections-list.js
@@ -144,7 +144,7 @@ export class CreateCollectionButton extends React.Component {
 CreateCollectionButton.propTypes = {
   api: PropTypes.any.isRequired,
   currentUser: PropTypes.object.isRequired,
-maybeTeam: PropTypes.object,
+  maybeTeam: PropTypes.object,
 };
 
 CreateCollectionButton.defaultProps = {


### PR DESCRIPTION
The API orders projects in a collection by the order they're added. Make the optimistic update match this.

Fixes https://glitch.manuscript.com/f/cases/3327898/