### PR TITLE
Superficial park: show all items of type when filter applied

### DIFF
--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -65,10 +65,8 @@ const groups = [
   { id: 'collection', label: 'Collections', ResultComponent: ({ result }) => <CollectionItem collection={result} /> },
 ];
 
-
-
-const ShowMoreButton = ({ onClick }) => (
-  <button onClick={onClick}>Show All</button>
+const ShowMoreButton = ({ label, onClick }) => (
+  <button onClick={onClick}>Show All {label}</button>
 )
 
 const MAX_UNFILTERED_RESULTS = 20
@@ -111,13 +109,15 @@ function SearchResults({ query, searchResults }) {
         <div key={id}>
           <article>
             <Heading tagName="h2">{label}</Heading>
-            <ul className="result-container">
+            <ul className={`${id}s-container`}>
               {results.map((result) => (
-                <ResultComponent key={result.id} result={result} />
+                <li key={result.id}>
+                  <ResultComponent result={result} />
+                </li>
               ))}
             </ul>
           </article>
-          {canShowMoreResults && <ShowMoreButton onClick={() => setActiveFilter(id)} />}
+          {canShowMoreResults && <ShowMoreButton label={label} onClick={() => setActiveFilter(id)} />}
         </div>
       ))}
       {noResults && <NotFound name="any results" />}

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -19,7 +19,6 @@ import TeamItem from '../team-item';
 import UserItem from '../user-item';
 import CollectionItem from '../collection-item';
 
