### PR TITLE
Torpid existence - added TOS & privacy policy to sign in pop

### DIFF
--- a/src/curated/featured.js
+++ b/src/curated/featured.js
@@ -14,18 +14,18 @@ Example:
 // make sure image urls use https
 export default [
   {
-    title: 'Create Colored Ink Patterns',
-    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_final-05.png?1554128528416',
-    link: 'https://glitch.com/~marbled-paper',
+    title: 'You Make The Rules',
+    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_final-03.png?1554128528198',
+    link: 'https://abiding-cyclone.glitch.me/',
   },
   {
-    title: 'You Can Be Mayo Hero',
-    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_final-07.png?1554128529193',
-    link: 'https://mayo-hero.glitch.me/',
+    title: 'Generate Freestyle Weaving Patterns',
+    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_final-02.png?1554128529639',
+    link: 'https://weaving-pattern.glitch.me/',
   },
   {
-    title: 'Ga Ga for Radio?',
-    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_final-01.png?1554128581859',
-    link: 'https://rdio.glitch.me/',  
+    title: 'Channel Your Inner Bach',
+    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_final-08.png?1554128529037',
+    link: 'https://coconet.glitch.me/',  
   }
 ];

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -230,7 +230,7 @@ const NewUserInfoSection = () => (
 );
 
 const SignInCodeSection = ({ onClick }) => (
-  <section className="pop-over-actions last-section pop-over-info first-section">
+  <section className="pop-over-actions pop-over-info">
     <button className="button-small button-tertiary button-on-secondary-background" onClick={onClick} type="button">
       <span>Use a sign in code</span>
     </button>
@@ -239,6 +239,12 @@ const SignInCodeSection = ({ onClick }) => (
 SignInCodeSection.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
+
+const TermsAndPrivacySection = () => (
+  <section className="pop-over-actions pop-over-info last-section">
+    <span></span>
+  </section>
+)
 
 const SignInPopWithoutRouter = (props) => {
   const { header, prompt, api, location, hash } = props;

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -131,7 +131,6 @@ class EmailHandler extends React.Component {
                 }}
               />
             )}
-            <TermsAndPrivacySection />
           </dialog>
         )}
       </NestedPopover>
@@ -242,12 +241,12 @@ SignInCodeSection.propTypes = {
 };
 
 const TermsAndPrivacySection = () => (
-  <section className="pop-over-actions pop-over-info last-section">
-    <aside>
-      By signing into Glitch, you agree to our <a href="https://glitch.com/legal/#tos">Terms of Services</a> and{' '}
-      <a href="https://glitch.com/legal/#privacy">Privacy Statement</a>.
-    </aside>
-  </section>
+  <aside className="pop-over-info last-section">
+    By signing into Glitch, you agree to our {" "}
+    <Link to="/legal/#tos">Terms of Services</Link>
+    {" "} and {" "} 
+    <Link to="/legal/#privacy">Privacy Statement</Link>
+  </aside>
 );
 
 const SignInPopWithoutRouter = (props) => {
@@ -290,6 +289,7 @@ const SignInPopWithoutRouter = (props) => {
                   showCodeLogin(api);
                 }}
               />
+              <TermsAndPrivacySection />
             </div>
           )}
         </NestedPopover>

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -242,9 +242,9 @@ SignInCodeSection.propTypes = {
 
 const TermsAndPrivacySection = () => (
   <aside className="pop-over-info last-section">
-    By signing into Glitch, you agree to our {" "}
+    By signing into Glitch, you agree to our {' '}
     <Link to="/legal/#tos">Terms of Services</Link>
-    {" "} and {" "} 
+    {' '} and {' '}
     <Link to="/legal/#privacy">Privacy Statement</Link>
   </aside>
 );

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -131,6 +131,7 @@ class EmailHandler extends React.Component {
                 }}
               />
             )}
+            <TermsAndPrivacySection />
           </dialog>
         )}
       </NestedPopover>
@@ -242,9 +243,12 @@ SignInCodeSection.propTypes = {
 
 const TermsAndPrivacySection = () => (
   <section className="pop-over-actions pop-over-info last-section">
-    <span></span>
+    <aside>
+      By signing into Glitch, you agree to our <a href="https://glitch.com/legal/#tos">Terms of Services</a> and{' '}
+      <a href="https://glitch.com/legal/#privacy">Privacy Statement</a>.
+    </aside>
   </section>
-)
+);
 
 const SignInPopWithoutRouter = (props) => {
   const { header, prompt, api, location, hash } = props;

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -56,7 +56,6 @@ popover-secondary-background()
   aside
     color: text-on-secondary-background
     font-size: 12px
-    text-align: center
     padding: 10px 12px
   .content-editable
     padding-left: 5px


### PR DESCRIPTION
## Links
* Remix link https://torpid-existence.glitch.me/
* Manuscript link https://glitch.manuscript.com/f/cases/3328252/add-TOS-and-privacy-agreement-to-sign-up-pop-over
* Specs/Notion docs

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/519336/55638858-2c36a380-5796-11e9-984a-d9ccb37325f3.png)

## Changes:
* Added terms of services and privacy statement to our sign-in-pop

## How To Test:
* Click on the sign in pop

## Feedback I'm looking for:


## Things left to do before deploying:
