### PR TITLE
Added a 1-second cache header to all community site routes

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -39,6 +39,7 @@ module.exports = function(external) {
   const ms = dayjs.convert(7, 'days', 'miliseconds');
   app.use(express.static('public', { index: false }));
   app.use(express.static('build', { index: false, maxAge: ms }));
+  app.use(express.static('views', { index: false, maxAge: 1000 }));
 
   const readFilePromise = util.promisify(fs.readFile);
   const imageDefault = 'https://cdn.gomix.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2Fsocial-card%402x.png';

--- a/server/routes.js
+++ b/server/routes.js
@@ -39,7 +39,6 @@ module.exports = function(external) {
   const ms = dayjs.convert(7, 'days', 'miliseconds');
   app.use(express.static('public', { index: false }));
   app.use(express.static('build', { index: false, maxAge: ms }));
-  app.use(express.static('views', { index: false, maxAge: 1000 }));
 
   const readFilePromise = util.promisify(fs.readFile);
   const imageDefault = 'https://cdn.gomix.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2Fsocial-card%402x.png';

--- a/server/routes.js
+++ b/server/routes.js
@@ -99,6 +99,11 @@ module.exports = function(external) {
       },
     }),
   );
+  
+  app.use(function(req, res, next) {
+    res.header('Cache-Control', 'public, maxAge=1');
+    return next();
+  });
 
   app.get('/~:domain', async (req, res) => {
     const { domain } = req.params;


### PR DESCRIPTION
Hoping to reduce occurrences of this bug: https://glitch.manuscript.com/f/cases/edit/3328085/Improve-edge-caching-understanding-and-processes

This PR adds a 1s cache header to all non-static routes (it's placed after the static routes for this reason). This reduces the likelihood that a user will get a version of the page from cloudfront with old build URLs that don't exist on that app any more.

How to test:
- Go to https://wakeful-galleon.glitch.me/, and observe a 1s response header on the page
<img width="483" alt="Screenshot 2019-03-26 at 6 16 54 PM" src="https://user-images.githubusercontent.com/9853740/55037226-6e702000-4ff3-11e9-865d-8df6950b45d2.png">
- Check that JS bundles still have the old caching on them (e.g. react.js)
<img width="477" alt="Screenshot 2019-03-26 at 6 17 48 PM" src="https://user-images.githubusercontent.com/9853740/55037253-7d56d280-4ff3-11e9-8e7f-3e58c617ec72.png">
