### PR TITLE
Wooded moose: improve flow when removing member from team

### DIFF
--- a/src/presenters/pop-overs/team-user-info-pop.js
+++ b/src/presenters/pop-overs/team-user-info-pop.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getAvatarThumbnailUrl } from '../../models/user';
+import { getAvatarThumbnailUrl, getDisplayName } from '../../models/user';
 
 import { TrackClick } from '../analytics';
 import { NestedPopover } from './popover-nested';
@@ -75,7 +75,7 @@ const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, ...prop
   const currentUserHasRemovePriveleges = currentUserIsTeamAdmin || (currentUser && currentUser.id === props.user.id);
   const canRemoveUser = !(props.userIsTheOnlyMember || props.userIsTheOnlyAdmin);
   const canCurrentUserRemoveUser = canRemoveUser && currentUserHasRemovePriveleges;
-
+  
   return (
     <dialog className="pop-over team-user-info-pop">
       <section className="pop-over-info user-info">
@@ -122,11 +122,28 @@ const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, ...prop
 // Team User Info or Remove
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
-const TeamUserInfoAndRemovePop = (props) => (
-  <NestedPopover alternateContent={() => <TeamUserRemovePop {...props} />}>
-    {(showRemove) => <TeamUserInfo {...props} showRemove={showRemove} />}
-  </NestedPopover>
-);
+const TeamUserInfoAndRemovePop = (props) => {
+  function removeUser(selectedProjects = []) {
+    props.createNotification(`${getDisplayName(props.user)} removed from Team`);
+    props.removeUserFromTeam(props.user.id, Array.from(selectedProjects));
+  }
+  
+  const [userTeamProjects, 
+  
+  async function getUserWithProjects() {
+    const { data } = await this.props.api.get(`users/${this.props.user.id}`);
+    this.setState({
+      userTeamProjects: data.projects.filter((userProj) => this.props.team.projects.some((teamProj) => teamProj.id === userProj.id)),
+      gettingUser: false,
+    });
+  }
+  
+  return (
+    <NestedPopover alternateContent={() => <TeamUserRemovePop {...props} removeUser={removeUser} />}>
+      {(showRemove) => <TeamUserInfo {...props} showRemove={showRemove} removeUser={removeUser} />}
+    </NestedPopover>
+  );
+}
 
 TeamUserInfoAndRemovePop.propTypes = {
   user: PropTypes.shape({

--- a/src/presenters/pop-overs/team-user-info-pop.js
+++ b/src/presenters/pop-overs/team-user-info-pop.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { getAvatarThumbnailUrl, getDisplayName } from '../../models/user';
@@ -128,19 +128,21 @@ const TeamUserInfoAndRemovePop = (props) => {
     props.removeUserFromTeam(props.user.id, Array.from(selectedProjects));
   }
   
-  const [userTeamProjects, 
+  const [userTeamProjects, setUserTeamProjects] = useState({ status: 'loading', data: null })
+  useEffect(() => {
+    props.api.get(`users/${props.user.id}`).then(({ data }) => {
+      setUserTeamProjects({
+        status: 'ready',
+        data: data.projects.filter((userProj) => props.team.projects.some((teamProj) => teamProj.id === userProj.id)),
+      })
+    })
+  }, [props.user.id])
   
-  async function getUserWithProjects() {
-    const { data } = await this.props.api.get(`users/${this.props.user.id}`);
-    this.setState({
-      userTeamProjects: data.projects.filter((userProj) => this.props.team.projects.some((teamProj) => teamProj.id === userProj.id)),
-      gettingUser: false,
-    });
-  }
+  const propsWithUserRemoval = { ...props, removeUser, userTeamProjects }
   
   return (
-    <NestedPopover alternateContent={() => <TeamUserRemovePop {...props} removeUser={removeUser} />}>
-      {(showRemove) => <TeamUserInfo {...props} showRemove={showRemove} removeUser={removeUser} />}
+    <NestedPopover alternateContent={() => <TeamUserRemovePop {...propsWithUserRemoval} />}>
+      {(showRemove) => <TeamUserInfo {...propsWithUserRemoval} showRemove={showRemove} />}
     </NestedPopover>
   );
 }

--- a/src/presenters/pop-overs/team-user-info-pop.js
+++ b/src/presenters/pop-overs/team-user-info-pop.js
@@ -8,7 +8,7 @@ import { NestedPopover } from './popover-nested';
 import { UserLink } from '../includes/link';
 import { Thanks } from '../includes/thanks';
 import TooltipContainer from '../../components/tooltips/tooltip-container';
-
+import { useNotifications } from '../notifications';
 import TeamUserRemovePop from './team-user-remove-pop';
 
 const MEMBER_ACCESS_LEVEL = 20;
@@ -132,11 +132,7 @@ const TeamUserInfo = ({ currentUser, currentUserIsTeamAdmin, showRemove, userTea
 // uses removeTeamUserVisible state to toggle between showing user info and remove views
 
 const TeamUserInfoAndRemovePop = (props) => {
-  function removeUser(selectedProjects = []) {
-    props.createNotification(`${getDisplayName(props.user)} removed from Team`);
-    props.removeUserFromTeam(props.user.id, Array.from(selectedProjects));
-  }
-
+  const { createNotification } = useNotifications();
   const [userTeamProjects, setUserTeamProjects] = useState({ status: 'loading', data: null });
   useEffect(() => {
     props.api.get(`users/${props.user.id}`).then(({ data }) => {
@@ -146,6 +142,11 @@ const TeamUserInfoAndRemovePop = (props) => {
       });
     });
   }, [props.user.id]);
+
+  function removeUser(selectedProjects = []) {
+    createNotification(`${getDisplayName(props.user)} removed from Team`);
+    props.removeUserFromTeam(props.user.id, Array.from(selectedProjects));
+  }
 
   const propsWithUserRemoval = { ...props, removeUser, userTeamProjects };
 

--- a/src/presenters/pop-overs/team-user-remove-pop.js
+++ b/src/presenters/pop-overs/team-user-remove-pop.js
@@ -5,12 +5,11 @@ import PropTypes from 'prop-types';
 
 import { TrackClick } from '../analytics';
 import { Loader } from '../includes/loader';
-import { NotificationConsumer } from '../notifications';
 import { NestedPopoverTitle } from './popover-nested';
 import { getAvatarThumbnailUrl, getDisplayName } from '../../models/user';
 import { getAvatarUrl as getProjectAvatarUrl } from '../../models/project';
 
-class TeamUserRemovePopBase extends React.Component {
+class TeamUserRemovePop extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -94,9 +93,11 @@ class TeamUserRemovePopBase extends React.Component {
       <dialog className="pop-over team-user-info-pop team-user-remove-pop">
         <NestedPopoverTitle>Remove {getDisplayName(this.props.user)}</NestedPopoverTitle>
 
-        {projects && <section className="pop-over-actions" id="user-team-projects">
-          {projects}
-        </section>}
+        {projects && (
+          <section className="pop-over-actions" id="user-team-projects">
+            {projects}
+          </section>
+        )}
 
         <section className="pop-over-actions danger-zone">
           <TrackClick name="Remove from Team submitted">
@@ -109,7 +110,7 @@ class TeamUserRemovePopBase extends React.Component {
     );
   }
 }
-TeamUserRemovePopBase.propTypes = {
+TeamUserRemovePop.propTypes = {
   user: PropTypes.shape({
     name: PropTypes.string,
     login: PropTypes.string,
@@ -126,9 +127,5 @@ TeamUserRemovePopBase.propTypes = {
   }).isRequired,
   removeUser: PropTypes.func.isRequired,
 };
-
-const TeamUserRemovePop = (props) => (
-  <NotificationConsumer>{(notifyFuncs) => <TeamUserRemovePopBase {...notifyFuncs} {...props} />}</NotificationConsumer>
-);
 
 export default TeamUserRemovePop;

--- a/src/presenters/pop-overs/team-user-remove-pop.js
+++ b/src/presenters/pop-overs/team-user-remove-pop.js
@@ -24,11 +24,11 @@ class TeamUserRemovePopBase extends React.Component {
 
   removeUser() {
     this.props.togglePopover();
-    this.props.removeUser(this.props.user.id, Array.from(this.state.selectedProjects));
+    this.props.removeUser(Array.from(this.state.selectedProjects));
   }
 
   selectAllProjects() {
-    const userTeamProjects = this.props.userTeamProjects.data || []
+    const userTeamProjects = this.props.userTeamProjects.data || [];
     this.setState({
       selectedProjects: new Set(userTeamProjects.map((p) => p.id)),
     });
@@ -54,14 +54,14 @@ class TeamUserRemovePopBase extends React.Component {
   }
 
   render() {
-    const userTeamProjects = this.props.userTeamProjects.data || []
+    const userTeamProjects = this.props.userTeamProjects.data || [];
     const allProjectsSelected = userTeamProjects.every((p) => this.state.selectedProjects.has(p.id));
     const userAvatarStyle = { backgroundColor: this.props.user.color };
 
     let projects = null;
     if (this.props.userTeamProjects.status === 'loading') {
       projects = <Loader />;
-    } else  {
+    } else if (userTeamProjects.length > 0) {
       projects = (
         <>
           <p className="action-description">Also remove them from these projects</p>
@@ -94,9 +94,9 @@ class TeamUserRemovePopBase extends React.Component {
       <dialog className="pop-over team-user-info-pop team-user-remove-pop">
         <NestedPopoverTitle>Remove {getDisplayName(this.props.user)}</NestedPopoverTitle>
 
-        <section className="pop-over-actions" id="user-team-projects">
+        {projects && <section className="pop-over-actions" id="user-team-projects">
           {projects}
-        </section>
+        </section>}
 
         <section className="pop-over-actions danger-zone">
           <TrackClick name="Remove from Team submitted">
@@ -110,7 +110,6 @@ class TeamUserRemovePopBase extends React.Component {
   }
 }
 TeamUserRemovePopBase.propTypes = {
-  api: PropTypes.func.isRequired,
   user: PropTypes.shape({
     name: PropTypes.string,
     login: PropTypes.string,

--- a/src/presenters/pop-overs/team-user-remove-pop.js
+++ b/src/presenters/pop-overs/team-user-remove-pop.js
@@ -38,8 +38,7 @@ class TeamUserRemovePopBase extends React.Component {
 
   removeUser() {
     this.props.togglePopover();
-    this.props.createNotification(`${getDisplayName(this.props.user)} removed from Team`);
-    this.props.removeUserFromTeam(this.props.user.id, Array.from(this.state.selectedProjects));
+    this.props.removeUser(this.props.user.id, Array.from(this.state.selectedProjects));
   }
 
   selectAllProjects() {
@@ -107,9 +106,9 @@ class TeamUserRemovePopBase extends React.Component {
       <dialog className="pop-over team-user-info-pop team-user-remove-pop">
         <NestedPopoverTitle>Remove {getDisplayName(this.props.user)}</NestedPopoverTitle>
 
-        <section className="pop-over-actions" id="user-team-projects">
-          {projects || <p className="action-description">{getDisplayName(this.props.user)} is not a member of any projects</p>}
-        </section>
+        {projects && <section className="pop-over-actions" id="user-team-projects">
+          {projects}
+        </section>}
 
         <section className="pop-over-actions danger-zone">
           <TrackClick name="Remove from Team submitted">
@@ -134,8 +133,7 @@ TeamUserRemovePopBase.propTypes = {
   team: PropTypes.shape({
     projects: PropTypes.array.isRequired,
   }).isRequired,
-  removeUserFromTeam: PropTypes.func.isRequired,
-  createNotification: PropTypes.func.isRequired,
+  removeUser: PropTypes.func.isRequired,
 };
 
 const TeamUserRemovePop = (props) => (


### PR DESCRIPTION
See https://glitch.manuscript.com/f/cases/3327687/

When removing a user from a team, there's a second popover that asks if you want to (also) remove them from the team's projects, or just the team itself. This is unnecessary and somewhat confusing if they aren't a member of any projects.

This PR moves much of the logic for removing team members from the `remove` popover and into the `info` popover, so that the remove one doesn't even need to be rendered in this particular case.

NB this is an excellent example of how putting our logic nearest to the UI that uses it makes refactoring kind of complicated.