### PR TITLE
loud-cockroach: open new project popover from the right

### DIFF
--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -449,6 +449,7 @@ popover-secondary-background()
       
 .new-project-pop
   top: 26px
+  right: 0
   @media(max-width: smallViewport)
     right: 0px
     max-width: 200px


### PR DESCRIPTION
## Links
* https://loud-cockroach.glitch.me/
* https://glitch.manuscript.com/f/cases/3328349/New-Project-Pop-is-popping-up-off-the-screen

## GIF/Screenshots:
before 😭 
![Screen Shot 2019-04-19 at 11 37 15 AM](https://user-images.githubusercontent.com/6620164/56431393-8572fc80-6297-11e9-88e6-b4526a7a56ae.png)

after 🎉 
![Screen Shot 2019-04-19 at 11 36 51 AM](https://user-images.githubusercontent.com/6620164/56431712-c4558200-6298-11e9-8756-56f437a1bc93.png)

during 🐞 https://twitter.com/dykediscourse/status/1092885295865970688

## Changes:
* open new project popover from the right rather than the left

## How To Test:
* pretty sure this is used in only one place, you open the remix (and don't log in!) and click new project

## Feedback I'm looking for:
felt too easy did I forget to double check anything?

## Things left to do before deploying:
- [ ] quick crossbrowser test maybe?
