### PR TITLE
Hail dungeon: Moved TOS & Privacy Statement in Sign-in-Pop

### DIFF
--- a/src/curated/featured.js
+++ b/src/curated/featured.js
@@ -24,7 +24,7 @@ export default [
     link: 'https://glitch.com/~planet-generator'
   },
   {
-    title: 'Step into the Metaverse... D\'oh',
+    title: 'Step Into the Metaverse',
     img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_homer.jpg?1552302001952',
     link: 'https://glitch.com/~homer-metaverse'  
   }

--- a/src/curated/featured.js
+++ b/src/curated/featured.js
@@ -14,18 +14,18 @@ Example:
 // make sure image urls use https
 export default [
   {
-    title: 'Which Domain Costs More?',
-    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fdomainpricing_final.jpg?1549281323718',
-    link: 'https://glitch.com/~domain-pricing'
-  },
-  {
-    title: 'Just Take A Moment',
-    img: 'https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2FYourMomentofZen.jpg?1541072010180',
-    link: 'https://glitch.com/~your-moment-of-zen'  
+    title: 'Get to the Escape Pod!',
+    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_space_extinguisher.jpg?1552302001273',
+    link: 'https://glitch.com/~space-extinguisher'
   },  
   {
-    title: 'I\'d Totally Eat That!',
-    img: 'https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2Ffood-hype.jpg?1540206366423',
-    link: 'https://glitch.com/~food-hype'
+    title: 'Make Your Own Planet',
+    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fplanetgenerator.jpg?1538392449068',
+    link: 'https://glitch.com/~planet-generator'
+  },
+  {
+    title: 'Step into the Metaverse... D\'oh',
+    img: 'https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fglitch_homer.jpg?1552302001952',
+    link: 'https://glitch.com/~homer-metaverse'  
   }
 ];

--- a/src/presenters/pop-overs/sign-in-pop.js
+++ b/src/presenters/pop-overs/sign-in-pop.js
@@ -267,7 +267,7 @@ SignInCodeSection.propTypes = {
 };
 
 const TermsAndPrivacySection = () => (
-  <aside className="pop-over-info last-section">
+  <aside className="pop-over-info">
     By signing into Glitch, you agree to our {' '}
     <Link to="/legal/#tos">Terms of Services</Link>
     {' '} and {' '}
@@ -298,6 +298,7 @@ const SignInPopWithoutRouter = (props) => {
             <div className="pop-over sign-in-pop">
               {header}
               <NewUserInfoSection />
+              <TermsAndPrivacySection />
               <section className="pop-over-actions">
                 {prompt}
                 <SignInPopButton href={facebookAuthLink()} company="Facebook" emoji="facebook" onClick={onClick} />
@@ -317,7 +318,6 @@ const SignInPopWithoutRouter = (props) => {
                   showCodeLogin(api);
                 }}
               />
-              <TermsAndPrivacySection />
             </div>
           )}
         </NestedPopover>


### PR DESCRIPTION
## Links
* Remix link: https://hail-dungeon.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3328424/move-TOS-Privacy-notice-in-sign-in-pop-over-to-above-buttons

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/519336/56748663-3f61e100-674e-11e9-9e3c-944a87e29ce4.png)

## Changes:
* Moved TOS & Privacy statement message to above sign in buttons based on nkasi's request (to help ensure users see it before they log in)
