### PR TITLE
Nova chance: new embed support check that should be more reliable

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "stylus-loader": "^3.0.2",
     "terser-webpack-plugin": "^1.2.3",
     "url-join": "^4.0.0",
-    "url-search-params-polyfill": "^5.0.0",
+    "url-search-params-polyfill": "^5.1.0",
     "webpack": "^4.29.3",
     "helmet": "^3.16.0",
     "express-sslify": "^1.2.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -70,7 +70,7 @@ dependencies:
   stylus-loader: 3.0.2
   terser-webpack-plugin: 1.2.3
   url-join: 4.0.0
-  url-search-params-polyfill: 5.0.0
+  url-search-params-polyfill: 5.1.0
   webpack: 4.29.6
   webpack-cli: 3.3.0
   webpack-dev-middleware: 3.6.1
@@ -11623,10 +11623,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
-  /url-search-params-polyfill/5.0.0:
+  /url-search-params-polyfill/5.1.0:
     dev: false
     resolution:
-      integrity: sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ==
+      integrity: sha512-yjFY7uw2xRf9e8Mg4ZVkZwtp8dMCC4cbBkEIZiTDpuSY2WJ9+Quw0wRhxncv32qaMQwmBQT+P847rO8PrFhhDA==
   /url/0.11.0:
     dependencies:
       punycode: 1.3.2
@@ -12126,7 +12126,7 @@ specifiers:
   stylus-loader: ^3.0.2
   terser-webpack-plugin: ^1.2.3
   url-join: ^4.0.0
-  url-search-params-polyfill: ^5.0.0
+  url-search-params-polyfill: ^5.1.0
   webpack: ^4.29.3
   webpack-cli: ^3.3.0
   webpack-dev-middleware: ^3.6.1

--- a/src/presenters/includes/embed.js
+++ b/src/presenters/includes/embed.js
@@ -9,8 +9,9 @@ const telescopeImageUrl = 'https://cdn.glitch.com/7138972f-76e1-43f4-8ede-84c3cd
 // TODO(sheridan) make this more robust in future
 const browserSatisfiesRequirements = (() => {
   try {
-    if (URLSearchParams.name !== 'URLSearchParams') {
-      throw new Error('URLSearchParams is minified, so it must have been polyfilled');
+    const test = new Function('return () => true'); // eslint-disable-line no-new-func
+    if (test()() !== true) {
+      throw new Error('Arrow functions are not supported, so the editor will not work');
     }
     return true;
   } catch (error) {


### PR DESCRIPTION
Use `new Function()` to test the features we care about without transpilation getting in the way.

Embeds now work on latest ff/chrome/edge, and get hidden in chrome 41