### PR TITLE
Sweet blinker: Fix removing projects

### DIFF
--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -17,41 +17,35 @@ import styles from './projects-list.styl';
 
 const cx = classNames.bind(styles);
 
-function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enablePagination, ...props }) {
+function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enablePagination, projects, ...props }) {
   const [filter, setFilter] = useState('');
   const [filteredProjects, setFilteredProjects] = useState([]);
   const [isDoneFiltering, setIsDoneFiltering] = useState(false);
 
   const validFilter = filter.length > 1;
-  let { projects } = props;
-  console.log("no props", projects.length, "with props", props.projects.length)
+  
   function filterProjects() {
     setIsDoneFiltering(false);
-    console.log("inside filterProjects", projects.length)
     if (validFilter) {
-      console.log("validFilter")
       const lowercaseFilter = filter.toLowerCase();
       setFilteredProjects(projects.filter((p) => p.domain.includes(lowercaseFilter) || p.description.toLowerCase().includes(lowercaseFilter)));
       setIsDoneFiltering(true);
     } else {
-      console.log("not a valid filter")
       setFilteredProjects([]);
     }
   }
 
+  useEffect(() => filterProjects(), [projects]);
   useEffect(() => debounce(filterProjects, 400)(), [filter]);
-  useEffect(() => {
-    console.log("calling filterProjects");
-    filterProjects()
-  }, [projects]);
   
   const filtering = validFilter && isDoneFiltering;
-  projects = filtering ? filteredProjects : projects;
+  const displayedProjects = filtering ? filteredProjects : projects;
+  
   let projectsEl;
   if (enablePagination) {
-    projectsEl = <PaginatedProjects {...props} projects={projects} />;
+    projectsEl = <PaginatedProjects {...props} projects={displayedProjects} />;
   } else {
-    projectsEl = <ProjectsUL {...props} projects={projects} />;
+    projectsEl = <ProjectsUL {...props} projects={displayedProjects} />;
   }
 
   const placeholderEl = filtering ? (
@@ -80,8 +74,7 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
           />
         ) : null}
       </div>
-
-      {projects.length ? projectsEl : placeholderEl}
+      {displayedProjects.length ? projectsEl : placeholderEl}
     </article>
   );
 }

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -23,7 +23,7 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
   const [isDoneFiltering, setIsDoneFiltering] = useState(false);
 
   const validFilter = filter.length > 1;
