### PR TITLE
CSP rollback

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -30,17 +30,10 @@ const envs = {
   },
 };
 
-const sources = {
-  styles: ['*.webtype.com', 'cdn.glitch.com', 'cdn.gomix.com'],
-  images: ['*.glitch.com', '*.gomix.com', 'gomix.com', 'cdn.hyperdev.com', 's3.amazonaws.com', '*.webtype.com', 'fast.wistia.com', 'culture-zine.glitch.me', '*.akamaihd.net'],
-  fonts: ['data:', '*.webtype.com', 'fonts.gstatic.com'],
-};
-
 // in the backend, just switch between staging and production
 const currentEnv = process.env.RUNNING_ON === 'staging' ? 'staging' : 'production';
 module.exports = {
   ...envs,
-  sources,
   current: envs[currentEnv],
   currentEnv,
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -91,16 +91,10 @@ module.exports = function(external) {
   }
 
   const { CDN_URL } = constants.current;
-  const { sources } = constants;
 
   app.use(
     helmet.contentSecurityPolicy({
       directives: {
-        // style-src unsafe-inline is required for our SVGs
-        // for context and link to bug, see https://pokeinthe.io/2016/04/09/black-icons-with-svg-and-csp/
-        styleSrc: ["'self'", "'unsafe-inline'", ...sources.styles],
-        imgSrc: ["'self'", ...sources.images],
-        fontSrc: ["'self'", ...sources.fonts],
         baseUri: ["'self'"],
         reportUri: 'https://csp-reporting-server.glitch.me/report',
       },


### PR DESCRIPTION
Our use of embeds makes it difficult (impossible?) to deploy a meaningful CSP. Gotta roll back the policies for `image-src`, `style-src`, and `font-src`