### PR TITLE
Cedar deal: fix collection UI overflow

### DIFF
--- a/src/presenters/collection-item.js
+++ b/src/presenters/collection-item.js
@@ -102,7 +102,7 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
               <div className="collection-name-description button-area">
                 <div className="button">
                   <span className="project-badge private-project-badge" aria-label="private" />
-                  <div className="collectionname">{collection.name}</div>
+                  <div className="collection-name">{collection.name}</div>
                 </div>
                 <div
                   className="description"

--- a/src/presenters/collection-item.js
+++ b/src/presenters/collection-item.js
@@ -102,7 +102,7 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
               <div className="collection-name-description button-area">
                 <div className="button">
                   <span className="project-badge private-project-badge" aria-label="private" />
-                  <div className="project-name">{collection.name}</div>
+                  <div className="collectionname">{collection.name}</div>
                 </div>
                 <div
                   className="description"

--- a/styles/collections.styl
+++ b/styles/collections.styl
@@ -137,7 +137,9 @@ collection-avatar-size = 55px
     vertical-align: -13px
 
   .project-name
-    display: inline-block
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
 
   .description
     display: block
@@ -191,7 +193,8 @@ collection-avatar-size = 55px
       &:focus
         background-color: secondary-hover-on-color
     .project-link
-      display: block
+      display: flex
+      flex-direction: row
       padding: 7px 15px
   .projects-preview.empty
     height: 100%


### PR DESCRIPTION
## Links
* Remix link: https://cedar-deal.glitch.me/@modernserf
* Manuscript link: https://glitch.manuscript.com/f/cases/3328181/

## GIF/Screenshots ##

### Before
![Screen Shot 2019-04-01 at 2 06 28 PM](https://user-images.githubusercontent.com/938722/55349451-c1305880-5487-11e9-9cfd-1d5e23eee93b.png)

### After
![Screen Shot 2019-04-01 at 2 06 48 PM](https://user-images.githubusercontent.com/938722/55349460-c5f50c80-5487-11e9-8e83-5942a460067c.png)

## Changes
* make long project names in collections ellipsify when they're too big to fit on one line

## How To Test
- Look at collections with projects that have long project names as they appear on other pages, e.g. 
   + user page: https://cedar-deal.glitch.me/@modernserf
   + project page (included in collections) https://cedar-deal.glitch.me/~community-site-test-runner-staging

## Feedback I'm looking for
* is truncating the project title the desired effect, or should collection items have variable sizes? They have a fixed height defined in their CSS, but a lot of the other item components have variable height.