### PR TITLE
frosted-aquarius: Handle case where OAuth login fails due to no email provided

### DIFF
--- a/src/presenters/pages/login.js
+++ b/src/presenters/pages/login.js
@@ -49,7 +49,7 @@ const LoginPage = ({ provider, url }) => {
 
   const [state, setState] = React.useState({ status: 'active' });
   const setDone = () => setState({ status: 'done' });
-  const setError = (message) => setState({ status: 'error', message });
+  const setError = (title, message) => setState({ status: 'error', title, message });
 
   const perform = async () => {
     try {
@@ -66,11 +66,12 @@ const LoginPage = ({ provider, url }) => {
       notifyParent({ success: true, details: { provider } });
     } catch (error) {
       const errorData = error && error.response && error.response.data;
-      setError(errorData && errorData.message);
+      setError(undefined, errorData && errorData.message);
 
       if (error && error.response) {
         if (error.response.status === 403) {
-          const noEmailReturnedMessage = "We didn't get an email back from your login provider. Try signing in with your email address instead.";
+          const noEmailReturnedTitle = "Missing Email Address";
+          const noEmailReturnedMessage = `${provider} didn't return an email address for your account.  Try using "Sign in with Email" instead to create an account on Glitch.`;
           setError(noEmailReturnedMessage);
         } else if (error.response.status !== 401) {
           console.error('Login error.', errorData);
@@ -89,12 +90,14 @@ const LoginPage = ({ provider, url }) => {
     return <RedirectToDestination />;
   }
   if (state.status === 'error') {
+    const genericTitle = `${provider} Login Problem`;
     const genericDescription = "Hard to say what happened, but we couldn't log you in. Try again?";
+    const errorTitle = state.title || genericTitle;
     const errorMessage = state.message || genericDescription;
     if (provider === 'Email') {
-      return <EmailErrorPage title={`${provider} Login Problem`} description={errorMessage} />;
+      return <EmailErrorPage title={errorTitle} description={errorMessage} />;
     }
-    return <OauthErrorPage title={`${provider} Login Problem`} description={errorMessage} />;
+    return <OauthErrorPage title={errorTitle} description={errorMessage} />;
   }
   return <div className="content" />;
 };

--- a/src/presenters/pages/login.js
+++ b/src/presenters/pages/login.js
@@ -70,7 +70,8 @@ const LoginPage = ({ provider, url }) => {
 
       if (error && error.response) {
         if (error.response.status === 403) {
-          setError("403");
+          const noEmailReturnedMessage = "We didn't get an email back from your login provider. Try signing in with your email address instead.";
+          setError(noEmailReturnedMessage);
         } else if (error.response.status !== 401) {
           console.error('Login error.', errorData);
           captureException(error);

--- a/src/presenters/pages/login.js
+++ b/src/presenters/pages/login.js
@@ -70,9 +70,11 @@ const LoginPage = ({ provider, url }) => {
 
       if (error && error.response) {
         if (error.response.status === 403) {
-          const noEmailReturnedTitle = "Missing Email Address";
-          const noEmailReturnedMessage = `${provider} didn't return an email address for your account.  Try using "Sign in with Email" instead to create an account on Glitch.`;
-          setError(noEmailReturnedMessage);
+          // Our API returns a 403 when the login provider didn't return an email address
+          // We can suggest using email for login and avoid capturing this error in Sentry
+          const title = "Missing Email Address";
+          const message = `${provider} didn't return an email address for your account.  Try using "Sign in with Email" instead to create an account on Glitch.`;
+          setError(title, message);
         } else if (error.response.status !== 401) {
           console.error('Login error.', errorData);
           captureException(error);

--- a/src/presenters/pages/login.js
+++ b/src/presenters/pages/login.js
@@ -68,9 +68,13 @@ const LoginPage = ({ provider, url }) => {
       const errorData = error && error.response && error.response.data;
       setError(errorData && errorData.message);
 
-      if (error && error.response && error.response.status !== 401) {
-        console.error('Login error.', errorData);
-        captureException(error);
+      if (error && error.response) {
+        if (error.response.status === 403) {
+          setError("403");
+        } else if (error.response.status !== 401) {
+          console.error('Login error.', errorData);
+          captureException(error);
+        }
       }
       const details = { provider, error: errorData };
       notifyParent({ success: false, details });

--- a/src/presenters/pages/login.js
+++ b/src/presenters/pages/login.js
@@ -72,7 +72,7 @@ const LoginPage = ({ provider, url }) => {
         if (error.response.status === 403) {
           // Our API returns a 403 when the login provider didn't return an email address
           // We can suggest using email for login and avoid capturing this error in Sentry
-          const title = "Missing Email Address";
+          const title = 'Missing Email Address';
           const message = `${provider} didn't return an email address for your account.  Try using "Sign in with Email" instead to create an account on Glitch.`;
           setError(title, message);
         } else if (error.response.status !== 401) {


### PR DESCRIPTION
## Links
* Remix link: https://frosted-aquarius.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/edit/3327833/Handle-case-where-Facebook-or-Github-login-fails-due-to-no-email-provided-by-Facebook-Github
* Specs/Notion docs

## GIF/Screenshots:
![Screenshot 2019-04-24 at 12 35 52 PM](https://user-images.githubusercontent.com/1237410/56688452-9eabec80-668d-11e9-8c7f-b1e751461361.png)

## Changes:
When we get a `403` from the API after login we know that we didn't get an email back from the provider. This handles that case, suggests login with email instead, and no longer reports the error to Sentry.

I based this off of `nova-chance` because Greg has work on the same stuff that I didn't want to conflict with. It could go to `master` but it will have more changes in the diff.

## How To Test:
Signing up with a Facebook account with no email address associated will reproduce this. I have one if you want to use it. :(

## Feedback I'm looking for:
Always looking for any feedback.

## Things left to do before deploying:
- [ ] Review the copy and UI.
