### PR TITLE
Stingy print: store active search filter in query params

### DIFF
--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -125,9 +125,10 @@ const Router = () => (
       <Route
         path="/search"
         exact
-        render={({ location }) => (
-          <SearchPage key={location.key} query={parse(location.search, 'q')} activeFilter={parse(location.search, 'activeFilter')} />
-        )}
+        render={({ location }) => {
+          const query = parse(location.search, 'q');
+          return <SearchPage key={query} query={query} activeFilter={parse(location.search, 'activeFilter')} />;
+        }}
       />
 
       {categories.map((category) => (

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -122,7 +122,8 @@ const Router = () => (
         <Route key={name} path={`/${name}`} exact render={({ location }) => <TeamPage key={location.key} id={rootTeams[name]} name={name} />} />
       ))}
 
-      <Route path="/search" exact render={({ location }) => <SearchPage key={location.key} query={parse(location.search, 'q')} />} />
+      <Route path="/search" exact render={({ location }) => 
+        <SearchPage key={location.key} query={parse(location.search, 'q')} activeFilter={parse(location.search, 'searchType')} />} />
 
       {categories.map((category) => (
         <Route

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -122,8 +122,13 @@ const Router = () => (
         <Route key={name} path={`/${name}`} exact render={({ location }) => <TeamPage key={location.key} id={rootTeams[name]} name={name} />} />
       ))}
 
-      <Route path="/search" exact render={({ location }) => 
-        <SearchPage key={location.key} query={parse(location.search, 'q')} activeFilter={parse(location.search, 'searchType')} />} />
+      <Route
+        path="/search"
+        exact
+        render={({ location }) => (
+          <SearchPage key={location.key} query={parse(location.search, 'q')} activeFilter={parse(location.search, 'activeFilter')} />
+        )}
+      />
 
       {categories.map((category) => (
         <Route

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -76,14 +76,12 @@ const MAX_UNFILTERED_RESULTS = 20;
 
 const groupIsInFilter = (id, activeFilter) => activeFilter === 'all' || activeFilter === id;
 
-const validFilter = (activeFilter) => ['all', 'team', 'user', 'project', 'collection'].includes(activeFilter);
-
 const SearchResults = withRouter(({ query, searchResults, activeFilter, history }) => {
   const setActiveFilter = (filter) => {
     history.push(`/search?q=${query}&activeFilter=${filter}`);
   };
 
-  if (!validFilter(activeFilter)) {
+  if (!searchResults[activeFilter] || searchResults[activeFilter].length <= 0) {
     activeFilter = 'all';
   }
 

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { withRouter } from 'react-router-dom';

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -21,7 +21,7 @@ import { Loader } from '../includes/loader';
 import MoreIdeas from '../more-ideas';
 import NotFound from '../includes/not-found';
 
-const FilterContainer = ({ filters, activeFilter, setActiveFilter, query }) => {
+const FilterContainer = ({ filters, activeFilter, setFilter, query }) => {
   const buttons = filters.map((filter) => ({
     name: filter.id,
     contents: (
@@ -34,7 +34,7 @@ const FilterContainer = ({ filters, activeFilter, setActiveFilter, query }) => {
 
   return (
     <>
-      <SegmentedButtons value={activeFilter} buttons={buttons} onChange={setActiveFilter} />
+      <SegmentedButtons value={activeFilter} buttons={buttons} onChange={setFilter} />
       {activeFilter === 'all' && <h1>All results for {query}</h1>}
     </>
   );
@@ -119,7 +119,7 @@ const SearchResults = withRouter(({ query, searchResults, activeFilter, history 
         </>
       )}
       {ready && searchResults.totalHits > 0 && (
-        <FilterContainer filters={filters} activeFilter={activeFilter} setActiveFilter={setActiveFilter} query={query} />
+        <FilterContainer filters={filters} setFilter={setActiveFilter} activeFilter={activeFilter} query={query} />
       )}
       {renderedGroups.map(({ id, label, results, canShowMoreResults, ResultComponent }) => (
         <div key={id}>

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -98,18 +98,31 @@ export function useAlgoliaSearch(query) {
   };
 }
 
+// When the URL changes, the whole search page unmounts, so 
+const legacySearchResultCache = {
+  requests: new Map(),
+  get (api, url) {
+    if (this.requests.has(url)) {
+      return this.requests.get(url)
+    }
+    const request = api.get(url)
+    this.requests.set(url, request)
+    return request
+  }
+}
+
 async function searchTeams(api, query) {
-  const { data } = await api.get(`teams/search?q=${query}`);
+  const { data } = await legacySearchResultCache.get(api, `teams/search?q=${query}`);
   return data;
 }
 
 async function searchUsers(api, query) {
-  const { data } = await api.get(`users/search?q=${query}`);
+  const { data } = await legacySearchResultCache.get(api, `users/search?q=${query}`);
   return data;
 }
 
 async function searchProjects(api, query) {
-  const { data } = await api.get(`projects/search?q=${query}`);
+  const { data } = await legacySearchResultCache.get(api, `projects/search?q=${query}`);
   return data;
 }
 
@@ -117,7 +130,7 @@ async function searchProjects(api, query) {
 // But its still useful for comparing against Algolia
 // eslint-disable-next-line no-unused-vars
 async function searchCollections(api, query) {
-  const { data } = await api.get(`collections/search?q=${query}`);
+  const { data } = await legacySearchResultCache.get(api, `collections/search?q=${query}`);
   // NOTE: collection URLs don't work correctly with these
   return data.map((coll) => ({
     ...coll,

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -98,31 +98,18 @@ export function useAlgoliaSearch(query) {
   };
 }
 
-// When the URL changes, the whole search page unmounts, so 
-const legacySearchResultCache = {
-  requests: new Map(),
-  get (api, url) {
-    if (this.requests.has(url)) {
-      return this.requests.get(url)
-    }
-    const request = api.get(url)
-    this.requests.set(url, request)
-    return request
-  }
-}
-
 async function searchTeams(api, query) {
-  const { data } = await legacySearchResultCache.get(api, `teams/search?q=${query}`);
+  const { data } = await api.get(`teams/search?q=${query}`);
   return data;
 }
 
 async function searchUsers(api, query) {
-  const { data } = await legacySearchResultCache.get(api, `users/search?q=${query}`);
+  const { data } = await api.get(`users/search?q=${query}`);
   return data;
 }
 
 async function searchProjects(api, query) {
-  const { data } = await legacySearchResultCache.get(api, `projects/search?q=${query}`);
+  const { data } = await api.get(`projects/search?q=${query}`);
   return data;
 }
 
@@ -130,7 +117,7 @@ async function searchProjects(api, query) {
 // But its still useful for comparing against Algolia
 // eslint-disable-next-line no-unused-vars
 async function searchCollections(api, query) {
-  const { data } = await legacySearchResultCache.get(api, `collections/search?q=${query}`);
+  const { data } = await api.get(`collections/search?q=${query}`);
   // NOTE: collection URLs don't work correctly with these
   return data.map((coll) => ({
     ...coll,


### PR DESCRIPTION
## Links
* Remix link: https://stingy-print.glitch.me/search
* Manuscript link: https://glitch.manuscript.com/f/cases/3328201/

## Changes:
* activeFilter is now a query param, so you can link to a category of search results, and the search filter is persistent across page refreshes

## How To Test:
* search: https://stingy-print.glitch.me/search?q=community
* apply a filter and refresh the page
* it should show the filtered search results

## Feedback I'm looking for:
- Is this useful / worthwhile?
- Does this impact loading performance?