### PR TITLE
Lightning badger: Limit reported Sentry errors to Glitch.com

### DIFF
--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -1,7 +1,7 @@
-const onProductionSite = (projectDomain, apiEnvironment) => (projectDomain === 'community' || projectDomain === 'community-staging') && 
-  apiEnvironment === 'production';
+const onProductionSite = (projectDomain, apiEnvironment) =>
+  (projectDomain === 'community' || projectDomain === 'community-staging') && apiEnvironment === 'production';
 
-const filterSecrets = function (jsonEvent) {
+const filterSecrets = function(jsonEvent) {
   const tokens = ['facebookToken', 'gitAccessToken', 'githubToken', 'inviteToken', 'persistentToken'];
   tokens.forEach((token) => {
     const regexp = new RegExp(`"${token}":"[^"]+"`, 'g');
@@ -12,16 +12,16 @@ const filterSecrets = function (jsonEvent) {
 
 const ignoreErrors = ['Network Error', 'timeout', 'status code 401'];
 
-const beforeSend = function (projectDomain, apiEnv, event) {
- // if (!onProductionSite(projectDomain, apiEnv)) {
- //    return null;
- //  }
+const beforeSend = function(projectDomain, apiEnv, event) {
+  if (!onProductionSite(projectDomain, apiEnv)) {
+    return null;
+  }
 
   const json = filterSecrets(JSON.stringify(event));
   return JSON.parse(json);
 };
 
-const beforeBreadcrumb = function (breadcrumb) { 
+const beforeBreadcrumb = function(breadcrumb) {
   if (breadcrumb.category === 'console' && breadcrumb.data) {
     const extras = JSON.stringify(breadcrumb.data.extra);
     const filteredExtras = filterSecrets(extras);

--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -1,9 +1,6 @@
 const onProductionSite = (projectDomain, apiEnvironment) => (projectDomain === 'community' || projectDomain === 'community-staging') && 
   apiEnvironment === 'production';
 
-const isFromBrowserExtension = (event) => {
-  return false;
-}
 const filterSecrets = function (jsonEvent) {
   const tokens = ['facebookToken', 'gitAccessToken', 'githubToken', 'inviteToken', 'persistentToken'];
   tokens.forEach((token) => {

--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -1,6 +1,9 @@
 const onProductionSite = (projectDomain, apiEnvironment) => (projectDomain === 'community' || projectDomain === 'community-staging') && 
   apiEnvironment === 'production';
 
+const isFromBrowserExtension = (event) => {
+  return false;
+}
 const filterSecrets = function (jsonEvent) {
   const tokens = ['facebookToken', 'gitAccessToken', 'githubToken', 'inviteToken', 'persistentToken'];
   tokens.forEach((token) => {

--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -13,9 +13,9 @@ const filterSecrets = function (jsonEvent) {
 const ignoreErrors = ['Network Error', 'timeout', 'status code 401'];
 
 const beforeSend = function (projectDomain, apiEnv, event) {
- if (!onProductionSite(projectDomain, apiEnv)) {
-    return null;
-  }
+ // if (!onProductionSite(projectDomain, apiEnv)) {
+ //    return null;
+ //  }
 
   const json = filterSecrets(JSON.stringify(event));
   return JSON.parse(json);

--- a/src/components/inputs/text-input.js
+++ b/src/components/inputs/text-input.js
@@ -12,7 +12,22 @@ const TYPES = ['email', 'password', 'search', 'text'];
 
 const InputPart = ({ children }) => <span className={styles.inputPart}>{children}</span>;
 
-const TextInput = ({ autoFocus, className, disabled, error, labelText, maxLength, name, onChange, opaque, placeholder, postfix, prefix, type, value }) => {
+const TextInput = ({
+  autoFocus,
+  className,
+  disabled,
+  error,
+  labelText,
+  maxLength,
+  name,
+  onChange,
+  opaque,
+  placeholder,
+  postfix,
+  prefix,
+  type,
+  value,
+}) => {
   const uniqueId = useUniqueId();
   const outerClassName = classNames(className, styles.outer);
   const borderClassName = classNames(styles.inputBorder, {

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -81,7 +81,7 @@ const loadCollection = async (api, { owner, name }) => {
     }
     captureException(error);
   }
-  throw new Error('testing');
+
   return null;
 };
 

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -44,7 +44,6 @@ const CollectionWide = ({ collection }) => {
           View all <Pluralize count={collection.projectCount} singular="project" /> <span aria-hidden>→</span>
         </CollectionLink>
       </div>
-    {() => throw Error('testing')}
     </article>
   );
 };
@@ -82,6 +81,7 @@ const loadCollection = async (api, { owner, name }) => {
     }
     captureException(error);
   }
+  throw new Error('testing');
   return null;
 };
 

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -23,7 +23,6 @@ const CollectionWide = ({ collection }) => {
   const dark = isDarkColor(collection.coverColor) ? 'dark' : '';
   const featuredProjects = sampleSize(collection.projects, 3);
   const featuredProjectsHaveAtLeastOneNote = featuredProjects.filter((p) => !!p.note).length > 0;
-
   return (
     <article className="collection-wide projects" style={{ backgroundColor: collection.coverColor }}>
       <header className={`collection ${dark}`}>
@@ -45,6 +44,7 @@ const CollectionWide = ({ collection }) => {
           View all <Pluralize count={collection.projectCount} singular="project" /> <span aria-hidden>→</span>
         </CollectionLink>
       </div>
+    {() => throw Error('testing')}
     </article>
   );
 };

--- a/src/presenters/pop-overs/create-team-pop.js
+++ b/src/presenters/pop-overs/create-team-pop.js
@@ -126,7 +126,13 @@ class CreateTeamPopBase extends React.Component {
 
         <section className="pop-over-actions">
           <form onSubmit={this.handleSubmit}>
-            <TextInput labelText={placeholder} value={this.state.teamName} onChange={this.handleChange} placeholder={placeholder} error={this.state.error} />
+            <TextInput
+              labelText={placeholder}
+              value={this.state.teamName}
+              onChange={this.handleChange}
+              placeholder={placeholder}
+              error={this.state.error}
+            />
             <p className="action-description team-url-preview">/@{_.kebabCase(this.state.teamName || placeholder)}</p>
 
             {this.state.isLoading ? (

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -22,7 +22,7 @@ try {
     environment: ENVIRONMENT,
     release: `community@${BUILD_TIMESTAMP}`,
     ignoreErrors: SentryHelpers.ignoreErrors,
-    whitelistUrls: [/glitch\.com/],
+    whitelistUrls: ['/glitch.com/'],
     beforeSend(event) {
       try {
         return SentryHelpers.beforeSend(PROJECT_DOMAIN, _env, event);

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -22,6 +22,7 @@ try {
     environment: ENVIRONMENT,
     release: `community@${BUILD_TIMESTAMP}`,
     ignoreErrors: SentryHelpers.ignoreErrors,
+    whitelistUrls: ["glitch.com"],
     beforeSend(event) {
       try {
         return SentryHelpers.beforeSend(PROJECT_DOMAIN, _env, event);

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -22,7 +22,7 @@ try {
     environment: ENVIRONMENT,
     release: `community@${BUILD_TIMESTAMP}`,
     ignoreErrors: SentryHelpers.ignoreErrors,
-    whitelistUrls: ["glitch.com"],
+    whitelistUrls: [/glitch\.com/],
     beforeSend(event) {
       try {
         return SentryHelpers.beforeSend(PROJECT_DOMAIN, _env, event);


### PR DESCRIPTION
## Links
* Remix link: https://lightning-badger.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3327972/Sentry-exclude-errors-from-browser-extensions
* Specs/Notion docs: n/a

## GIF/Screenshots: n/a

## Changes:
* Adds `glitch.com` to `whitelistUrls` in Sentry initialization to prevent external errors from being reported

## How To Test:
* In`https://glitch.com/edit/#!/lightning-badger?path=shared/sentryHelpers.js:16:0` modify the condition so that errors will be reported when not on production, and then cause an error.

## Feedback I'm looking for:

Configuration.

## Things left to do before deploying:
- [ ] Test
