### PR TITLE
Nova chance: Updated embed support check to account for polyfills

### DIFF
--- a/src/presenters/includes/embed.js
+++ b/src/presenters/includes/embed.js
@@ -18,7 +18,7 @@ class Embed extends React.Component {
   browserSatisfiesRequirements = () => {
     try {
       if (URLSearchParams.name !== 'URLSearchParams') {
-        throw new Error('URLSearchParams is minified, so it must be polyfilled');
+        throw new Error('URLSearchParams is minified, so it must have been polyfilled');
       }
       return true;
     } catch (error) {

--- a/src/presenters/includes/embed.js
+++ b/src/presenters/includes/embed.js
@@ -17,18 +17,17 @@ class Embed extends React.Component {
   // TODO(sheridan) make this more robust in future
   browserSatisfiesRequirements = () => {
     try {
-      /* eslint-disable */
-      new URLSearchParams();
-      /* eslint-enable */
-
+      if (URLSearchParams.name !== 'URLSearchParams') {
+        throw new Error('URLSearchParams is minified, so it must be polyfilled');
+      }
       return true;
     } catch (error) {
       console.log(
         "Sorry, you don't have the necessary JavaScript features to run Glitch code editors. Try applying your latest system updates, or try again with a different web browser.",
         error,
       );
-      return false;
     }
+    return false;
   };
 
   render() {


### PR DESCRIPTION
This won't work for dev builds, but we don't do any sort of babel stuff so the whole site breaks anyways.

Instead of checking if URLSearchParams exists, check if we're using the polyfilled version by checking if it is polyfilled and has a junk name value.