### PR TITLE
Text / Heading - Replacement

### DIFF
--- a/src/presenters/collections-list.js
+++ b/src/presenters/collections-list.js
@@ -8,6 +8,8 @@ import { getLink, createCollection } from '../models/collection';
 import { Loader } from './includes/loader';
 import { NotificationConsumer } from './notifications';
 
+import Heading from '../components/text/heading';
+
 class CollectionsList extends React.Component {
   constructor(props) {
     super(props);
@@ -37,7 +39,7 @@ class CollectionsList extends React.Component {
     }
     return (
       <article className="collections">
-        <h2>{title}</h2>
+        <Heading tagName="h2">{title}</Heading>
         {canMakeCollections && (
           <>
             <CreateCollectionButton {...{ api, currentUser: maybeCurrentUser, maybeTeam }} />

--- a/src/presenters/deleted-projects.js
+++ b/src/presenters/deleted-projects.js
@@ -8,6 +8,8 @@ import { getAvatarUrl } from '../models/project';
 import { TrackClick } from './analytics';
 import { Loader } from './includes/loader';
 
+import Heading from '../components/text/heading';
+
 function clickUndelete(event, callback) {
   const node = event.target.closest('li');
   node.addEventListener('animationend', callback, { once: true });
@@ -101,9 +103,9 @@ export default class DeletedProjects extends React.Component {
   render() {
     return (
       <article className="deleted-projects">
-        <h2>
+        <Heading tagName="h2">
           Deleted Projects <span className="emoji bomb emoji-in-title" />
-        </h2>
+        </Heading>
         {this.renderContents()}
       </article>
     );

--- a/src/presenters/entity-page-featured-project.js
+++ b/src/presenters/entity-page-featured-project.js
@@ -8,6 +8,8 @@ import ReportButton from './pop-overs/report-abuse-pop';
 import AddProjectToCollection from './includes/add-project-to-collection';
 import { TrackClick } from './analytics';
 
+import Heading from '../components/text/heading';
+
 const EntityPageFeaturedProject = ({ api, isAuthorized, currentUser, unfeatureProject, addProjectToCollection, featuredProject }) => {
   const reportBtn = (
     <div className="buttons buttons-left">
@@ -25,7 +27,7 @@ const EntityPageFeaturedProject = ({ api, isAuthorized, currentUser, unfeaturePr
   return (
     <>
       <section id="featured-project-embed">
-        <h2>{featuredTitle}</h2>
+        <Heading tagName="h2">{featuredTitle}</Heading>
 
         {isAuthorized && <FeaturedProjectOptionsPop unfeatureProject={unfeatureProject} />}
         <Embed domain={featuredProject.domain} />

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -17,6 +17,8 @@ import { ProjectsUL } from './projects-list';
 import { TeamTile } from './teams-list';
 import { UserTile } from './users-list';
 
+import Heading from '../components/text/heading';
+
 const CollectionWide = ({ collection, api }) => {
   const dark = isDarkColor(collection.coverColor) ? 'dark' : '';
   return (
@@ -26,7 +28,7 @@ const CollectionWide = ({ collection, api }) => {
           <CollectionAvatar color={collection.coverColor} />
         </CollectionLink>
         <CollectionLink className="collection-name" collection={collection}>
-          <h2>{collection.name}</h2>
+          <Heading tagName="h2">{collection.name}</Heading>
         </CollectionLink>
         {!!collection.team && <TeamTile team={collection.team} />}
         {!!collection.user && <UserTile {...collection.user} />}

--- a/src/presenters/featured-embed.js
+++ b/src/presenters/featured-embed.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Link } from './includes/link';
 import Embed from './includes/embed';
 
+import Heading from '../components/text/heading';
+
 const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) => (
   <div className="featured-embed">
     <div className="mask-container">
@@ -15,7 +17,7 @@ const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) 
     <div className="content" style={{ backgroundColor: color }}>
       <div className="description">
         <Link to={`culture${blogUrl}`}>
-          <h2>{title}</h2>
+          <Heading tagName="h2">{title}</Heading>
         </Link>
         {/* eslint-disable-next-line react/no-danger */}
         <p dangerouslySetInnerHTML={{ __html: body }} />

--- a/src/presenters/more-ideas.js
+++ b/src/presenters/more-ideas.js
@@ -12,7 +12,7 @@ import Heading from '../components/text/heading';
 
 const MoreIdeasCollectionsDisplay = ({ collections }) => (
   <section className="more-ideas">
-    <Heading tagName="h2">More Ideas</h2>
+    <Heading tagName="h2">More Ideas</Heading>
     <ul>
       {collections.map((collection) => (
         <li key={collection.id}>
@@ -49,7 +49,7 @@ export const MoreIdeasCollections = ({ api }) => (
 
 export const MoreIdeasCategories = () => (
   <section className="more-ideas">
-    <h2>More Ideas</h2>
+    <Heading tagName="h2">More Ideas</Heading>
     <ul>
       {categories.map((category) => (
         <li key={category.id}>

--- a/src/presenters/more-ideas.js
+++ b/src/presenters/more-ideas.js
@@ -8,9 +8,11 @@ import CollectionAvatar from './includes/collection-avatar';
 import { CollectionLink, Link } from './includes/link';
 import { DataLoader } from './includes/loader';
 
+import Heading from '../components/text/heading';
+
 const MoreIdeasCollectionsDisplay = ({ collections }) => (
   <section className="more-ideas">
-    <h2>More Ideas</h2>
+    <Heading tagName="h2">More Ideas</h2>
     <ul>
       {collections.map((collection) => (
         <li key={collection.id}>

--- a/src/presenters/pages/category.js
+++ b/src/presenters/pages/category.js
@@ -13,6 +13,8 @@ import MoreIdeas from '../more-ideas';
 import CollectionEditor from '../collection-editor';
 import { CurrentUserConsumer } from '../current-user';
 
+import Heading from '../../components/text/heading';
+
 const CategoryPageWrap = ({ addProjectToCollection, api, category, currentUser, ...props }) => (
   <>
     <Helmet>
@@ -21,7 +23,7 @@ const CategoryPageWrap = ({ addProjectToCollection, api, category, currentUser, 
     <main className="collection-page">
       <article className="projects collection-full" style={{ backgroundColor: category.backgroundColor }}>
         <header className="collection">
-          <h1 className="collection-name">{category.name}</h1>
+          <Heading tagName="h1">{category.name}</Heading>
           <div className="collection-image-container">
             <img src={category.avatarUrl} alt="" />
           </div>
@@ -33,7 +35,7 @@ const CategoryPageWrap = ({ addProjectToCollection, api, category, currentUser, 
           {(projects) => (
             <div className="collection-contents">
               <div className="collection-project-container-header">
-                <h3>Projects ({category.projects.length})</h3>
+                <Heading tagName="h3">Projects ({category.projects.length})</Heading>
               </div>
 
               {currentUser.login ? (

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -27,6 +27,8 @@ import { UserTile } from '../users-list';
 
 import { CurrentUserConsumer } from '../current-user';
 
+import Heading from '../../components/text/heading';
+
 function syncPageToUrl(collection, url) {
   history.replaceState(null, null, getLink({ ...collection, url }));
 }
@@ -121,7 +123,7 @@ const CollectionPageContents = ({
               <>
                 <div className="collection-contents">
                   <div className="collection-project-container-header">
-                    <h3>Projects ({collection.projects.length})</h3>
+                    <Heading tagName="h3">Projects ({collection.projects.length})</Heading>
 
                     {!!isAuthorized && (
                       <AddCollectionProject

--- a/src/presenters/pages/error.js
+++ b/src/presenters/pages/error.js
@@ -9,6 +9,8 @@ import { getShowUrl } from '../../models/project';
 import { useCurrentUser } from '../current-user';
 import NotFound from '../includes/not-found';
 
+import Heading from '../../components/text/heading';
+
 const telescopeImageUrl = 'https://cdn.glitch.com/7138972f-76e1-43f4-8ede-84c3cdd4b40a%2Ftelescope_404.svg?1543258683849';
 
 export const NotFoundPage = ({ api }) => (
@@ -17,7 +19,7 @@ export const NotFoundPage = ({ api }) => (
     <main className="error-page-container">
       <img className="error-image" src={telescopeImageUrl} alt="" width="318px" height="297px" />
       <div className="error-msg">
-        <h1>Page Not Found</h1>
+        <Heading tagName="h1">Page Not Found</Heading>
         <p>Maybe a typo, or perhaps it's moved?</p>
         <a className="button button-link" href="/">
           Back to Glitch

--- a/src/presenters/pages/index.js
+++ b/src/presenters/pages/index.js
@@ -15,6 +15,8 @@ import Questions from '../questions';
 import RecentProjects from '../recent-projects';
 import ReportButton from '../pop-overs/report-abuse-pop';
 
+import Heading from '../../components/text/heading';
+
 function loadScript(src) {
   const script = document.createElement('script');
   script.src = src;
@@ -63,10 +65,10 @@ class WhatIsGlitch extends React.Component {
       <section className="what-is-glitch">
         <span>
           <figure>
-            <h1>
+            <Heading tagName="h1">
               <img className="witch large" src={witchLarge} alt={whatsGlitchAlt} />
               <img className="witch small" src={witchSmall} alt={whatsGlitchAlt} />
-            </h1>
+            </Heading>
 
             <OverlayVideo>
               <div className="button video">

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -11,6 +11,7 @@ import { AnalyticsContext } from '../analytics';
 import TooltipContainer from '../../components/tooltips/tooltip-container';
 import { DataLoader } from '../includes/loader';
 import NotFound from '../includes/not-found';
+import Heading from '../../components/text/heading';
 import Markdown from '../../components/text/markdown';
 import ProjectEditor from '../project-editor';
 import Expander from '../includes/expander';
@@ -105,7 +106,7 @@ const ProjectPage = ({ project, addProjectToCollection, api, currentUser, isAuth
       <section id="info">
         <InfoContainer>
           <ProjectInfoContainer style={{ backgroundImage: `url('${getAvatarUrl(project.id)}')` }}>
-            <h1>
+            <Heading tagName="h1">
               {isAuthorized ? (
                 <EditableField
                   value={domain}
@@ -118,7 +119,7 @@ const ProjectPage = ({ project, addProjectToCollection, api, currentUser, isAuth
                   {domain} {project.private && <PrivateBadge />}
                 </>
               )}
-            </h1>
+            </Heading>
             <div className="users-information">
               <UsersList users={users} />
               {!!teams.length && <TeamsList teams={teams} />}

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -14,9 +14,11 @@ import ProjectsList from '../projects-list';
 import TeamItem from '../team-item';
 import UserItem from '../user-item';
 
+import Heading from '../../components/text/heading';
+
 const TeamResults = ({ teams }) => (
   <article>
-    <h2>Teams</h2>
+    <Heading tagName="h2">Teams</Heading>
     <ul className="teams-container">
       {teams ? (
         teams.map((team) => (
@@ -33,7 +35,7 @@ const TeamResults = ({ teams }) => (
 
 const UserResults = ({ users }) => (
   <article>
-    <h2>Users</h2>
+    <Heading tagName="h2">Users</Heading>
     <ul className="users-container">
       {users ? (
         users.map((user) => (
@@ -52,7 +54,7 @@ const ProjectResults = ({ addProjectToCollection, api, projects, currentUser }) 
   if (!projects) {
     return (
       <article>
-        <h2>Projects</h2>
+        <Heading tagName="h2">Projects</Heading>
         <Loader />
       </article>
     );

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -29,15 +29,17 @@ import TeamAnalytics from '../includes/team-analytics';
 import { TeamMarketing, VerifiedBadge } from '../includes/team-elements';
 import ReportButton from '../pop-overs/report-abuse-pop';
 
+import Heading from '../../components/text/heading';
+
 function syncPageToUrl(team) {
   history.replaceState(null, null, getLink(team));
 }
 
 const TeamNameUrlFields = ({ team, updateName, updateUrl }) => (
   <>
-    <h1>
+    <Heading tagName="h1">
       <EditableField value={team.name} update={updateName} placeholder="What's its name?" suffix={team.isVerified ? <VerifiedBadge /> : null} />
-    </h1>
+    </Heading>
     <p className="team-url">
       <EditableField
         value={team.url}
@@ -140,7 +142,7 @@ class TeamPage extends React.Component {
           <a href="/teams/" target="_blank" className="beta">
             <img src="https://cdn.glitch.com/0c3ba0da-dac8-4904-bb5e-e1c7acc378a2%2Fbeta-flag.svg?1541448893958" alt="" />
             <div>
-              <h4>Teams are in beta</h4>
+              <Heading tagName="h4">Teams are in beta</Heading>
               <p>Learn More</p>
             </div>
           </a>
@@ -158,9 +160,9 @@ class TeamPage extends React.Component {
               <TeamNameUrlFields team={team} updateName={this.props.updateName} updateUrl={this.props.updateUrl} />
             ) : (
               <>
-                <h1>
+                <Heading tagName="h1">
                   {team.name} {team.isVerified && <VerifiedBadge />}
-                </h1>
+                </Heading>
                 <p className="team-url">@{team.url}</p>
               </>
             )}

--- a/src/presenters/projects-list.js
+++ b/src/presenters/projects-list.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ProjectItem from './project-item';
 
+import Heading from '../components/text/heading';
+
 const ProjectsList = ({ title, placeholder, extraClasses, ...props }) => (
   <article className={`projects ${extraClasses}`}>
-    <h2>{title}</h2>
+    <Heading tagName="h2">{title}</Heading>
 
     {!!(placeholder && !props.projects.length) && <div className="placeholder">{placeholder}</div>}
 

--- a/src/presenters/questions.js
+++ b/src/presenters/questions.js
@@ -9,6 +9,8 @@ import { Link } from './includes/link';
 import QuestionItem from './question-item';
 import { captureException } from '../utils/sentry';
 
+import Heading from '../components/text/heading';
+
 const kaomojis = ['八(＾□＾*)', '(ノ^_^)ノ', 'ヽ(*ﾟｰﾟ*)ﾉ', '♪(┌・。・)┌', 'ヽ(๏∀๏ )ﾉ', 'ヽ(^。^)丿'];
 
 const QuestionTimer = ({ animating, callback }) => (
@@ -70,9 +72,9 @@ class Questions extends React.Component {
     const { kaomoji, loading, questions } = this.state;
     return (
       <section className="questions">
-        <h2>
+        <Heading tagName="h2">
           <Link to="/questions">Help Others, Get Thanks →</Link> <QuestionTimer animating={!loading} callback={() => this.load()} />
-        </h2>
+        </Heading>
         <article className="projects">
           {questions.length ? (
             <ErrorBoundary>

--- a/src/presenters/recent-projects.js
+++ b/src/presenters/recent-projects.js
@@ -11,11 +11,13 @@ import ProjectsLoader from './projects-loader';
 import { ProjectsUL } from './projects-list';
 import SignInPop from './pop-overs/sign-in-pop';
 
+import Heading from '../components/text/heading';
+
 const RecentProjectsContainer = ({ children, user, api }) => (
   <section className="profile recent-projects">
-    <h2>
+    <Heading tagName="h2">
       <UserLink user={user}>Your Projects →</UserLink>
-    </h2>
+    </Heading>
     <CoverContainer style={getProfileStyle(user)}>
       <div className="profile-avatar">
         <div className="user-avatar-container">


### PR DESCRIPTION
Using the new `Heading` component.

- [x] Replace all `<h1>...<h4>` tags with `Heading` component

I went ahead and did them all because it wasn't as large of a change as I thought.

The one place where a `className` was removed was the Category page, and there is a slight difference in spacing between this remix and production.

- [Building Blocks category on production](https://glitch.com/building-blocks)
- [Building Blocks category on this remix](https://indigo-closet.glitch.me/building-blocks)