### PR TITLE
Romantic barracuda: Bug Fixes to Collection Grid Styling

### DIFF
--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -179,35 +179,6 @@ const CollectionPageContents = ({
                   <ProjectsUL projects={collection.projects} collection={collection} api={api} projectOptions={{}} />
                 )}
               </div>
-              {currentUserIsAuthor && (
-                <ProjectsUL
-                  {...props}
-                  projects={collection.projects}
-                  collection={collection}
-                  api={api}
-                  hideNote={hideNote}
-                  projectOptions={{
-                    removeProjectFromCollection,
-                    addProjectToCollection,
-                    updateOrAddNote,
-                    addNoteField,
-                  }}
-                />
-              )}
-              {!currentUserIsAuthor && userIsLoggedIn && (
-                <ProjectsUL
-                  {...props}
-                  projects={collection.projects}
-                  collection={collection}
-                  api={api}
-                  projectOptions={{
-                    addProjectToCollection,
-                  }}
-                />
-              )}
-              {!currentUserIsAuthor && !userIsLoggedIn && (
-                <ProjectsUL projects={collection.projects} collection={collection} api={api} projectOptions={{}} />
-              )}
             </>
           )}
         </article>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -121,7 +121,9 @@ const CollectionPageContents = ({
               />
             </div>
             
-            <div className="
+            <div className="collection-project-count">
+              {collection.projects.length} Projects
+            </div>
 
             {currentUserIsAuthor && <EditCollectionColor update={updateColor} initialColor={collection.coverColor} />}
           </header>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -120,6 +120,8 @@ const CollectionPageContents = ({
                 placeholder="Tell us about your collection"
               />
             </div>
+            
+            <div className="
 
             {currentUserIsAuthor && <EditCollectionColor update={updateColor} initialColor={collection.coverColor} />}
           </header>
@@ -146,9 +148,6 @@ const CollectionPageContents = ({
               <>
                 <div className="collection-contents">
                   <div className="collection-project-container-header">
-                    <Heading tagName="h3">
-                      Projects ({collection.projects.length})
-                    </Heading>
                     {
                       currentUserIsAuthor && (
                         <AddCollectionProject

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -27,8 +27,6 @@ import { UserTile } from '../users-list';
 
 import { CurrentUserConsumer } from '../current-user';
 
-import Heading from '../../components/text/heading';
-
 function syncPageToUrl(collection, url) {
   history.replaceState(null, null, getLink({ ...collection, url }));
 }
@@ -120,90 +118,65 @@ const CollectionPageContents = ({
                 placeholder="Tell us about your collection"
               />
             </div>
-            
-            <div className="collection-project-count">
-              {collection.projects.length} Projects
-            </div>
+
+            <div className="collection-project-count">{collection.projects.length} Projects</div>
 
             {currentUserIsAuthor && <EditCollectionColor update={updateColor} initialColor={collection.coverColor} />}
           </header>
-          {
-            !collectionHasProjects && currentUserIsAuthor && (
-              <div className="empty-collection-hint">
-                <img
-                  src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934"
-                  alt=""
-                />
-                <p>You can add any project, created by any user</p>
-              </div>
-            )
-          }
-          {
-            !collectionHasProjects && !currentUserIsAuthor && (
-              <div className="empty-collection-hint">
-                No projects to see in this collection just yet.
-              </div>
-            )
-          }
-          {
-            collectionHasProjects && (
-              <>
-                <div className="collection-contents">
-                  <div className="collection-project-container-header">
-                    {
-                      currentUserIsAuthor && (
-                        <AddCollectionProject
-                          addProjectToCollection={addProjectToCollection}
-                          collection={collection}
-                          api={api}
-                          currentUser={currentUser}
-                        />
-                      )
-                    }
-                  </div>
-                  {
-                    currentUserIsAuthor && (
-                      <ProjectsUL
-                        {...props}
-                        projects={collection.projects}
-                        collection={collection}
-                        api={api}
-                        hideNote={hideNote}
-                        projectOptions={{
-                          removeProjectFromCollection,
-                          addProjectToCollection,
-                          updateOrAddNote,
-                          addNoteField,
-                        }}
-                      />
-                    )
-                  }
-                  {
-                    !currentUserIsAuthor && userIsLoggedIn && (
-                      <ProjectsUL
-                        {...props}
-                        projects={collection.projects}
-                        collection={collection}
-                        api={api}
-                        projectOptions={{
-                          addProjectToCollection,
-                        }}
-                      />
-                    )
-                  }
-                  {
-                    !currentUserIsAuthor && !userIsLoggedIn && (
-                      <ProjectsUL
-                        projects={collection.projects}
-                        collection={collection}
-                        api={api}
-                        projectOptions={{}}
-                      />
-                    )
-                  }
+          {!collectionHasProjects && currentUserIsAuthor && (
+            <div className="empty-collection-hint">
+              <img src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" />
+              <p>You can add any project, created by any user</p>
+            </div>
+          )}
+          {!collectionHasProjects && !currentUserIsAuthor && (
+            <div className="empty-collection-hint">No projects to see in this collection just yet.</div>
+          )}
+          {collectionHasProjects && (
+            <>
+              <div className="collection-contents">
+                <div className="collection-project-container-header">
+                  {currentUserIsAuthor && (
+                    <AddCollectionProject
+                      addProjectToCollection={addProjectToCollection}
+                      collection={collection}
+                      api={api}
+                      currentUser={currentUser}
+                    />
+                  )}
                 </div>
-              </>
-            )}
+                {currentUserIsAuthor && (
+                  <ProjectsUL
+                    {...props}
+                    projects={collection.projects}
+                    collection={collection}
+                    api={api}
+                    hideNote={hideNote}
+                    projectOptions={{
+                      removeProjectFromCollection,
+                      addProjectToCollection,
+                      updateOrAddNote,
+                      addNoteField,
+                    }}
+                  />
+                )}
+                {!currentUserIsAuthor && userIsLoggedIn && (
+                  <ProjectsUL
+                    {...props}
+                    projects={collection.projects}
+                    collection={collection}
+                    api={api}
+                    projectOptions={{
+                      addProjectToCollection,
+                    }}
+                  />
+                )}
+                {!currentUserIsAuthor && !userIsLoggedIn && (
+                  <ProjectsUL projects={collection.projects} collection={collection} api={api} projectOptions={{}} />
+                )}
+              </div>
+            </>
+          )}
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}
       </main>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -121,85 +121,33 @@ const CollectionPageContents = ({
               />
             </div>
 
-            <div className="collection-project-count"><Text>{collection.projects.length} Projects</Text></div>
+            <div className="collection-project-count">
+              <Text>{collection.projects.length} Projects</Text>
+            </div>
 
             {currentUserIsAuthor && <EditCollectionColor update={updateColor} initialColor={collection.coverColor} />}
           </header>
-          {
-            !collectionHasProjects && currentUserIsAuthor && (
-              <div className="empty-collection-hint">
-                <img
-                  src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934"
-                  alt=""
-                />
-                <Text>You can add any project, created by any user</Text>
-              </div>
-            )
-          }
-          {
-            !collectionHasProjects && !currentUserIsAuthor && (
-              <div className="empty-collection-hint">
-                No projects to see in this collection just yet.
-              </div>
-            )
-          }
-          {
-            collectionHasProjects && (
-              <>
-                <div className="collection-contents">
-                  <div className="collection-project-container-header">
-                    {
-                      currentUserIsAuthor && (
-                        <AddCollectionProject
-                          addProjectToCollection={addProjectToCollection}
-                          collection={collection}
-                          api={api}
-                          currentUser={currentUser}
-                        />
-                      )
-                    }
-                  </div>
-                  {
-                    currentUserIsAuthor && (
-                      <ProjectsUL
-                        {...props}
-                        projects={collection.projects}
-                        collection={collection}
-                        api={api}
-                        hideNote={hideNote}
-                        projectOptions={{
-                          removeProjectFromCollection,
-                          addProjectToCollection,
-                          updateOrAddNote,
-                          addNoteField,
-                        }}
-                      />
-                    )
-                  }
-                  {
-                    !currentUserIsAuthor && userIsLoggedIn && (
-                      <ProjectsUL
-                        {...props}
-                        projects={collection.projects}
-                        collection={collection}
-                        api={api}
-                        projectOptions={{
-                          addProjectToCollection,
-                        }}
-                      />
-                    )
-
-                  }
-                  {
-                    !currentUserIsAuthor && !userIsLoggedIn && (
-                      <ProjectsUL
-                        projects={collection.projects}
-                        collection={collection}
-                        api={api}
-                        projectOptions={{}}
-                      />
-                    )
-                  }
+          {!collectionHasProjects && currentUserIsAuthor && (
+            <div className="empty-collection-hint">
+              <img src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" />
+              <Text>You can add any project, created by any user</Text>
+            </div>
+          )}
+          {!collectionHasProjects && !currentUserIsAuthor && (
+            <div className="empty-collection-hint">No projects to see in this collection just yet.</div>
+          )}
+          {collectionHasProjects && (
+            <>
+              <div className="collection-contents">
+                <div className="collection-project-container-header">
+                  {currentUserIsAuthor && (
+                    <AddCollectionProject
+                      addProjectToCollection={addProjectToCollection}
+                      collection={collection}
+                      api={api}
+                      currentUser={currentUser}
+                    />
+                  )}
                 </div>
                 {currentUserIsAuthor && (
                   <ProjectsUL
@@ -231,6 +179,35 @@ const CollectionPageContents = ({
                   <ProjectsUL projects={collection.projects} collection={collection} api={api} projectOptions={{}} />
                 )}
               </div>
+              {currentUserIsAuthor && (
+                <ProjectsUL
+                  {...props}
+                  projects={collection.projects}
+                  collection={collection}
+                  api={api}
+                  hideNote={hideNote}
+                  projectOptions={{
+                    removeProjectFromCollection,
+                    addProjectToCollection,
+                    updateOrAddNote,
+                    addNoteField,
+                  }}
+                />
+              )}
+              {!currentUserIsAuthor && userIsLoggedIn && (
+                <ProjectsUL
+                  {...props}
+                  projects={collection.projects}
+                  collection={collection}
+                  api={api}
+                  projectOptions={{
+                    addProjectToCollection,
+                  }}
+                />
+              )}
+              {!currentUserIsAuthor && !userIsLoggedIn && (
+                <ProjectsUL projects={collection.projects} collection={collection} api={api} projectOptions={{}} />
+              )}
             </>
           )}
         </article>

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -88,18 +88,11 @@
   .projects-container
     margin: 30px 30px 30px 16px
     overflow: visible
-    
-    display: grid
-    grid-template-columns: 1fr 1fr 1fr
-    grid-template-rows: auto
-    @media (max-width: mediumViewport)
-      grid-template-columns: 1fr
 
 
   .projects-container > li
     display: grid
     align-content: end
-    min-width: 95%;
     
     .project-options-pop
       width: 200px

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -60,6 +60,10 @@
       margin: 0
     > * p
       margin: 0 !important
+  .collection-project-count
+    margin: 25px 0px 0px
+    font-size: 14px
+    font-weight: 600
   .edit-collection-color-btn
     margin-top: 25px
   .collection-url

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -92,16 +92,10 @@
   .projects-container
     margin: 30px 30px 30px 16px
     overflow: visible
-    display: grid
-    grid-template-columns: 1fr 1fr 1fr
-    grid-template-rows: auto
-    @media (max-width: mediumViewport)
-      grid-template-columns: 1fr
 
   .projects-container > li
-    display: grid
-    min-width: 95%
-    align-content: end
+    float: none
+    display: inline-block
     
     .project-options-pop
       width: 200px

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -89,9 +89,7 @@
     margin: 30px 30px 30px 16px
     overflow: visible
 
-
   .projects-container > li
-    display: grid
     align-content: end
     
     .project-options-pop
@@ -112,6 +110,8 @@
   .project-options
     display: block
     background: none
+  .project-options:hover
+    background: secondary-background
 a.collection-view-all
   font-weight: 600
   font-size: 13px

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -90,7 +90,7 @@
   .collection-project-container-header
     margin: 0px 10px
   .projects-container
-    margin: 30px 30px 30px 16px
+    margin: 30px 16px
     overflow: visible
 
   .projects-container > li

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -74,7 +74,7 @@
     color: text-on-secondary-background 
   .collection-contents 
     width: 75%
-    padding: 12px
+    padding: 20px 12px
     background-color: secondary-background
     border-top-right-radius: 5px
     border-bottom-right-radius: 5px
@@ -92,8 +92,15 @@
   .projects-container
     margin: 30px 30px 30px 16px
     overflow: visible
+    display: grid
+    grid-template-columns: 1fr 1fr 1fr
+    grid-template-rows: auto
+    @media (max-width: mediumViewport)
+      grid-template-columns: 1fr
 
   .projects-container > li
+    display: grid
+    min-width: 95%
     align-content: end
     
     .project-options-pop

--- a/styles/users.styl
+++ b/styles/users.styl
@@ -6,6 +6,7 @@
     position: relative
     white-space: nowrap
     height: 35px
+    max-width: 100%
     // like overflow:hidden but with an L shape
     // it extends below the rect and to the right
     // cut off avatars but let tooltips keep rendering

--- a/styles/users.styl
+++ b/styles/users.styl
@@ -6,7 +6,6 @@
     position: relative
     white-space: nowrap
     height: 35px
-    max-width: 100%
     // like overflow:hidden but with an L shape
     // it extends below the rect and to the right
     // cut off avatars but let tooltips keep rendering


### PR DESCRIPTION
Removed grid css to fix styling issues on collection pages.

Also removed project heading with counter to make the layout a bit more readable with annotations.

Testable links:
https://romantic-barracuda.glitch.me/@scientiffic/glitch-things

vs 
https://glitch.com/@scientiffic/glitch-things

![image](https://user-images.githubusercontent.com/519336/54713509-2a79a880-4b25-11e9-9660-aa883d906937.png)
![image](https://user-images.githubusercontent.com/519336/54713517-2ea5c600-4b25-11e9-82b2-67973038dd6f.png)
