### PR TITLE
Fix alignment of help items on homepage and /questions

### DIFF
--- a/styles/includes/projects-collections-teams-users-container.styl
+++ b/styles/includes/projects-collections-teams-users-container.styl
@@ -5,6 +5,7 @@
   display: grid
   grid-template-columns: 1fr
   grid-gap: 10px
+  align-items: start
   list-style-type: none
   padding: 0
 


### PR DESCRIPTION
[manuscript case](https://glitch.manuscript.com/f/cases/3328275/Help-requests-are-getting-stretched-out-behind-the-featured-stuff)
[twist-tuba.glitch.me/questions](https://twisty-tuba.glitch.me/questions)

## Feedback I'm looking for:
These changes also affect any lists that use one of `.projects-container`, `.users-container`, `.teams-container`, `.collections-container`. I've checked that adding the `align-items` property doesn't introduce any regressions, but it would be great to get some extra eyes on team/user pages, collections, and search results