### PR TITLE
Strong duchess: enable algolia search for everyone

### DIFF
--- a/src/presenters/includes/dev-toggles.js
+++ b/src/presenters/includes/dev-toggles.js
@@ -26,6 +26,7 @@ const toggleData = [
   {
     name: 'Algolia Search',
     description: 'Use the new Algolia-powered search API.',
+    enabledByDefault: true,
   },
 ].slice(0, 3); // <-- Yeah really, only 3.  If you need more, clean up one first.
 
@@ -39,7 +40,8 @@ const toggleData = [
 // };
 
 export const DevTogglesProvider = ({ children }) => {
-  const [enabledToggles, setEnabledToggles] = useUserPref('devToggles', []);
+  const defaultEnabledToggles = toggleData.filter(toggle => toggle.enabledByDefault).map(toggle => toggle.name);
+  const [enabledToggles, setEnabledToggles] = useUserPref('devToggles', defaultEnabledToggles);
   return <Context.Provider value={{ enabledToggles, toggleData, setEnabledToggles }}>{children}</Context.Provider>;
 };
 DevTogglesProvider.propTypes = {

--- a/src/presenters/includes/dev-toggles.js
+++ b/src/presenters/includes/dev-toggles.js
@@ -40,7 +40,7 @@ const toggleData = [
 // };
 
 export const DevTogglesProvider = ({ children }) => {
-  const defaultEnabledToggles = toggleData.filter(toggle => toggle.enabledByDefault).map(toggle => toggle.name);
+  const defaultEnabledToggles = toggleData.filter((toggle) => toggle.enabledByDefault).map((toggle) => toggle.name);
   const [enabledToggles, setEnabledToggles] = useUserPref('devToggles', defaultEnabledToggles);
   return <Context.Provider value={{ enabledToggles, toggleData, setEnabledToggles }}>{children}</Context.Provider>;
 };


### PR DESCRIPTION
Turn algolia search flag on by default.

if all goes well, a future PR will remove the non-algolia search code.