### PR TITLE
Bead-Walrus: fix z-index for dropdowns

### DIFF
--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -8,6 +8,8 @@
   
 .userListContainer
   max-width: 100%
+  position: relative
+  z-index: 1
   &.spaceForOptions
     max-width: calc(100% - 30px)
 

--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -5,7 +5,6 @@
   margin-top: 0rem
   margin-bottom: 0.5rem
   position: relative
-  z-index: 1
   
 .userListContainer
   max-width: 100%


### PR DESCRIPTION
## Links
* https://bead-walrus.glitch.me/
* https://glitch.manuscript.com/f/cases/3328320/

## GIF/Screenshots:
before 😭 notice how the user avatars on the project item below it are appearing above the pop over
![Screen Shot 2019-04-19 at 10 43 03 AM](https://user-images.githubusercontent.com/6620164/56429297-6755ce00-6290-11e9-9bc4-4ef148067c7a.png)
after 🎉 
![Screen Shot 2019-04-19 at 10 43 23 AM](https://user-images.githubusercontent.com/6620164/56429306-6f157280-6290-11e9-997f-4d9d843dc75e.png)

## Changes:
* moves the z-index of 1 to a lower level component (I believe we have it there mainly for the hover tooltips that tell users the names of each user avatar)

## How To Test:
* I tried to map out everywhere we use project items and as best I can tell everything looks good but feel free to give it your own test!
- [x] search page
- [x] featured-collections (on home page)
- [x] related-projects on the project page
- [x] category page
- [x] collection page
- [x] recent-projects on team page
- [x] recent-projects on user page

## Feedback I'm looking for:
* does this break anything I didn't know to test for? 
* honestly I'm still a little mystified why the original code doesn't work so if you see why I bet I would learn a thing about zindexes I didn't learn before. Here's my current understanding of what's happening:
```
header (parent) - zIndex of 1, position relative (needed for user name hover tooltips)
   - userList (unrelated to the problem, but somehow I am the solution)
   - wrapper (direct child)
       - down arrow button (grandchild) - zindex of 1, position relative 
          - actual arrow (greatgrandchild) has opacity less than 1**
       - dialog (grandchild) - zindex of 10, position absolute (not working?)
```
**  I don't think this great grandchild matters in this instance, but [TIL sometimes it does!](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/)

Anyway my understanding of these things is that because they are all children of header the fact that it has a z-index of 1 shouldn't matter, that their z-indexes are relative from one child to another? AND YET it does? idk y'all. 

## Things left to do before deploying:
- [ ] I can do a quick crossbrowser test
