### PR TITLE
Imaginary tourmaline: Webpack stop deleting storybook files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,7 +150,7 @@ module.exports = smp.wrap({
       hash: true,
       publicPath: true,
     }),
-    new CleanWebpackPlugin({ verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*', '!stats.json']}),
+    new CleanWebpackPlugin({ verbose: true, cleanOnceBeforeBuildPatterns: ['!storybook/*', '!stats.json']}),
   ],
   watchOptions: {
     ignored: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,7 +150,7 @@ module.exports = smp.wrap({
       hash: true,
       publicPath: true,
     }),
-    new CleanWebpackPlugin(),
+    new CleanWebpackPlugin({ verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*', 'stats.json']}),
   ],
   watchOptions: {
     ignored: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,7 +150,7 @@ module.exports = smp.wrap({
       hash: true,
       publicPath: true,
     }),
-    new CleanWebpackPlugin({ verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*', 'stats.json']}),
+    new CleanWebpackPlugin({ verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*', '!stats.json']}),
   ],
   watchOptions: {
     ignored: /node_modules/,


### PR DESCRIPTION
## Changes:
* Clean Webpack Plugin changed to verbose (so we can see what files it's removing), and no longer removes the storybook folder or stats.json