### PR TITLE
Somber humor: fix `New Stuff` dialog positioning

### DIFF
--- a/src/components/global.styl
+++ b/src/components/global.styl
@@ -7,4 +7,3 @@
 body
   font-family: sansserif
   color: primary
-  text-align: center

--- a/src/components/global.styl
+++ b/src/components/global.styl
@@ -7,3 +7,4 @@
 body
   font-family: sansserif
   color: primary
+  text-align: center

--- a/src/presenters/overlays/new-stuff.js
+++ b/src/presenters/overlays/new-stuff.js
@@ -120,12 +120,13 @@ const NewStuffContainer = ({ children, isSignedIn }) => {
   const [showNewStuff, setShowNewStuff] = useUserPref('showNewStuff', true);
   const [newStuffReadId, setNewStuffReadId] = useUserPref('newStuffReadId', 0);
   console.log(showNewStuff, newStuffReadId)
+  
   return (
     <NewStuff
       {...{
         isSignedIn,
         showNewStuff,
-        newStuffReadId,
+        newStuffReadId: 0,
         setShowNewStuff,
         setNewStuffReadId,
       }}

--- a/src/presenters/overlays/new-stuff.js
+++ b/src/presenters/overlays/new-stuff.js
@@ -119,14 +119,13 @@ NewStuff.propTypes = {
 const NewStuffContainer = ({ children, isSignedIn }) => {
   const [showNewStuff, setShowNewStuff] = useUserPref('showNewStuff', true);
   const [newStuffReadId, setNewStuffReadId] = useUserPref('newStuffReadId', 0);
-  console.log(showNewStuff, newStuffReadId)
-  
+
   return (
     <NewStuff
       {...{
         isSignedIn,
         showNewStuff,
-        newStuffReadId: 0,
+        newStuffReadId,
         setShowNewStuff,
         setNewStuffReadId,
       }}

--- a/src/presenters/overlays/new-stuff.js
+++ b/src/presenters/overlays/new-stuff.js
@@ -14,7 +14,7 @@ import newStuffLog from '../../curated/new-stuff-log';
 const latestId = Math.max(...newStuffLog.map(({ id }) => id));
 
 const NewStuffOverlay = ({ setShowNewStuff, showNewStuff, newStuff }) => (
-  <dialog className="pop-over overlay new-stuff-overlay overlay-narrow" open>
+  <dialog className="pop-over overlay new-stuff-overlay" open>
     <section className="pop-over-info">
       <figure className="new-stuff-avatar" />
       <div className="overlay-title">New Stuff</div>

--- a/src/presenters/overlays/new-stuff.js
+++ b/src/presenters/overlays/new-stuff.js
@@ -119,6 +119,7 @@ NewStuff.propTypes = {
 const NewStuffContainer = ({ children, isSignedIn }) => {
   const [showNewStuff, setShowNewStuff] = useUserPref('showNewStuff', true);
   const [newStuffReadId, setNewStuffReadId] = useUserPref('newStuffReadId', 0);
+  console.log(showNewStuff, newStuffReadId)
   return (
     <NewStuff
       {...{

--- a/styles/new-stuff.styl
+++ b/styles/new-stuff.styl
@@ -70,3 +70,6 @@
         max-width: 100%
     .image
       border-radius: 5px
+      
+dialog.new-stuff-overlay
+  max-width: 460px

--- a/styles/overlays.styl
+++ b/styles/overlays.styl
@@ -81,12 +81,6 @@ dialog.overlay
     .button
       margin-bottom: 14px
       margin-right: 0.5rem
-  
-  &.overlay-narrow
-    max-width: 460px
-    left: 0px
-    margin: 0 auto
-    transform: initial
 
   // wistia embed styling
   .wistia_responsive_padding


### PR DESCRIPTION
## Links
* https://somber-humor.glitch.me/
* https://glitch.manuscript.com/f/cases/3328343/New-stuff-pop-appears-on-the-left-on-Safari-from-homepage

## GIF/Screenshots:
before ☹️ 
<img width="1408" alt="Screen Shot 2019-04-22 at 1 32 28 PM" src="https://user-images.githubusercontent.com/6620164/56514404-287b7e80-6503-11e9-900e-8bb5ed095029.png">

after 💃  
<img width="1407" alt="Screen Shot 2019-04-22 at 1 32 02 PM" src="https://user-images.githubusercontent.com/6620164/56514416-3204e680-6503-11e9-98e8-0e5d1c192ca3.png">

## Changes:
* removes unused/broken class `overlay-narrow`
* updates `new-stuff-overlay` to have the correct width, removes `left`, `margin`, and `transform` properties as I don't think those added anything and added bugs in safari. 

## How To Test:
* if you don't see the new stuff dog/cat thing you can either mess with your localstorage.userPrefs or you can update line 128 to be `newStuffReadId: 0,` here: https://glitch.com/edit/#!/somber-humor?path=src/presenters/overlays/new-stuff.js:128:6 (just remember to remove it 😄 )

## Feedback I'm looking for:
anything I'm missing in removing some of this styling? seems legit to me?

## Things left to do before deploying:
- [x] crossbrowser testing (tested latest chrome/ff/safari/edge)
