### PR TITLE
Amazing slug: use title prop for helmet

### DIFF
--- a/src/presenters/pages/category.js
+++ b/src/presenters/pages/category.js
@@ -17,7 +17,7 @@ import Heading from '../../components/text/heading';
 
 const CategoryPageWrap = ({ addProjectToCollection, api, category, currentUser, ...props }) => (
   <>
-    <Helmet title="category.name" />
+    <Helmet title={category.name} />
     <main className="collection-page">
       <article className="projects collection-full" style={{ backgroundColor: category.backgroundColor }}>
         <header className="collection">

--- a/src/presenters/pages/category.js
+++ b/src/presenters/pages/category.js
@@ -17,9 +17,7 @@ import Heading from '../../components/text/heading';
 
 const CategoryPageWrap = ({ addProjectToCollection, api, category, currentUser, ...props }) => (
   <>
-    <Helmet>
-      <title>{category.name}</title>
-    </Helmet>
+    <Helmet title="category.name" />
     <main className="collection-page">
       <article className="projects collection-full" style={{ backgroundColor: category.backgroundColor }}>
         <header className="collection">

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -92,9 +92,7 @@ const CollectionPageContents = ({
 
   return (
     <>
-      <Helmet>
-        <title>{collection.name}</title>
-      </Helmet>
+      <Helmet title={collection.name} />
       <main className="collection-page">
         <article className="collection-full projects" style={{ backgroundColor: collection.coverColor }}>
           <header className={`collection ${isDarkColor(collection.coverColor) ? 'dark' : ''}`}>

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -209,9 +209,7 @@ const ProjectPageLoader = ({ domain, api, currentUser, ...props }) => (
         <ProjectEditor api={api} initialProject={project}>
           {(currentProject, funcs, userIsMember) => (
             <>
-              <Helmet>
-                <title>{currentProject.domain}</title>
-              </Helmet>
+              <Helmet title={currentProject.domain} />
               <ProjectPage api={api} project={currentProject} {...funcs} isAuthorized={userIsMember} currentUser={currentUser} {...props} />
             </>
           )}

--- a/src/presenters/pages/questions.js
+++ b/src/presenters/pages/questions.js
@@ -9,9 +9,7 @@ import MoreIdeas from '../more-ideas';
 
 const QuestionsPage = ({ api }) => (
   <Layout api={api}>
-    <Helmet>
-      <title>Questions</title>
-    </Helmet>
+    <Helmet title="Questions" />
     <main className="questions-page">
       <Questions api={api} max={12} />
       <MoreIdeas api={api} />

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -230,7 +230,7 @@ const SearchPage = ({ api, query }) => {
   const errorFuncs = useErrorHandlers();
   return (
     <Layout api={api} searchQuery={query}>
-      <Helmet>{!!query && <title>Search for {query}</title>}</Helmet>
+      {!!query && <Helmet title={`Search for ${query}`} />}
       {query ? <SearchResults {...errorFuncs} api={api} query={query} currentUser={currentUser} /> : <NotFound name="anything" />}
       <MoreIdeas api={api} />
     </Layout>

--- a/src/presenters/pages/secret.js
+++ b/src/presenters/pages/secret.js
@@ -50,9 +50,7 @@ const Secret = ({ enabledToggles, toggleData, setEnabledToggles }) => {
   return (
     <section className="secretPage">
       <div className="filler" />
-      <Helmet>
-        <title>Glitch - It's a secret to everybody.</title>
-      </Helmet>
+      <Helmet title="Glitch - It's a secret to everybody." />
       <SecretEffectsOnMount />
       <ul>
         {toggleData.map(({ name, description }) => (

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -384,9 +384,7 @@ const TeamPageContainer = ({ api, team, ...props }) => {
       <TeamPageEditor api={api} initialTeam={team}>
         {(teamFromEditor, funcs, currentUserIsOnTeam, currentUserIsTeamAdmin) => (
           <>
-            <Helmet>
-              <title>{teamFromEditor.name}</title>
-            </Helmet>
+            <Helmet title={teamFromEditor.name} />
             <TeamPage
               api={api}
               team={teamFromEditor}

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -225,9 +225,7 @@ const UserPageContainer = ({ api, user }) => {
       <UserEditor api={api} initialUser={user}>
         {(userFromEditor, funcs, isAuthorized) => (
           <>
-            <Helmet>
-              <title>{userFromEditor.name || (userFromEditor.login ? `@${userFromEditor.login}` : `User ${userFromEditor.id}`)}</title>
-            </Helmet>
+            <Helmet title={userFromEditor.name || (userFromEditor.login ? `@${userFromEditor.login}` : `User ${userFromEditor.id}`)} />
             <ProjectsLoader api={api} projects={orderBy(userFromEditor.projects, (project) => project.updatedAt, ['desc'])}>
               {(projects) => <UserPage {...{ api, isAuthorized, maybeCurrentUser }} user={{ ...userFromEditor, projects }} {...funcs} />}
             </ProjectsLoader>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/938722/54834726-21104d80-4c97-11e9-910e-0b1b66a725ec.png)
[pictured: an amazing slug]

The infinite recursion errors we're getting are coming from react-helmet's use of [deep equality comparison on circular structures](https://github.com/nfl/react-helmet/issues/441). This is supposedly fixed in the current beta, but I think that using a title prop instead of children will also fix this (since its now comparing strings, not react elements).