### PR TITLE
Better settee: sample collections _before_ fetching all of their data

### DIFF
--- a/shared/api.js
+++ b/shared/api.js
@@ -2,7 +2,7 @@
 
 const joinIdsToQueryString = (ids) => {
   return ids.map((id) => `id=${id}`).join('&');
-}
+};
 
 const getFromApi = async (api, url) => {
   const { data } = await api.get(url);
@@ -24,17 +24,20 @@ const getSingleItem = async (api, url, key) => {
   return null;
 };
 
-const getAllPages = async (api, url) => {
+const getPages = async (api, url, maxPages = 1) => {
   let hasMore = true;
   let results = [];
-  while (hasMore) {
+  while (hasMore && maxPages > 0) {
     const data = await getFromApi(api, url);
     results.push(...data.items);
     hasMore = data.hasMore;
     url = data.nextPage;
+    maxPages--;
   }
   return results;
 };
+
+const getAllPages = (api, url) => getPages(api, url, Infinity)
 
 // like Promise.all but with an object instead of an array, e.g.
 // `let { user, projects } = await allByKeys({ user: getUser(id), projects: getProjects(id) })`
@@ -51,6 +54,7 @@ module.exports = {
   joinIdsToQueryString,
   getFromApi,
   getSingleItem,
+  getPages,
   getAllPages,
   allByKeys,
 };

--- a/shared/api.js
+++ b/shared/api.js
@@ -24,20 +24,17 @@ const getSingleItem = async (api, url, key) => {
   return null;
 };
 
-const getPages = async (api, url, maxPages = 1) => {
+const getAllPages = async (api, url) => {
   let hasMore = true;
   let results = [];
-  while (hasMore && maxPages > 0) {
+  while (hasMore) {
     const data = await getFromApi(api, url);
     results.push(...data.items);
     hasMore = data.hasMore;
     url = data.nextPage;
-    maxPages--;
   }
   return results;
 };
-
-const getAllPages = (api, url) => getPages(api, url, Infinity)
 
 // like Promise.all but with an object instead of an array, e.g.
 // `let { user, projects } = await allByKeys({ user: getUser(id), projects: getProjects(id) })`
@@ -54,7 +51,6 @@ module.exports = {
   joinIdsToQueryString,
   getFromApi,
   getSingleItem,
-  getPages,
   getAllPages,
   allByKeys,
 };

--- a/src/presenters/includes/included-in-collections.js
+++ b/src/presenters/includes/included-in-collections.js
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { sampleSize } from 'lodash';
-import { getSingleItem, getAllPages, allByKeys } from '../../../shared/api';
+import { getSingleItem, getPages, getAllPages, allByKeys } from '../../../shared/api';
 
 import CollectionItem from '../collection-item';
 
 const getIncludedCollections = async (api, projectId) => {
   const collections = await getAllPages(api, `/v1/projects/by/id/collections?id=${projectId}&limit=100&orderKey=createdAt&orderDirection=DESC`);
-  const withData = await Promise.all(
-    collections.map(async (collection) => {
+  const selectedCollections = sampleSize(collections, 3);
+  return Promise.all(
+    selectedCollections.map(async (collection) => {
       const { projects, user, team } = await allByKeys({
         projects: getAllPages(api, `/v1/collections/by/id/projects?id=${collection.id}&limit=100&orderKey=createdAt&orderDirection=DESC`),
         user: collection.user && getSingleItem(api, `v1/users/by/id?id=${collection.user.id}`, collection.user.id),
@@ -16,7 +17,6 @@ const getIncludedCollections = async (api, projectId) => {
       return { ...collection, projects, user, team };
     }),
   );
-  return sampleSize(withData, 3);
 };
 
 const useAsync = (asyncFunction, ...args) => {

--- a/src/presenters/includes/included-in-collections.js
+++ b/src/presenters/includes/included-in-collections.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { sampleSize } from 'lodash';
-import { getSingleItem, getPages, getAllPages, allByKeys } from '../../../shared/api';
+import { getSingleItem, getAllPages, allByKeys } from '../../../shared/api';
 
 import CollectionItem from '../collection-item';
 


### PR DESCRIPTION
We don't need to fetch the projects, users, etc of collections that won't even make it out of this function