### PR TITLE
Square salamander: use mask-image component on home page

### DIFF
--- a/src/components/images/mask-image.js
+++ b/src/components/images/mask-image.js
@@ -9,9 +9,9 @@ const maskClasses = maskClassesWithDash.map((className) => className.replace('-'
 
 const MaskImage = ({ maskClass: controlledMaskClass, ...props }) => {
   const randomMaskClass = useRef(sample(maskClasses));
-  const maskClass = controlledMaskClass.replace('-','') || randomMaskClass.current;
+  const maskClass = controlledMaskClass || randomMaskClass.current;
 
-  return <img alt="" {...props} className={classnames(styles.mask, styles[maskClass])} />;
+  return <img alt="" {...props} className={classnames(styles.mask, styles[maskClass.replace('-', '')])} />;
 };
 
 MaskImage.propTypes = {

--- a/src/components/images/mask-image.js
+++ b/src/components/images/mask-image.js
@@ -4,17 +4,18 @@ import classnames from 'classnames';
 import { sample } from 'lodash';
 import styles from './mask-image.styl';
 
-const maskClasses = ['mask1', 'mask2', 'mask3', 'mask4'];
+const maskClassesWithDash = ['mask-1', 'mask-2', 'mask-3', 'mask-4', 'mask-5'];
+const maskClasses = maskClassesWithDash.map((className) => className.replace('-', ''));
 
 const MaskImage = ({ maskClass: controlledMaskClass, ...props }) => {
   const randomMaskClass = useRef(sample(maskClasses));
-  const maskClass = controlledMaskClass || randomMaskClass.current;
+  const maskClass = controlledMaskClass.replace('-','') || randomMaskClass.current;
 
-  return <img {...props} alt="" className={classnames(styles.mask, styles[maskClass])} />;
+  return <img alt="" {...props} className={classnames(styles.mask, styles[maskClass])} />;
 };
 
 MaskImage.propTypes = {
-  maskClass: PropTypes.oneOf(maskClasses),
+  maskClass: PropTypes.oneOf([...maskClasses, ...maskClassesWithDash]),
 };
 
 MaskImage.defaultProps = {

--- a/src/components/images/mask-image.styl
+++ b/src/components/images/mask-image.styl
@@ -1,6 +1,5 @@
 .mask
   width: 100%
-  height: 100%
   object-fit: cover
   mask-size: contain
   mask-repeat: no-repeat

--- a/src/presenters/featured-embed.js
+++ b/src/presenters/featured-embed.js
@@ -3,15 +3,14 @@ import PropTypes from 'prop-types';
 
 import Heading from 'Components/text/heading';
 import Embed from 'Components/project/embed';
+import MaskImage from 'Components/images/mask-image';
 import { Link } from './includes/link';
 
 const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) => (
   <div className="featured-embed">
-    <div className="mask-container">
-      <Link to={`culture${blogUrl}`}>
-        <img className={`mask ${mask}`} src={image} alt="" />
-      </Link>
-    </div>
+    <Link to={`culture${blogUrl}`}>
+      <MaskImage maskClass={mask} src={image} />
+    </Link>
 
     <div className="content" style={{ backgroundColor: color }}>
       <div className="description">

--- a/src/presenters/featured-embed.js
+++ b/src/presenters/featured-embed.js
@@ -8,9 +8,11 @@ import { Link } from './includes/link';
 
 const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) => (
   <div className="featured-embed">
-    <Link to={`culture${blogUrl}`}>
-      <MaskImage maskClass={mask} src={image} />
-    </Link>
+    <div className="mask-container">
+      <Link to={`culture${blogUrl}`}>
+        <MaskImage maskClass={mask} src={image} />
+      </Link>
+    </div>
 
     <div className="content" style={{ backgroundColor: color }}>
       <div className="description">

--- a/src/presenters/featured.js
+++ b/src/presenters/featured.js
@@ -25,7 +25,11 @@ const ZineItems = () => {
         {posts.map(({ id, title, url, feature_image, primary_tag }, n) => (
           <li key={id} className="zine-item">
             <Link to={`/culture${url}`}>
-              {!!feature_image && <MaskImage maskClass={`mask${masks[n]}`} src={feature_image} alt="" />}
+              {!!feature_image && (
+                <div className="mask-container">
+                  <MaskImage maskClass={`mask${masks[n]}`} src={feature_image} />
+                </div>
+              )}
               <div className="zine-item-meta">
                 <h1 className="zine-item-title">{title}</h1>
                 {!!primary_tag && <p className="zine-item-tag">{primary_tag.name}</p>}

--- a/src/presenters/featured.js
+++ b/src/presenters/featured.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { sampleSize } from 'lodash';
 import Image from 'Components/images/image';
@@ -14,8 +14,8 @@ import FeaturedEmbed from './featured-embed';
 import { FeaturedCollections } from './featured-collections';
 
 const ZineItems = () => {
-  const [posts] = React.useState(window.ZINE_POSTS.slice(0, 4));
-  const [masks] = React.useState(sampleSize([1, 2, 3, 4, 5], 4));
+  const { current: posts } = useRef(window.ZINE_POSTS.slice(0, 4));
+  const { current: masks } = useRef(sampleSize([1, 2, 3, 4, 5], 4));
   if (!posts.length) {
     return null;
   }
@@ -25,9 +25,7 @@ const ZineItems = () => {
         {posts.map(({ id, title, url, feature_image, primary_tag }, n) => (
           <li key={id} className="zine-item">
             <Link to={`/culture${url}`}>
-              {!!feature_image && (
-                <MaskImage maskClass={`mask${masks[n]}`} src={feature_image} alt="" />
-              )}
+              {!!feature_image && <MaskImage maskClass={`mask${masks[n]}`} src={feature_image} alt="" />}
               <div className="zine-item-meta">
                 <h1 className="zine-item-title">{title}</h1>
                 {!!primary_tag && <p className="zine-item-tag">{primary_tag.name}</p>}

--- a/src/presenters/featured.js
+++ b/src/presenters/featured.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { sampleSize } from 'lodash';
 import Image from 'Components/images/image';
+import MaskImage from 'Components/images/mask-image';
 
 import FeaturedItems from '../curated/featured';
 import FeaturedEmbedObject from '../curated/featured-embed';
@@ -25,9 +26,7 @@ const ZineItems = () => {
           <li key={id} className="zine-item">
             <Link to={`/culture${url}`}>
               {!!feature_image && (
-                <div className="mask-container">
-                  <img className={`mask mask-${masks[n]}`} src={feature_image} alt="" />
-                </div>
+                <MaskImage maskClass={`mask${masks[n]}`} src={feature_image} alt="" />
               )}
               <div className="zine-item-meta">
                 <h1 className="zine-item-title">{title}</h1>

--- a/styles/includes/featured.styl
+++ b/styles/includes/featured.styl
@@ -97,24 +97,6 @@
     @media (max-width: smallViewport)
       margin: 0 auto
       width: 100%
-    .mask
-      width: 100%
-      height: 100%
-      object-fit: cover
-      mask-size: contain
-      mask-repeat: no-repeat
-      mask-position: center
-      mask-type: luminance
-    .mask-1
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-1.svg")
-    .mask-2
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-2.svg")
-    .mask-3
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-3.svg")
-    .mask-4
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-4.svg")
-    .mask-5
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-5.svg")      
   .content
     padding: 115px 20px 20px 20px
     box-shadow: 4px 4px #c3c3c3

--- a/styles/includes/zine-items.styl
+++ b/styles/includes/zine-items.styl
@@ -23,30 +23,6 @@
       height: 0
       padding-bottom: 60%
         
-    .mask-container img
-      position: absolute
-      width: 100%
-      height: 100%
-      object-fit: cover
-      border-radius: 5px
-
-    .mask
-      mask-type: luminance
-      mask-repeat: no-repeat
-      mask-position: center
-      mask-size: contain
-
-    .mask-1
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-1.svg")
-    .mask-2
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-2.svg")
-    .mask-3
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-3.svg")
-    .mask-4
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-4.svg")
-    .mask-5
-      mask-image: url("https://cdn.glitch.com/3cef6b25-69ba-4fa9-aa32-cff0fedce195%2Fmask-5.svg")
-
     .zine-item-meta
       background: secondary-background
       // z-index: -1


### PR DESCRIPTION
## Links
* Remix link https://square-salamander.glitch.me
* Manuscript link https://glitch.manuscript.com/f/cases/3328364/

## GIF/Screenshots:
![Screen Shot 2019-04-23 at 2 17 19 PM](https://user-images.githubusercontent.com/938722/56605817-f0dc0780-65d2-11e9-9011-d1b4d831c563.png)
![Screen Shot 2019-04-23 at 2 17 14 PM](https://user-images.githubusercontent.com/938722/56605818-f0dc0780-65d2-11e9-98e0-6a8909ec91be.png)
![Screen Shot 2019-04-23 at 2 18 25 PM](https://user-images.githubusercontent.com/938722/56605816-f0437100-65d2-11e9-863b-1ab5213ff0d6.png)

## Changes:
* use MaskImage component on home page
* tweaks for MaskImage component (add mask5 class, allow hyphenated class names, dont fit to height)
* remove old mask CSS

## How To Test:
* visit https://square-salamander.glitch.me
* verify the masks look correct on featured embed and culture blog links