### PR TITLE
Fertile Ruby: fix algolia autocomplete

### DIFF
--- a/src/components/search/autocomplete.js
+++ b/src/components/search/autocomplete.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import MaskImage from 'Components/images/mask-image';
 import { TeamAvatar, UserAvatar } from 'Components/images/avatar';
-import { Link, TeamLink, UserLink, ProjectLink, CollectionLink } from '../../presenters/includes/link';
+import { Link, TeamLink, UserLink, ProjectLink } from '../../presenters/includes/link';
 import ProjectAvatar from '../../presenters/includes/project-avatar';
 import CollectionAvatar from '../../presenters/includes/collection-avatar';
 import { useAlgoliaSearch } from '../../state/search';
@@ -53,6 +53,12 @@ const ProjectResult = ({ value: project }) => (
       <div className={styles.infoSecondary}>{project.description}</div>
     </div>
   </ProjectLink>
+);
+
+const CollectionLink = ({ collection, children, ...props }) => (
+  <a href={`/@${collection.fullUrl}`} {...props}>
+    {children}
+  </a>
 );
 
 const CollectionResult = ({ value: collection }) => (


### PR DESCRIPTION
https://fertile-ruby.glitch.me

## Summary
Autocomplete was breaking because CollectionLink was expecting the collections to have a fully populated user/team object, but search collection results have a `fullUrl` parameter instead.

## How to test
* enable algolia flag in https://fertile-ruby.glitch.me/secret
* search for "react"
* search should contain react collections
* clicking a collection result should take you to that collection