### PR TITLE
Knowing apology: `and`, not `or`

### DIFF
--- a/src/components/user/users-list.js
+++ b/src/components/user/users-list.js
@@ -114,7 +114,7 @@ const PlaceholderUsersList = () => (
 );
 
 const UsersList = ({ glitchTeam, users, layout, teams, avatarsOnly }) => {
-  if (!users || !teams) {
+  if (!users && !teams) {
     return <PlaceholderUsersList />;
   }
 


### PR DESCRIPTION
fix bug where users list never loads for legacy project results