### PR TITLE
Fixes to component styles

### DIFF
--- a/src/components/buttons/button.styl
+++ b/src/components/buttons/button.styl
@@ -5,6 +5,7 @@ button.btn
   font-size: 14px
   line-height: 14px
   font-weight: 600
+  font-family: sansserif
   background-color: white
   border: solid primary 2px
   display: inline-block

--- a/src/components/constants.styl
+++ b/src/components/constants.styl
@@ -46,3 +46,11 @@ largeViewport = 900px
 hugeViewport = 1080px
 
 side-padding = 20px
+
+*
+  box-sizing: border-box
+
+body
+  font-family: sansserif
+  color: primary
+  margin: 0

--- a/src/components/constants.styl
+++ b/src/components/constants.styl
@@ -46,11 +46,3 @@ largeViewport = 900px
 hugeViewport = 1080px
 
 side-padding = 20px
-
-*
-  box-sizing: border-box
-
-body
-  font-family: sansserif
-  color: primary
-  margin: 0

--- a/src/components/text/heading.js
+++ b/src/components/text/heading.js
@@ -1,13 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 import styles from './heading.styl';
+
+const cx = classNames.bind(styles);
 
 export const TAGS = ['h1', 'h2', 'h3', 'h4'];
 
 /**
  * Heading Component
  */
-const Heading = ({ children, tagName: TagName }) => <TagName className={styles[TagName]}>{children}</TagName>;
+const Heading = ({ children, tagName: TagName }) => {
+  const classNameObj = {
+    heading: true,
+  };
+  classNameObj[TagName] = true;
+
+  return <TagName className={cx(classNameObj)}>{children}</TagName>;
+};
 
 Heading.propTypes = {
   /** element(s) to display in the button */

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -3,16 +3,18 @@
 .heading
   font-family: sansserif
 
-.h1
-  font-size: 22px
-  
-.h2
-  font-size: 18px
-  a
-    color: primary
+  &.h1
+    font-size: 22px
+  font-weight: bold
 
-.h3
-  font-size: 16px
+  &.h2
+    font-size: 18px
+  font-weight: bold
+    a
+      color: primary
 
-.h4
-  font-size: 14px
+  &.h3
+    font-size: 16px
+
+  &.h4
+    font-size: 14px

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -5,7 +5,7 @@
 
   &.h1
     font-size: 22px
-  font-weight: bold
+    font-weight: bold
 
   &.h2
     font-size: 18px

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -9,7 +9,7 @@
 
   &.h2
     font-size: 18px
-  font-weight: bold
+    font-weight: bold
     a
       color: primary
 

--- a/src/components/text/heading.styl
+++ b/src/components/text/heading.styl
@@ -1,5 +1,8 @@
 @require '../constants'
 
+.heading
+  font-family: sansserif
+
 .h1
   font-size: 22px
   

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -2,6 +2,7 @@
 
 .markdownContent
   text-rendering: optimizeLegibility
+  font-family: sansserif
   
   *:first-child
     margin-top: 0.5rem !important

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -11,6 +11,10 @@
     color: link
     &:hover
       text-decoration: underline
+  
+  p
+    line-height: 20px;
+    
   //p,
   pre,
   table,

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -3,6 +3,7 @@
 .markdownContent
   text-rendering: optimizeLegibility
   font-family: sansserif
+  line-height: 20px;
   
   *:first-child
     margin-top: 0.5rem !important
@@ -11,9 +12,6 @@
     color: link
     &:hover
       text-decoration: underline
-  
-  p
-    line-height: 20px;
     
   //p,
   pre,

--- a/src/components/tooltips/tooltip.styl
+++ b/src/components/tooltips/tooltip.styl
@@ -1,4 +1,4 @@
-@require '../../../styles/globals'
+@require '../constants'
 
 tooltip-background = rgba(0,0,0,0.95)
 


### PR DESCRIPTION
I think the tooltip component was build according to a bad implementation I'd done in the early days of CSS modules, and it was importing in the globals.styl file from the styles directory. This meant a bunch of styles that shouldn't have been available to the other components were available, so components looked fine in storybook when in fact they weren't self-composed.

Fixed a bunch of things but please let me know if you can see anything I missed! Everything is looking good at http://lumpy-organ.glitch.me/storybook