### PR TITLE
hail-diploma: Change reference of environment

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -21,10 +21,7 @@ module.exports = function(external) {
   // CORS - Allow pages from any domain to make requests to our API
   app.use(function(request, response, next) {
     response.header('Access-Control-Allow-Origin', '*');
-    response.header(
-      'Access-Control-Allow-Headers',
-      'Origin, X-Requested-With, Content-Type, Accept',
-    );
+    response.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
 
     // security headers added by jenn to get mozilla observatory score up
     response.header('X-XSS-Protection', '1; mode=block');
@@ -66,9 +63,7 @@ module.exports = function(external) {
         }
       });
     } catch (error) {
-      console.error(
-        "Failed to load webpack stats file. Unless you see a webpack error here, the initial build probably just isn't ready yet.",
-      );
+      console.error("Failed to load webpack stats file. Unless you see a webpack error here, the initial build probably just isn't ready yet.");
       built = false;
     }
 
@@ -99,7 +94,7 @@ module.exports = function(external) {
       },
     }),
   );
-  
+
   app.use(function(req, res, next) {
     res.header('Cache-Control', 'public, max-age=1');
     return next();
@@ -161,7 +156,7 @@ module.exports = function(external) {
 
   app.get('/auth/:domain', async (req, res) => {
     const { domain } = req.params;
-    
+
     res.render('api-auth.ejs', {
       domain: domain,
       CONSTANTS: constants,

--- a/server/routes.js
+++ b/server/routes.js
@@ -85,7 +85,7 @@ module.exports = function(external) {
       PROJECT_DOMAIN: process.env.PROJECT_DOMAIN,
       ENVIRONMENT: process.env.NODE_ENV || 'dev',
       CONSTANTS: constants,
-      RUNNING_ON: process.env.RUNNING_ON,
+      RUNNING_ON: constants.currentEnv,
     });
   }
 
@@ -161,11 +161,11 @@ module.exports = function(external) {
 
   app.get('/auth/:domain', async (req, res) => {
     const { domain } = req.params;
-    console.log("Olivia", process.env.RUNNING_ON)
+    
     res.render('api-auth.ejs', {
       domain: domain,
       CONSTANTS: constants,
-      RUNNING_ON: process.env.RUNNING_ON,
+      RUNNING_ON: constants.currentEnv,
     });
   });
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -85,7 +85,7 @@ module.exports = function(external) {
       PROJECT_DOMAIN: process.env.PROJECT_DOMAIN,
       ENVIRONMENT: process.env.NODE_ENV || 'dev',
       CONSTANTS: constants,
-      RUNNING_ON: constants.currentEnv,
+      RUNNING_ON: process.env.RUNNING_ON,
     });
   }
 
@@ -165,7 +165,7 @@ module.exports = function(external) {
     res.render('api-auth.ejs', {
       domain: domain,
       CONSTANTS: constants,
-      RUNNING_ON: constants.currentEnv,
+      RUNNING_ON: process.env.RUNNING_ON,
     });
   });
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -161,7 +161,7 @@ module.exports = function(external) {
 
   app.get('/auth/:domain', async (req, res) => {
     const { domain } = req.params;
-
+    console.log("Olivia", process.env.RUNNING_ON)
     res.render('api-auth.ejs', {
       domain: domain,
       CONSTANTS: constants,

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -2,9 +2,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'sketch-with-p-5' },
-  { owner: 'glitch', name: 'code-with-comics' },
-  { owner: 'glitch', name: 'draw-with-music' }
+  { owner: 'glitch', name: 'glitch-this-week-april-17-2019' },
+  { owner: 'glitch', name: 'digital-deliciousness' },
+  { owner: 'glitch', name: 'apps-for-writers' }
 ];
 
 // More ideas is populated from this team

--- a/views/api-auth.ejs
+++ b/views/api-auth.ejs
@@ -2,6 +2,7 @@
   <body>
     <script>
       const CONSTANTS = <%- JSON.stringify(CONSTANTS) %>;
+      const RUNNING_ON = '<%= RUNNING_ON %>';
       let _env;
       if (RUNNING_ON === 'development') {
         _env = 'development';


### PR DESCRIPTION
## Links
* Remix link: https://hail-diploma.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3328329/operations-has-an-error-RUNNING_ON-is-not-defined-in-api-auth-ejs
* Specs/Notion docs: n/a

## Changes:
* Load `RUNNING_ON` in `api-auth.ejs`.

## How To Test:
* Everything should be the same as before.

## Feedback I'm looking for:
* ~There's a note in the `api-auth.ejs` about potential security implications changing this setup. Is this a safe change?~
* ~Should the template reference the `currentEnv` variable instead?~
* ~Should I just reverse the check in the template (`"development" === RUNNING_ON`?)~

## Things left to do before deploying:
- [x] Discuss.
