### PR TITLE
Bloom velociraptor: updates for team search results

### DIFF
--- a/src/components/blocks/search-result-cover-bar.styl
+++ b/src/components/blocks/search-result-cover-bar.styl
@@ -1,8 +1,8 @@
 .cover
   width: 100%
   height: 10px
-  border-top-right-radius: 5px
-  border-top-left-radius: 5px
+  border-radius: 5px 5px 0 0
+  overflow: hidden
   img
     display: block
     object-fit: none

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -3,7 +3,7 @@
   position: relative
   color: inherit
   text-decoration: none
-  border-radius: 0.5rem
+  border-radius: 5px
   &:hover
     text-decoration: none
   &:after
@@ -31,6 +31,12 @@
   
 .description
   font-size: 14px
+  padding-bottom: 8px
+  p
+    margin-bottom: 0
+    word-break: break-word
+    a
+      color: inherit
   
 .collectionAvatarContainer
   flex: 0 0 40px
@@ -44,7 +50,7 @@
   padding: 0.5rem
   font-size: 14px
   font-weight: 600
-  border-radius: 0 0 0.5rem 0.5rem
+  border-radius: 0 0 5px 5px
   
 a:hover .smallProjectCount
   text-decoration: underline

--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -38,7 +38,7 @@
   color: inherit
   background-color: #e5e5e5
   border-color: #e5e5e5
-  border-radius: 0.5rem
+  border-radius: 5px
   padding: 1rem 1rem 0.5rem
   min-height: 150px
   text-decoration: none

--- a/src/components/search/search-results.js
+++ b/src/components/search/search-results.js
@@ -60,6 +60,9 @@ const useTeams = createAPIHook(async (api, teamIDs) => {
   return Object.values(data);
 });
 
+
+
+
 function ProjectWithDataLoading({ project, ...props }) {
   const { value: users } = useUsers(project.userIDs);
   const { value: teams } = useTeams(project.teamIDs);

--- a/src/components/search/search-results.js
+++ b/src/components/search/search-results.js
@@ -38,25 +38,25 @@ const FilterContainer = ({ filters, activeFilter, setFilter, query }) => {
   );
 };
 
+// Search results from algolia do not contain their associated users or teams,
+// so those need to be fetched after the search results have loaded.
 const useTeamUsers = createAPIHook(async (api, teamID) => {
-  const { data } = await api.get(`/v1/teams/by/id/users?id=${teamID}`)
-  return data
-})
+  const res = await api.get(`/v1/teams/by/id/users?id=${teamID}`);
+  return res.data.items;
+});
 
 function TeamWithDataLoading({ team }) {
-  const { data: users } = useTeamUsers(team.id)
-  return <TeamItem team={{...team, users }} />
+  const { value: users } = useTeamUsers(team.id);
+  return <TeamItem team={{ ...team, users }} />;
 }
 
 const TeamResult = ({ result }) => {
   if (!result.users) {
-    return <TeamWithDataLoading team={result} />
+    return <TeamWithDataLoading team={result} />;
   }
-  return <TeamItem team={result} />
-}
+  return <TeamItem team={result} />;
+};
 
