### PR TITLE
Stupendous fisher 1: Fix aria-labelledby errors in avatar tooltip container

### DIFF
--- a/src/components/tooltips/tooltip-container.js
+++ b/src/components/tooltips/tooltip-container.js
@@ -15,6 +15,9 @@ function TooltipContainer({ id, type, tooltip, target, align, persistent, childr
     'tooltip-container': true,
   });
 
+  // prevents invalid aria-labelledby values when names contain whitespace
+  id = id.replace(/\s/g, '-');
+
   const tooltipClassName = cx({
     tooltip: true,
     top: align.includes('top'),

--- a/src/presenters/includes/avatar.js
+++ b/src/presenters/includes/avatar.js
@@ -29,7 +29,7 @@ export const Avatar = ({ name, src, color, srcFallback, type, hideTooltip, withi
   );
 
   if (!hideTooltip) {
-    return <TooltipContainer tooltip={name} target={contents} type="action" id={`avatar-tooltip-${name}`} align={['left']} fallback={withinButton} />;
+    return <TooltipContainer tooltip={name} target={contents} type="action" id={`avatar-tooltip-${name.replace(/\s/g, '_')}`} align={['left']} fallback={withinButton} />;
   }
   return contents;
 };

--- a/src/presenters/includes/avatar.js
+++ b/src/presenters/includes/avatar.js
@@ -29,7 +29,7 @@ export const Avatar = ({ name, src, color, srcFallback, type, hideTooltip, withi
   );
 
   if (!hideTooltip) {
-    return <TooltipContainer tooltip={name} target={contents} type="action" id={`avatar-tooltip-${name.replace(/\s/g, '_')}`} align={['left']} fallback={withinButton} />;
+    return <TooltipContainer tooltip={name} target={contents} type="action" id={`avatar-tooltip-${name}`} align={['left']} fallback={withinButton} />;
   }
   return contents;
 };


### PR DESCRIPTION
Currently where there is a user avatar with a tooltip, there is an invalid `aria-labelledby` value if a user's name has one or more spaces. The name is being used as the `id` value, which is then passed down to `aria-labelledby`. Having a space in that value is invalid. 

<img src="https://i.imgur.com/QAvajBv.jpg" alt="Accessibility errors during Lighthouse audit showing invalid `aria-labelledby` values" />

To solve this, I replaced spaces in the name at the site of the `id` prop with an underscore. I'm not sure if there is a better solution, but this seems to be the most simple and solved the issue.