-  
+
   function filterProjects() {
     setIsDoneFiltering(false);
     if (validFilter) {
@@ -37,10 +37,10 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
 
   useEffect(() => filterProjects(), [projects]);
   useEffect(() => debounce(filterProjects, 400)(), [filter]);
-  
+
   const filtering = validFilter && isDoneFiltering;
   const displayedProjects = filtering ? filteredProjects : projects;
-  
+
   let projectsEl;
   if (enablePagination) {
     projectsEl = <PaginatedProjects {...props} projects={displayedProjects} />;

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -23,22 +23,27 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
   const [isDoneFiltering, setIsDoneFiltering] = useState(false);
 
   const validFilter = filter.length > 1;
-  const totalUnfilteredProjects = props.projects;
   let { projects } = props;
-  console.log(...projects, ...props.projects)
+  console.log("no props", projects.length, "with props", props.projects.length)
   function filterProjects() {
     setIsDoneFiltering(false);
-
+    console.log("inside filterProjects", projects.length)
     if (validFilter) {
+      console.log("validFilter")
       const lowercaseFilter = filter.toLowerCase();
       setFilteredProjects(projects.filter((p) => p.domain.includes(lowercaseFilter) || p.description.toLowerCase().includes(lowercaseFilter)));
       setIsDoneFiltering(true);
     } else {
+      console.log("not a valid filter")
       setFilteredProjects([]);
     }
   }
 
-  useEffect(() => debounce(filterProjects, 400)(), [filter, projects]);
+  useEffect(() => debounce(filterProjects, 400)(), [filter]);
+  useEffect(() => {
+    console.log("calling filterProjects");
+    filterProjects()
+  }, [projects]);
   
   const filtering = validFilter && isDoneFiltering;
   projects = filtering ? filteredProjects : projects;

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -17,21 +17,20 @@ import styles from './projects-list.styl';
 
 const cx = classNames.bind(styles);
 
-function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enablePagination, projects, ...props }) {
+function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enablePagination, ...props }) {
   const [filter, setFilter] = useState('');
   const [filteredProjects, setFilteredProjects] = useState([]);
   const [isDoneFiltering, setIsDoneFiltering] = useState(false);
 
   const validFilter = filter.length > 1;
-
-  // let { projects } = props;
-
+  const totalUnfilteredProjects = props.projects;
+  let { projects } = props;
+  console.log(...projects, ...props.projects)
   function filterProjects() {
     setIsDoneFiltering(false);
 
     if (validFilter) {
       const lowercaseFilter = filter.toLowerCase();
-      console.log("projects in filter projects", ...projects)
       setFilteredProjects(projects.filter((p) => p.domain.includes(lowercaseFilter) || p.description.toLowerCase().includes(lowercaseFilter)));
       setIsDoneFiltering(true);
     } else {
@@ -39,11 +38,7 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
     }
   }
 
-  useEffect(() => debounce(filterProjects, 400)(), [filter]);
-  useEffect(() => {
-    console.log("projects in useEffect", ...projects)
-    setFilter(filter)
-  }, [projects]);
+  useEffect(() => debounce(filterProjects, 400)(), [filter, projects]);
   
   const filtering = validFilter && isDoneFiltering;
   projects = filtering ? filteredProjects : projects;

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -27,18 +27,21 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
   let { projects } = props;
 
   function filterProjects() {
+    console.log("filterProject is getting called", { propsprojects: props.projects, projects }, validFilter, filter); 
     setIsDoneFiltering(false);
 
     if (validFilter) {
+      console.log("Valid vilter")
       const lowercaseFilter = filter.toLowerCase();
       setFilteredProjects(props.projects.filter((p) => p.domain.includes(lowercaseFilter) || p.description.toLowerCase().includes(lowercaseFilter)));
       setIsDoneFiltering(true);
     } else {
+      console.log("not a valid filter")
       setFilteredProjects([]);
     }
   }
 
-  useEffect(() => debounce(filterProjects, 400)(), [filter]);
+  useEffect(() => debounce(filterProjects, 400)(), [filter, projects]);
 
   const filtering = validFilter && isDoneFiltering;
   projects = filtering ? filteredProjects : projects;
@@ -49,7 +52,7 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
   } else {
     projectsEl = <ProjectsUL {...props} projects={projects} />;
   }
-
+  console.log("filtering?", filtering)
   const placeholderEl = filtering ? (
     <div className={styles.filterResultsPlaceholder}>
       <Image alt="" src="https://cdn.glitch.com/c117d5df-3b8d-4389-9e6b-eb049bcefcd6%2Fcompass-not-found.svg?1554146070630" />

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -41,10 +41,10 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
     }
   }
 
-  useEffect(() => debounce(filterProjects, 400)(), [filter, projects]);
+  useEffect(() => debounce(filterProjects, 400)(), [filter, props.projects]);
 
   const filtering = validFilter && isDoneFiltering;
-  projects = filtering ? filteredProjects : projects;
+  projects = filtering ? filteredProjects : props.projects;
 
   let projectsEl;
   if (enablePagination) {
@@ -52,7 +52,7 @@ function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enabl
   } else {
     projectsEl = <ProjectsUL {...props} projects={projects} />;
   }
