### PR TITLE
Fixed a bug that was breaking team analytics

### DIFF
--- a/src/presenters/includes/team-analytics.js
+++ b/src/presenters/includes/team-analytics.js
@@ -115,8 +115,8 @@ class TeamAnalytics extends React.Component {
     });
 
     const { id, api, projects } = this.props;
-    const { fromDate, currentProjectsDomain } = this.state;
-    getAnalytics({ id, api, projects, fromDate, currentProjectsDomain }).then((data) => {
+    const { fromDate, currentProjectDomain } = this.state;
+    getAnalytics({ id, api, projects, fromDate, currentProjectDomain }).then((data) => {
       this.setState(
         {
           isGettingData: false,


### PR DESCRIPTION
Bug: https://glitch.manuscript.com/f/cases/3328184/Analytics-by-project-are-broken-in-production

currentProjectDomain had been renamed to currentProjectsDomain, so we were never updating the project whose analytics the user wanted to pull.

Verify at https://wax-snowstorm.glitch.me/@glitch