### PR TITLE
Outrageous shingle: Fix accessibility issues in footer links

### DIFF
--- a/src/presenters/footer.js
+++ b/src/presenters/footer.js
@@ -24,31 +24,31 @@ export default function Footer() {
     <footer role="contentinfo">
       <FooterLine href="/about" track="about">
         About Glitch{' '}
-        <span role="img" aria-label="">
+        <span aria-hidden="true">
           🔮
         </span>
       </FooterLine>
       <FooterLine href="https://medium.com/glitch" track="blog">
         Blog{' '}
-        <span role="img" aria-label="">
+        <span aria-hidden="true">
           📰
         </span>
       </FooterLine>
       <FooterLine href="/help/" track="faq">
         Help Center{' '}
-        <span role="img" aria-label="">
+        <span aria-hidden="true">
           ☂️
         </span>
       </FooterLine>
       <FooterLine href="http://status.glitch.com/" track="system status">
         System Status{' '}
-        <span role="img" aria-label="">
+        <span aria-hidden="true">
           🚥
         </span>
       </FooterLine>
       <FooterLine href="/legal" track="legal stuff">
         Legal Stuff{' '}
-        <span role="img" aria-label="">
+        <span aria-hidden="true">
           👮‍
         </span>
       </FooterLine>


### PR DESCRIPTION
Currently, the icons in the footer are given a `role` of `img`, but have no label. This was causing some failures when running a Lighthouse accessibility audit, and giving the landing page a score of 69/100. 

Since the icons are purely decorative and don't add context, I opted to hide them from AT using `aria-hidden`. After this change, the landing page gets a 81/100 score on accessibility running a Lighthouse audit. 