-
 const FilterContainer = ({ filters, activeFilter, setFilter, query }) => {
   const buttons = filters.map((filter) => ({
     name: filter.id,
@@ -47,8 +46,8 @@ const ProjectResult = ({ result }) => {
   const { currentUser } = useCurrentUser();
   const api = useAPI();
   return currentUser.login ? (
-    <ProjectItem 
-      project={result} 
+    <ProjectItem
+      project={result}
       projectOptions={{
         addProjectToCollection: (project, collection) => addProjectToCollection(api, project, collection),
       }}
@@ -65,13 +64,11 @@ const groups = [
   { id: 'collection', label: 'Collections', ResultComponent: ({ result }) => <CollectionItem collection={result} /> },
 ];
 
-const ShowMoreButton = ({ label, onClick }) => (
-  <button onClick={onClick}>Show All {label}</button>
-)
+const ShowMoreButton = ({ label, onClick }) => <button onClick={onClick}>Show All {label}</button>;
 
-const MAX_UNFILTERED_RESULTS = 20
+const MAX_UNFILTERED_RESULTS = 20;
 
-const groupIsInFilter = (id, activeFilter) => (activeFilter === 'all' || activeFilter === id);
+const groupIsInFilter = (id, activeFilter) => activeFilter === 'all' || activeFilter === id;
 
 function SearchResults({ query, searchResults }) {
   const [activeFilter, setActiveFilter] = useState('all');
@@ -80,19 +77,23 @@ function SearchResults({ query, searchResults }) {
 
   const filters = [
     { id: 'all', label: 'All' },
-    ...groups.map((group) => ({ 
-      ...group, 
-      hits: searchResults[group.id].length,
-      maxHits: activeFilter === group.id ? Infinity : MAX_UNFILTERED_RESULTS, 
-    })).filter((group) => group.hits > 0),
+    ...groups
+      .map((group) => ({
+        ...group,
+        hits: searchResults[group.id].length,
+        maxHits: activeFilter === group.id ? Infinity : MAX_UNFILTERED_RESULTS,
+      }))
+      .filter((group) => group.hits > 0),
   ];
-  
-  const renderedGroups = groups.map(group => ({
-    ...group,
-    isVisible: groupIsInFilter(group.id, activeFilter) && searchResults[group.id].length > 0,
-    results: activeFilter === group.id ? searchResults[group.id] : searchResults[group.id].slice(0, MAX_UNFILTERED_RESULTS),
-    canShowMoreResults: activeFilter !== group.id && searchResults[group.id].length > MAX_UNFILTERED_RESULTS,
-  })).filter(group => group.isVisible)
+
+  const renderedGroups = groups
+    .map((group) => ({
+      ...group,
+      isVisible: groupIsInFilter(group.id, activeFilter) && searchResults[group.id].length > 0,
+      results: activeFilter === group.id ? searchResults[group.id] : searchResults[group.id].slice(0, MAX_UNFILTERED_RESULTS),
+      canShowMoreResults: activeFilter !== group.id && searchResults[group.id].length > MAX_UNFILTERED_RESULTS,
+    }))
+    .filter((group) => group.isVisible);
 
   return (
     <main className="search-results">

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -108,7 +108,7 @@ function SearchResults({ query, searchResults }) {
       )}
       {renderedGroups.map(({ id, label, results, canShowMoreResults, ResultComponent }) => (
         <div key={id}>
-          <article>
+          <article className="search-results__group-container">
             <Heading tagName="h2">{label}</Heading>
             <ul className={`${id}s-container`}>
               {results.map((result) => (
@@ -117,8 +117,8 @@ function SearchResults({ query, searchResults }) {
                 </li>
               ))}
             </ul>
+            {canShowMoreResults && <ShowMoreButton label={label} onClick={() => setActiveFilter(id)} />}
           </article>
-          {canShowMoreResults && <ShowMoreButton label={label} onClick={() => setActiveFilter(id)} />}
         </div>
       ))}
       {noResults && <NotFound name="any results" />}

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -103,6 +103,8 @@ const groups = [
   { id: 'collection', label: 'Collections', ResultsComponent: CollectionResults },
 ];
 
+const MAX_UNFILTERED_RESULTS = 20
+
 const showGroup = (id, searchResults, activeFilter) => (activeFilter === 'all' || activeFilter === id) && searchResults[id].length > 0;
 
 function SearchResults({ query, searchResults }) {
@@ -112,8 +114,18 @@ function SearchResults({ query, searchResults }) {
 
   const filters = [
     { id: 'all', label: 'All' },
-    ...groups.map((group) => ({ ...group, hits: searchResults[group.id].length })).filter((group) => group.hits > 0),
+    ...groups.map((group) => ({ 
+      ...group, 
+      hits: searchResults[group.id].length,
+      maxHits: activeFilter === group.id ? Infinity : MAX_UNFILTERED_RESULTS, 
+    })).filter((group) => group.hits > 0),
   ];
+  
+  const renderedGroups = groups.map(group => ({
+    ...group,
+    results: activeFilter === group.id ? searchResults[group.id] : searchResults[group.id].slice(0, MAX_UNFILTERED_RESULTS),
+    canShowMoreResults: activeFilter === group.id
+  })).filter(group => group.isVisible)
 
   return (
     <main className="search-results">

--- a/src/presenters/project-item.js
+++ b/src/presenters/project-item.js
@@ -10,7 +10,7 @@ import Note from './note';
 import WrappingLink from './includes/wrapping-link';
 
 const ProjectItem = ({ project, collection, hideProjectDescriptions, ...props }) => (
-  <li>
+  <>
     <Note
       collection={collection}
       project={project}
@@ -40,7 +40,7 @@ const ProjectItem = ({ project, collection, hideProjectDescriptions, ...props })
         </div>
       </div>
     </WrappingLink>
-  </li>
+  </>
 );
 
 ProjectItem.propTypes = {

--- a/src/presenters/projects-list.js
+++ b/src/presenters/projects-list.js
@@ -4,7 +4,6 @@ import Heading from 'Components/text/heading';
 import ExpanderContainer from 'Components/containers/expander';
 import ProjectItem from './project-item';
 
-
 const ProjectsList = ({ title, placeholder, extraClasses, ...props }) => (
   <article className={`projects ${extraClasses}`}>
     <Heading tagName="h2">{title}</Heading>

--- a/src/presenters/projects-list.js
+++ b/src/presenters/projects-list.js
@@ -68,7 +68,9 @@ ExpandyProjects.defaultProps = {
 export const ProjectsUL = ({ showProjectDescriptions, ...props }) => (
   <ul className="projects-container">
     {props.projects.map((project) => (
-      <ProjectItem key={project.id} project={project} showProjectDescriptions={showProjectDescriptions} {...props} />
+      <li key={project.id}>
+        <ProjectItem key={project.id} project={project} showProjectDescriptions={showProjectDescriptions} {...props} />
+      </li>
     ))}
   </ul>
 );

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -93,17 +93,17 @@ export function useAlgoliaSearch(query) {
 
 async function searchTeams(api, query) {
   const { data } = await api.get(`teams/search?q=${query}`);
-  return data
+  return data;
 }
 
 async function searchUsers(api, query) {
   const { data } = await api.get(`users/search?q=${query}`);
-  return data
+  return data;
 }
 
 async function searchProjects(api, query) {
   const { data } = await api.get(`projects/search?q=${query}`);
-  return data
+  return data;
 }
 
 // This API is slow and is missing important data (so its unfit for production)

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -72,8 +72,6 @@ function formatHit(hit) {
 
 const emptyResults = { team: [], user: [], project: [], collection: [] };
 
-const MAX_RESULTS = 20;
-
 export function useAlgoliaSearch(query) {
   const [hits, setHits] = useState([]);
   useEffect(() => {
@@ -95,17 +93,17 @@ export function useAlgoliaSearch(query) {
 
 async function searchTeams(api, query) {
   const { data } = await api.get(`teams/search?q=${query}`);
-  return data.slice(0, MAX_RESULTS);
+  return data
 }
 
 async function searchUsers(api, query) {
   const { data } = await api.get(`users/search?q=${query}`);
-  return data.slice(0, MAX_RESULTS);
+  return data
 }
 
 async function searchProjects(api, query) {
   const { data } = await api.get(`projects/search?q=${query}`);
-  return data.slice(0, MAX_RESULTS);
+  return data
 }
 
 // This API is slow and is missing important data (so its unfit for production)
@@ -114,7 +112,7 @@ async function searchProjects(api, query) {
 async function searchCollections(api, query) {
   const { data } = await api.get(`collections/search?q=${query}`);
   // NOTE: collection URLs don't work correctly with these
-  return data.slice(0, MAX_RESULTS).map((coll) => ({
+  return data.map((coll) => ({
     ...coll,
     team: coll.teamId > 0 ? { id: coll.teamId } : null,
     user: coll.userId > 0 ? { id: coll.userId } : null,

--- a/styles/pages/search.styl
+++ b/styles/pages/search.styl
@@ -52,6 +52,9 @@
     margin-bottom: 2rem
     p
       margin: 0
+      
+.search-results__group-container
+  margin-bottom: 3rem
 
 // remove default search styling
 input[type="search"],

--- a/styles/pages/search.styl
+++ b/styles/pages/search.styl
@@ -15,7 +15,7 @@
         border-radius: 5px
         background: tertiary
   
-  .results-container
+  .projects-container, .teams-container, .users-container, .collections-container
     overflow: initial
     border-radius: 5px
     display: flex

--- a/styles/pages/search.styl
+++ b/styles/pages/search.styl
@@ -15,7 +15,7 @@
         border-radius: 5px
         background: tertiary
   
-  .projects-container, .teams-container, .users-container, .collections-container
+  .results-container
     overflow: initial
     border-radius: 5px
     display: flex

--- a/styles/projects.styl
+++ b/styles/projects.styl
@@ -57,6 +57,8 @@ project-avatar-size = 42px
     font-size: 14px
     margin-bottom: 0
 
+.projects,
+.search-results
   .projects-container
     margin: 0
     padding: 0


### PR DESCRIPTION
Currently, we limit search results to 20 items per type.
Instead, when showing all search result types, limit 20 items per type, but show all results when showing only a single type.

---

Indicate that there are more results than are visible in the filter badge. (Using an imprecise number here signals to the user that they should refine their search, and allows us to make a smaller initial search request.)
<img width="329" alt="Screen Shot 2019-03-30 at 9 54 42 AM" src="https://user-images.githubusercontent.com/938722/55277026-e54a3900-52d1-11e9-8df1-5ee77c1b206e.png">

---

Add a "show all" button to the bottom of the results for a type that sets the search filter.
<img width="1185" alt="Screen Shot 2019-03-30 at 9 52 34 AM" src="https://user-images.githubusercontent.com/938722/55277009-b7fd8b00-52d1-11e9-83c1-42c80e606786.png">
