### PR TITLE
Quixotic rocket: Use the rest api in current-user.js

### DIFF
--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -129,11 +129,13 @@ class CurrentUserManager extends React.Component {
   }
 
   async getSharedUser() {
+    const persistentToken = this.persistentToken();
+    if (!persistentToken) {
+      return undefined;
+    }
     try {
-      const {
-        data: { user },
-      } = await this.api().get('boot?latestProjectOnly=true');
-      return user;
+      const { data } = await this.api().get(`v1/users/by/persistentToken?persistentToken=${persistentToken}`);
+      return data[persistentToken];
     } catch (error) {
       if (error.response && error.response.status === 401) {
         return undefined;

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -161,7 +161,6 @@ class CurrentUserManager extends React.Component {
         collections: getAllPages(api, makeUrl('collections')),
       });
       const user = { ...baseUser, emails, projects, teams, collections };
-      console.log(user);
       if (!usersMatch(sharedUser, user)) {
         return 'error';
       }


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/
https://glitch.fogbugz.com/f/cases/3327984/Use-the-new-api-for-user-management

## Changes:
Gets rid of some calls to the old api and replaces them with equivalent rest api calls

## How To Test:
Try signing in and out, and use different pages on the site to make sure they aren't broken from a new data layout or something