### PR TITLE
Shaded fold - bug fix for team notes

### DIFF
--- a/src/presenters/note.js
+++ b/src/presenters/note.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 // TODO: let's move these into components
 import { AuthDescription } from './includes/description-field';
 import { UserTile } from './users-list';
+import { TeamTile } from './teams-list';
 
 import { isDarkColor } from '../models/collection';
 
@@ -13,7 +14,7 @@ import { isDarkColor } from '../models/collection';
  * Note Component
  */
 const Note = ({
-  collectionCoverColor, author, project, update, hideNote,
+  collection, project, update, hideNote,
 }) => {
   function updateNoteVisibility(description) {
     description = _.trim(description);
@@ -25,6 +26,8 @@ const Note = ({
   if (!project.isAddingANewNote && !project.note) {
     return null;
   }
+  
+  const collectionCoverColor = collection.coverColor;
 
   const className = classNames({
     'description-container': true,
@@ -46,7 +49,11 @@ const Note = ({
         />
       </div>
       <div className="user">
-        <UserTile user={author} />
+        {
+          collection.teamId === -1 ?
+            <UserTile user={collection.user} /> :
+            <TeamTile team={collection.team} />
+        }
       </div>
     </div>
   );
@@ -54,8 +61,6 @@ const Note = ({
 
 
 Note.propTypes = {
-  collectionCoverColor: PropTypes.string,
-  author: PropTypes.object,
   project: PropTypes.shape({
     note: PropTypes.string,
     isAddingANewNote: PropTypes.bool,
@@ -66,9 +71,7 @@ Note.propTypes = {
 };
 
 Note.defaultProps = {
-  author: {},
   update: null,
-  collectionCoverColor: null,
 };
 
 export default Note;

--- a/src/presenters/note.js
+++ b/src/presenters/note.js
@@ -26,7 +26,7 @@ const Note = ({
   if (!project.isAddingANewNote && !project.note) {
     return null;
   }
-  
+
   const collectionCoverColor = collection.coverColor;
 
   const className = classNames({
@@ -50,9 +50,7 @@ const Note = ({
       </div>
       <div className="user">
         {
-          collection.teamId === -1 ?
-            <UserTile user={collection.user} /> :
-            <TeamTile team={collection.team} />
+          collection.teamId === -1 ? <UserTile user={collection.user} /> : <TeamTile team={collection.team} />
         }
       </div>
     </div>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -165,8 +165,8 @@ const CollectionPageContents = ({
                       <ProjectsUL
                         {...props}
                         projects={collection.projects}
+                        collection={collection}
                         api={api}
-                        collectionCoverColor={collection.coverColor}
                         hideNote={hideNote}
                         projectOptions={{
                           removeProjectFromCollection,
@@ -182,9 +182,8 @@ const CollectionPageContents = ({
                       <ProjectsUL
                         {...props}
                         projects={collection.projects}
-                        author={collection.user}
+                        collection={collection}
                         api={api}
-                        collectionCoverColor={collection.coverColor}
                         projectOptions={{
                           addProjectToCollection,
                         }}
@@ -195,9 +194,8 @@ const CollectionPageContents = ({
                     !currentUserIsAuthor && !userIsLoggedIn && (
                       <ProjectsUL
                         projects={collection.projects}
-                        author={collection.user}
+                        collection={collection}
                         api={api}
-                        collectionCoverColor={collection.coverColor}
                         projectOptions={{}}
                       />
                     )

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -165,7 +165,6 @@ const CollectionPageContents = ({
                       <ProjectsUL
                         {...props}
                         projects={collection.projects}
-                        author={collection.user}
                         api={api}
                         collectionCoverColor={collection.coverColor}
                         hideNote={hideNote}

--- a/src/presenters/project-item.js
+++ b/src/presenters/project-item.js
@@ -41,6 +41,7 @@ const ProjectItem = ({
 ProjectItem.propTypes = {
   api: PropTypes.func,
   author: PropTypes.object,
+  hideNote: PropTypes.func,
   project: PropTypes.shape({
     collectionCoverColor: PropTypes.string,
     description: PropTypes.string.isRequired,

--- a/src/presenters/project-item.js
+++ b/src/presenters/project-item.js
@@ -9,12 +9,11 @@ import Note from './note';
 import WrappingLink from './includes/wrapping-link';
 
 const ProjectItem = ({
-  api, project, author, collectionCoverColor, ...props
+  api, project, collection, ...props
 }) => (
   <li>
     <Note
-      collectionCoverColor={collectionCoverColor}
-      author={author}
+      collection={collection}
       project={project}
       update={props.projectOptions.updateOrAddNote ? (note) => props.projectOptions.updateOrAddNote({ note, projectId: project.id }) : null}
       hideNote={props.hideNote}
@@ -41,7 +40,6 @@ const ProjectItem = ({
 
 ProjectItem.propTypes = {
   api: PropTypes.func,
-  collectionCoverColor: PropTypes.string,
   author: PropTypes.object,
   project: PropTypes.shape({
     collectionCoverColor: PropTypes.string,
@@ -59,8 +57,8 @@ ProjectItem.propTypes = {
 ProjectItem.defaultProps = {
   api: null,
   author: null,
-  collectionCoverColor: null,
   projectOptions: {},
+  hideNote: () => {},
 };
 
 export default ProjectItem;


### PR DESCRIPTION
Forgot to test out authoring a note as a team, turns out we tried to render an author without a user :( Tested it out by making a team and then creating a note.

Also fixes a bug where we were throwing an error in the console about hideNote not being defined.

![Screen Shot 2019-03-20 at 2 48 48 PM](https://user-images.githubusercontent.com/6620164/54711198-c1dbfd00-4b1f-11e9-86f8-133739ca8db3.png)

Can test out my remix here: https://shaded-fold.glitch.me
