### PR TITLE
Dart Meteor: only set width if ref is mounted

### DIFF
--- a/src/components/profile/profile-list.js
+++ b/src/components/profile/profile-list.js
@@ -29,7 +29,9 @@ const useResizeObserver = () => {
   const [width, setWidth] = useState(0);
   useEffect(() => {
     const setWidthOfRef = () => {
-      setWidth(ref.current.getBoundingClientRect().width);
+      if (ref.current) {
+        setWidth(ref.current.getBoundingClientRect().width);
+      }
     };
     const debouncedSetWidth = debounce(setWidthOfRef, 100);
     setWidthOfRef();


### PR DESCRIPTION
## Links
* Remix link: https://dark-meteor.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3328317/Cannot-read-property-getBoundingClientRect-of-null
* Specs/Notion docs

## Changes:
* Don't try to get the component's width if it's not mounted.

## How To Test:
* No idea, I didn't encounter this in development. My hypothesis is that this is happening when someone navigates while a ProfileList is resizing, but there's a very narrow window when that would happen and I couldn't get it to work in dev. Deploy and see if the sentry errors decrease?