### PR TITLE
Metadata fixes

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -13,6 +13,7 @@ const generalCache = new Cache();
 const projectCache = new Cache();
 const teamCache = new Cache();
 const userCache = new Cache();
+const collectionCache = new Cache();
 
 async function getFromCacheOrApi(id, cache, api) {
   let promise = cache.get(id);
@@ -67,6 +68,17 @@ async function getUserFromApi(login) {
   }
 }
 
+async function getCollectionFromApi(url) {
+  try {
+    return await getSingleItem(api, `v1/collections/by/fullUrl?fullUrl=${url}`, url);
+  } catch (error) {
+    if (error.response && error.response.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function getCultureZinePosts() {
   console.log('Fetching culture zine posts');
   const client = 'client_id=ghost-frontend&client_secret=c9a97f14ced8';
@@ -83,5 +95,6 @@ module.exports = {
   getProject: (domain) => getFromCacheOrApi(domain, projectCache, getProjectFromApi),
   getTeam: (url) => getFromCacheOrApi(url, teamCache, getTeamFromApi),
   getUser: (login) => getFromCacheOrApi(login, userCache, getUserFromApi),
+  getCollection: url => getFromCacheOrApi(url, collectionCache, getCollectionFromApi),
   getZine: () => getFromCacheOrApi('culture', generalCache, getCultureZinePosts),
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -86,8 +86,12 @@ module.exports = function(external) {
     const { name } = req.params;
     const team = await getTeam(name);
     if (team) {
-      const teamAvatar = team.hasAvatarImage ? `${CDN_URL}/team-avatar/${team.id}/large` : null;
-      await render(res, team.name, team.description, teamAvatar);
+      const args = [res, team.name, team.description];
+      if (team.hasAvatarImage) {
+        args.push(`${CDN_URL}/team-avatar/${team.id}/large`);
+      }
+      //await render(res, team.name, team.description, teamAvatar);
+      await render.apply(args);
       return;
     }
     const user = await getUser(name);

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const util = require('util');
 const dayjs = require('dayjs');
 
-const { getProject, getTeam, getUser, getZine } = require('./api');
+const { getProject, getTeam, getUser, getCollection, getZine } = require('./api');
 const initWebpack = require('./webpack');
 const constants = require('./constants');
 
@@ -95,6 +95,26 @@ module.exports = function(external) {
       return;
     }
     await render(res, `@${name}`, `We couldn't find @${name}`);
+  });
+
+  app.get('/@:name/:collection', async (req, res) => {
+    const { name, collection } = req.params;
+    const collectionObj = await getCollection(`${name}/${collection}`);
+
+    // TODO metada for teams as well
+    // @ + user.login
+    if (collectionObj) {
+      let { name, description, team, user } = collectionObj;
+      const author = team || `@${user.login}`;
+
+      description = description.trimEnd(); // trim trailing whitespace from description
+      description += ` 🎏 A collection of apps by ${author}`;
+      description = description.trimStart(); // if there was no description, trim space before the fish
+
+      await render(res, name, description);
+      return;
+    }
+    await render(res, `${collection}`, `We couldn't find @${name}/${collection}`);
   });
 
   app.get('/auth/:domain', async (req, res) => {

--- a/server/routes.js
+++ b/server/routes.js
@@ -86,8 +86,8 @@ module.exports = function(external) {
     const { name } = req.params;
     const team = await getTeam(name);
     if (team) {
-      const avatar = `${CDN_URL}/team-avatar/${team.id}`;
-      await render(res, team.name, team.description);
+      const teamAvatar = team.hasAvatarImage ? `${CDN_URL}/team-avatar/${team.id}/large` : null;
+      await render(res, team.name, team.description, teamAvatar);
       return;
     }
     const user = await getUser(name);
@@ -102,8 +102,6 @@ module.exports = function(external) {
     const { name, collection } = req.params;
     const collectionObj = await getCollection(`${name}/${collection}`);
 
-    // TODO metada for teams as well
-    // @ + user.login
     if (collectionObj) {
       let { name, description, team, user } = collectionObj;
       const author = team || `@${user.login}`;

--- a/server/routes.js
+++ b/server/routes.js
@@ -88,10 +88,10 @@ module.exports = function(external) {
     if (team) {
       const args = [res, team.name, team.description];
       if (team.hasAvatarImage) {
-        args.push(`${CDN_URL}/team-avatar/${team.id}/large`);
+        args.push(`${CDN_URL}/team-avatar/${team.id}/large?2222`);
       }
       //await render(res, team.name, team.description, teamAvatar);
-      await render.apply(args);
+      await render(...args);
       return;
     }
     const user = await getUser(name);

--- a/server/routes.js
+++ b/server/routes.js
@@ -88,9 +88,8 @@ module.exports = function(external) {
     if (team) {
       const args = [res, team.name, team.description];
       if (team.hasAvatarImage) {
-        args.push(`${CDN_URL}/team-avatar/${team.id}/large?2222`);
+        args.push(`${CDN_URL}/team-avatar/${team.id}/large`);
       }
-      //await render(res, team.name, team.description, teamAvatar);
       await render(...args);
       return;
     }

--- a/server/routes.js
+++ b/server/routes.js
@@ -86,6 +86,7 @@ module.exports = function(external) {
     const { name } = req.params;
     const team = await getTeam(name);
     if (team) {
+      const avatar = `${CDN_URL}/team-avatar/${team.id}`;
       await render(res, team.name, team.description);
       return;
     }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,11 +15,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- facebook open graph tags -->
-    <meta name="og:type" content="website">
-    <meta name="og:url" content="https://glitch.com">
-    <meta name="og:title" content="<%= title %>">
-    <meta name="og:description" content="<%= description %>">
-    <meta name="og:image" content="<%= image %>">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://glitch.com">
+    <meta property="og:title" content="<%= title %>">
+    <meta property="og:description" content="<%= description %>">
+    <meta property="og:image" content="<%= image %>">
     <!-- twitter card tags (stacks with og: tags) -->
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@glitch">


### PR DESCRIPTION
**remix** [~metadata-fixes](https://metadata-fixes.glitch.me)
**cases** [use property in meta tags](https://glitch.manuscript.com/f/cases/3327855/Replace-use-of-name-with-property-in-meta-tags), [add metadata to collections](https://glitch.manuscript.com/f/cases/3327645/Add-Meta-Data-to-Team-and-User-Collections)

This includes a few metadata fixes that improve our collection and team social cards

## Collection updates
Uses the collection name and description (if it exists) instead of the default glitch.com metadata
<img width="300" alt="Screen Shot 2019-03-19 at 2 27 13 PM" src="https://user-images.githubusercontent.com/7584833/54700825-bbd72380-4b01-11e9-97d0-23424f555f51.png">
<img width="300" alt="Screen Shot 2019-03-19 at 2 26 01 PM" src="https://user-images.githubusercontent.com/7584833/54700834-c0034100-4b01-11e9-9a4c-c5a0a2397d33.png">
<img width="300" alt="Screen Shot 2019-03-19 at 2 21 11 PM" src="https://user-images.githubusercontent.com/7584833/54700854-ca253f80-4b01-11e9-87e4-1c8470f87e75.png">

## Team updates
Uses the team avatar for the card image, falls back to the default card image
<img width="300" alt="Screen Shot 2019-03-20 at 11 19 01 AM" src="https://user-images.githubusercontent.com/7584833/54700983-fe98fb80-4b01-11e9-9155-b55be48ae6a5.png">