-  console.log("filtering?", filtering)
+
   const placeholderEl = filtering ? (
     <div className={styles.filterResultsPlaceholder}>
       <Image alt="" src="https://cdn.glitch.com/c117d5df-3b8d-4389-9e6b-eb049bcefcd6%2Fcompass-not-found.svg?1554146070630" />

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -17,35 +17,36 @@ import styles from './projects-list.styl';
 
 const cx = classNames.bind(styles);
 
-function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enablePagination, ...props }) {
+function ProjectsList({ title, placeholder, extraClasses, enableFiltering, enablePagination, projects, ...props }) {
   const [filter, setFilter] = useState('');
   const [filteredProjects, setFilteredProjects] = useState([]);
   const [isDoneFiltering, setIsDoneFiltering] = useState(false);
 
   const validFilter = filter.length > 1;
 
-  let { projects } = props;
+  // let { projects } = props;
 
   function filterProjects() {
-    console.log("filterProject is getting called", { propsprojects: props.projects, projects }, validFilter, filter); 
     setIsDoneFiltering(false);
 
     if (validFilter) {
-      console.log("Valid vilter")
       const lowercaseFilter = filter.toLowerCase();
-      setFilteredProjects(props.projects.filter((p) => p.domain.includes(lowercaseFilter) || p.description.toLowerCase().includes(lowercaseFilter)));
+      console.log("projects in filter projects", ...projects)
+      setFilteredProjects(projects.filter((p) => p.domain.includes(lowercaseFilter) || p.description.toLowerCase().includes(lowercaseFilter)));
       setIsDoneFiltering(true);
     } else {
-      console.log("not a valid filter")
       setFilteredProjects([]);
     }
   }
 
-  useEffect(() => debounce(filterProjects, 400)(), [filter, props.projects]);
-
+  useEffect(() => debounce(filterProjects, 400)(), [filter]);
+  useEffect(() => {
+    console.log("projects in useEffect", ...projects)
+    setFilter(filter)
+  }, [projects]);
+  
   const filtering = validFilter && isDoneFiltering;
-  projects = filtering ? filteredProjects : props.projects;
-
+  projects = filtering ? filteredProjects : projects;
   let projectsEl;
   if (enablePagination) {
     projectsEl = <PaginatedProjects {...props} projects={projects} />;

--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -67,6 +67,10 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
     animate(event, 'slide-down', () => props.deleteProject(props.project.id));
   }
 
+  function animateThenRemoveProjectFromTeam(event) {
+    animate(event, 'slide-down', () => props.removeProjectFromTeam(props.project.id));
+  }
+
   function featureProject(event) {
     animate(event, 'slide-up', () => props.featureProject(props.project.id));
   }
@@ -134,7 +138,7 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
       {(props.currentUserIsOnProject || !!props.removeProjectFromTeam) && !props.removeProjectFromCollection && (
         <section className="pop-over-actions danger-zone last-section">
           {!!props.removeProjectFromTeam && (
-            <PopoverButton onClick={() => props.removeProjectFromTeam(props.project.id)} text="Remove Project " emoji="thumbs_down" />
+            <PopoverButton onClick={animateThenRemoveProjectFromTeam} text="Remove Project " emoji="thumbs_down" />
           )}
 
           {props.currentUserIsOnProject && !props.removeProjectFromCollection && (


### PR DESCRIPTION
## Links
* https://sweet-blinker.glitch.me
* https://glitch.manuscript.com/f/cases/3328335/

## GIF/Screenshots:
http://g.recordit.co/ENHzTG95uw.gif

## Changes:
* we used to overwrite `props.projects` to whatever the filteredProjects results were which was fine in the initial render, but then if we tried to filter again after a delete or a remove it was filtering with the existing filtered projects rather than the whole list. By using another variable `displayedProjects` we ensure that whenever we call filterProjects we are filtering from the full and current list.
* useEffect to re-filter anytime props.projects changes.  
* add some animation to the removeProject from team function

## How To Test:
* on a team page: add a project, filter projects, and click "remove project" 
* on user page: create a throwaway project, filter projects, and click "delete project"
* just futz around with the projects filter on any page you see it and ensure it works as expected

## Feedback I'm looking for:
* I do find this thing in general to be a little...for lack of a better word....glitchy? filtering is very smooth, like buttah. But adding/removing projects not so much. Like you can see it sort of flash a bit, there's also a bit of a delay that I don't totally understand why (I do see we debounce on filter which makes sense but why on add/remove?). If you see things we can do to make this smoother or have ideas on things I should look for let me know! Otherwise this is probably at least an improvement to the current situation?
* any other use cases I'm missing?

## Things left to do before deploying:
- [x] crossbrowser test (tested briefly in chrome/firefox/safari)