-// Project and collection search results (from algolia) do not contain their associated users,
-// so those need to be fetched after the search results have loaded.
 const useUsers = createAPIHook(async (api, userIDs) => {
   if (!userIDs.length) {
     return undefined;

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -7,7 +7,6 @@ import Markdown from 'Components/text/markdown';
 import Cover from 'Components/blocks/search-result-cover-bar';
 import Image from 'Components/images/image';
 import Thanks from 'Components/blocks/thanks';
-import { StaticUsersList } from 'Components/user/users-list';
 import { getAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
 import { TeamLink } from '../../presenters/includes/link';
 import { VerifiedBadge } from '../../presenters/includes/team-elements';
@@ -29,9 +28,6 @@ const TeamItem = ({ team }) => (
         <div>
           <Button decorative>{team.name}</Button>
           {!!team.isVerified && <VerifiedBadge />}
-        </div>
-        <div className={styles.usersList}>
-          <StaticUsersList users={team.users} layout="block" />
         </div>
         <Markdown length={96}>{team.description || ' '}</Markdown>
         <Thanks count={getTeamThanksCount(team)} />

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -7,7 +7,7 @@ import Markdown from 'Components/text/markdown';
 import Cover from 'Components/blocks/search-result-cover-bar';
 import Image from 'Components/images/image';
 import Thanks from 'Components/blocks/thanks';
-import { StaticUsersList } from 'Components/user/users-list';
+import UsersList from 'Components/user/users-list';
 import { getAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
 import { TeamLink } from '../../presenters/includes/link';
 import { VerifiedBadge } from '../../presenters/includes/team-elements';
@@ -31,7 +31,7 @@ const TeamItem = ({ team }) => (
           {!!team.isVerified && <VerifiedBadge />}
         </div>
         <div className={styles.usersList}>
-          <StaticUsersList users={team.users} layout="block" />
+          <UsersList avatarsOnly users={team.users} layout="block" />
         </div>
         <Markdown length={96}>{team.description || ' '}</Markdown>
         <Thanks count={getTeamThanksCount(team)} />

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -7,6 +7,7 @@ import Markdown from 'Components/text/markdown';
 import Cover from 'Components/blocks/search-result-cover-bar';
 import Image from 'Components/images/image';
 import Thanks from 'Components/blocks/thanks';
+import { StaticUsersList } from 'Components/user/users-list';
 import { getAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
 import { TeamLink } from '../../presenters/includes/link';
 import { VerifiedBadge } from '../../presenters/includes/team-elements';
@@ -28,6 +29,9 @@ const TeamItem = ({ team }) => (
         <div>
           <Button decorative>{team.name}</Button>
           {!!team.isVerified && <VerifiedBadge />}
+        </div>
+        <div className={styles.usersList}>
+          <StaticUsersList users={team.users} layout="block" />
         </div>
         <Markdown length={96}>{team.description || ' '}</Markdown>
         <Thanks count={getTeamThanksCount(team)} />

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -33,9 +33,7 @@ const TeamItem = ({ team }) => (
         <div className={styles.usersList}>
           <UsersList avatarsOnly users={team.users} layout="block" />
         </div>
-        <div className={styles.descriptionWrap}>
-          <Markdown length={96}>{team.description || ' '}</Markdown>
-        </div>
+        <Markdown length={96}>{team.description || ' '}</Markdown>
         <Thanks count={getTeamThanksCount(team)} />
       </div>
     </div>

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -33,7 +33,9 @@ const TeamItem = ({ team }) => (
         <div className={styles.usersList}>
           <UsersList avatarsOnly users={team.users} layout="block" />
         </div>
-        <Markdown length={96}>{team.description || ' '}</Markdown>
+        <div className={styles.descriptionWrap}>
+          <Markdown length={96}>{team.description || ' '}</Markdown>
+        </div>
         <Thanks count={getTeamThanksCount(team)} />
       </div>
     </div>
@@ -45,7 +47,7 @@ TeamItem.propTypes = {
     description: PropTypes.string.isRequired,
     isVerified: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
-    users: PropTypes.array.isRequired,
+    users: PropTypes.array,
     url: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/src/components/team/team-item.styl
+++ b/src/components/team/team-item.styl
@@ -2,8 +2,7 @@
 
 .container
   display: block
-  overflow: hidden
-  border-radius: 0.5rem
+  border-radius: 5px
   background-color: #e5e5e5
   font-size: 14px
   text-decoration: none
@@ -32,7 +31,9 @@
 .body
   flex: 1 1 auto
   padding-left: 0.5rem
-  // for markdown component  
+      
+.descriptionWrap
+  overflow: hidden
   p
     margin-bottom: 0
     a

--- a/src/components/team/team-item.styl
+++ b/src/components/team/team-item.styl
@@ -31,10 +31,9 @@
 .body
   flex: 1 1 auto
   padding-left: 0.5rem
-      
-.descriptionWrap
-  overflow: hidden
+  // for markdown component  
   p
     margin-bottom: 0
+    word-break: break-word
     a
       color: inherit

--- a/src/components/user/user-item.styl
+++ b/src/components/user/user-item.styl
@@ -38,5 +38,6 @@
   // for markdown component
   p
     margin-bottom: 0
+    word-break: break-word
     a
       color: inherit

--- a/src/components/user/user-item.styl
+++ b/src/components/user/user-item.styl
@@ -3,8 +3,7 @@
 .container
   color: inherit
   display: block
-  overflow: hidden
-  border-radius: 0.5rem
+  border-radius: 5px
   background-color: #e5e5e5
   font-size: 14px
   text-decoration: none

--- a/src/components/user/users-list.js
+++ b/src/components/user/users-list.js
@@ -34,12 +34,13 @@ export const StaticUsersList = ({ users, teams, layout }) => {
 };
 
 StaticUsersList.propTypes = {
-  users: PropTypes.array.isRequired,
+  users: PropTypes.array,
   teams: PropTypes.array,
   layout: PropTypes.oneOf(['row', 'block']).isRequired,
 };
 
 StaticUsersList.defaultProps = {
+  users: [],
   teams: [],
 };
 

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -2,7 +2,7 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'glitch-this-week-april-12-2019' },
+  { owner: 'glitch', name: 'sketch-with-p-5' },
   { owner: 'glitch', name: 'code-with-comics' },
   { owner: 'glitch', name: 'draw-with-music' }
 ];

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -2,7 +2,7 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'sketch-with-p-5' },
+  { owner: 'glitch', name: 'glitch-this-week-april-12-2019' },
   { owner: 'glitch', name: 'code-with-comics' },
   { owner: 'glitch', name: 'draw-with-music' }
 ];

--- a/src/curated/featured-embed.js
+++ b/src/curated/featured-embed.js
@@ -6,7 +6,7 @@ export default {
   image: 'https://community.glitch.me/culture/content/images/2019/04/Glitch_Illo_TechArt-VR-Headline-v1--1-.png',
   mask: 'mask-4',
   title: 'Master WebVR This Week',
-  appDomain: 'aframe-vr-10-print',
+  appDomain: 'aframe-bvh-mocap',
   blogUrl: '/master-webvr-with-a-week-of-experiments/',
   body,
   color: '#f5f5f5',

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -89,8 +89,7 @@ const formatByType = {
     thanksCount: user.thanks,
   }),
   team: (team) => ({
-    users: [],
-    isVerified: false,
+  isVerified: false,
     ...team,
     id: Number(team.objectID.replace('team-', '')),
   }),

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -89,7 +89,7 @@ const formatByType = {
     thanksCount: user.thanks,
   }),
   team: (team) => ({
-  isVerified: false,
+    isVerified: false,
     ...team,
     id: Number(team.objectID.replace('team-', '')),
   }),


### PR DESCRIPTION
## Links
* Remix link: https://bloom-velociraptor.glitch.me

## GIF/Screenshots
![Screen Shot 2019-04-12 at 12 36 38 PM](https://user-images.githubusercontent.com/938722/56052550-b7c4ad00-5d1f-11e9-8a43-54aecc544634.png)

## Changes:
* load team users in algolia search results
* fix overflow issues in team/user descriptions (allow overflow of tooltips, but break long words in descriptions)
* use consistent border radii for search result items
* incorporate fixes from #427

## How To Test:
* enable algolia search at https://bloom-velociraptor.glitch.me/secret
* search https://bloom-velociraptor.glitch.me/search?q=community&activeFilter=all

## Feedback I'm looking for:
* Does team user loading work correctly?
* Is this the right strategy for text overflow?