### PR TITLE
Iris okapi: Update email sign in to have consistent error styles

### DIFF
--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -106,7 +106,14 @@ class EmailHandler extends React.Component {
             <section className="pop-over-actions first-section">
               {!this.state.done && (
                 <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
-                  <input value={this.state.email} onChange={this.onChange} className="pop-over-input" type="email" placeholder="new@user.com" />
+                  <TextInput
+                    type="email"
+                    labelText="new@user.com"
+                    value={this.state.email}
+                    onChange={this.onChange}
+                    placeholder="new@user.com"
+                    error={this.state.errorMsg}
+                  />
                   <button type="submit" style={{ marginTop: 10 }} className="button-small button-link" disabled={!isEnabled}>
                     Send Link
                   </button>

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -53,14 +53,9 @@ class EmailHandler extends React.Component {
       error: false,
       errorMsg: '',
     };
-    this.debouncedValidate = debounce(this.onChange.bind(this), 5000);
+    this.debouncedValidate = debounce(this.validate.bind(this), 500);
     this.onChange = this.onChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
-  }
-
-  validate(email) {
-    const isValidEmail = parseOneAddress(email) !== null;
-    this.setState({ errorMsg: isValidEmail ? undefined : 'Enter an email address.' });
   }
 
   onChange(email) {
@@ -100,6 +95,11 @@ class EmailHandler extends React.Component {
         });
       }
     }
+  }
+
+  validate(email) {
+    const isValidEmail = parseOneAddress(email) !== null;
+    this.setState({ errorMsg: isValidEmail ? undefined : 'Enter an email address.' });
   }
 
   render() {

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -99,7 +99,7 @@ class EmailHandler extends React.Component {
 
   validate(email) {
     const isValidEmail = parseOneAddress(email) !== null;
-    this.setState({ errorMsg: isValidEmail ? undefined : 'Enter an email address.' });
+    this.setState({ errorMsg: isValidEmail ? undefined : 'Enter a valid email address' });
   }
 
   render() {

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import dayjs from 'dayjs';
 import { parseOneAddress } from 'email-addresses';
-
+import debounce from 'lodash/debounce';
 import TextInput from 'Components/inputs/text-input';
 import { Link } from '../includes/link';
 import useLocalStorage from '../../state/local-storage';
@@ -53,13 +53,19 @@ class EmailHandler extends React.Component {
       error: false,
       errorMsg: '',
     };
+    this.debouncedValidate = debounce(this.onChange.bind(this), 5000);
     this.onChange = this.onChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  onChange(email) {
+  validate(email) {
     const isValidEmail = parseOneAddress(email) !== null;
-    this.setState({ email, errorMsg: isValidEmail ? undefined : 'Enter an email address.' });
+    this.setState({ errorMsg: isValidEmail ? undefined : 'Enter an email address.' });
+  }
+
+  onChange(email) {
+    this.setState({ email });
+    this.debouncedValidate(email);
   }
 
   async onSubmit(e) {

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import dayjs from 'dayjs';
+import { parseOneAddress } from 'email-addresses';
 
 import TextInput from 'Components/inputs/text-input';
 import { Link } from '../includes/link';
@@ -57,6 +58,7 @@ class EmailHandler extends React.Component {
   }
 
   onChange(email) {
+    console.log(parseOneAddress(email));
     this.setState({ email });
   }
 

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -58,8 +58,8 @@ class EmailHandler extends React.Component {
   }
 
   onChange(email) {
-    console.log(parseOneAddress(email));
-    this.setState({ email });
+    const isValidEmail = parseOneAddress(email) !== null;
+    this.setState({ email, errorMsg: isValidEmail ? undefined : 'Enter an email address.' });
   }
 
   async onSubmit(e) {
@@ -109,7 +109,8 @@ class EmailHandler extends React.Component {
               {!this.state.done && (
                 <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
                   <TextInput
-                    labelText="new@user.com"
+                    type="email"
+                    labelText="Email address"
                     value={this.state.email}
                     onChange={this.onChange}
                     placeholder="new@user.com"

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -56,8 +56,8 @@ class EmailHandler extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  onChange(e) {
-    this.setState({ email: e.target.value });
+  onChange(email) {
+    this.setState({ email });
   }
 
   async onSubmit(e) {
@@ -107,7 +107,6 @@ class EmailHandler extends React.Component {
               {!this.state.done && (
                 <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
                   <TextInput
-                    type="email"
                     labelText="new@user.com"
                     value={this.state.email}
                     onChange={this.onChange}

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import dayjs from 'dayjs';
 
+import TextInput from 'Components/inputs/text-input';
 import { Link } from '../includes/link';
 import useLocalStorage from '../../state/local-storage';
 import PopoverWithButton from './popover-with-button';


### PR DESCRIPTION
## Links
* Remix link: https://iris-okapi.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3327691/
* Specs/Notion docs: https://www.notion.so/glitch/87bda09f85184c1d81e1659aa62e4392?v=78db6cf11f8a43859bd17bc800cebde0&p=40dcbd076b574f1695d94094742608e5

## GIF/Screenshots:
![Screenshot 2019-04-04 at 10 49 57 AM](https://user-images.githubusercontent.com/1237410/55577033-76048880-56c7-11e9-8e48-2348251ca67b.png)


## Changes:
* Previously the error would show after submitting that an invalid email was submitted. This checks for a valid email first and then displays an error below the text input.

## How To Test:
* Try to enter an invalid email and see what happens on ~community and this remix.

## Feedback I'm looking for:
I think this is just the quickest way to make the styles consistent. There are probably notes we could make as we componentize more things.

## Things left to do before deploying:
