### PR TITLE
Sideways decimal: Don't even try to fetch entities with invalid names

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -33,7 +33,7 @@ async function getCultureZinePosts() {
   console.log('Fetching culture zine posts');
   const client = 'client_id=ghost-frontend&client_secret=c9a97f14ced8';
   const params = 'filter=featured:true&limit=4&fields=id,title,url,feature_image,primary_tag&include=tags';
-  
+
   const response = await api.get(`https://culture-zine.glitch.me/culture/ghost/api/v0.1/posts/?${client}&${params}`);
   return response.data.posts;
 }
@@ -59,7 +59,6 @@ async function getFromCacheOrApi(key, api, ...args) {
     return null;
   }
 }
-
 
 module.exports = {
   getProject: (domain) => getFromCacheOrApi(`project ${domain}`, getProjectFromApi, domain),

--- a/server/routes.js
+++ b/server/routes.js
@@ -149,7 +149,7 @@ module.exports = function(external) {
   app.get('/@:name/:collection', async (req, res) => {
     const { name, collection } = req.params;
     if (!validateEntityName(name) || !validateEntityName(collection)) {
-      await render(res, `${collection}`, `We couldn't find @${name}/${collection}`);
+      await render(res, collection, `We couldn't find @${name}/${collection}`);
       return;
     }
     const collectionObj = await getCollection(`${name}/${collection}`);
@@ -165,7 +165,7 @@ module.exports = function(external) {
       await render(res, name, description);
       return;
     }
-    await render(res, `${collection}`, `We couldn't find @${name}/${collection}`);
+    await render(res, collection, `We couldn't find @${name}/${collection}`);
   });
 
   app.get('/auth/:domain', async (req, res) => {

--- a/server/routes.js
+++ b/server/routes.js
@@ -13,6 +13,8 @@ const { getProject, getTeam, getUser, getCollection, getZine } = require('./api'
 const initWebpack = require('./webpack');
 const constants = require('./constants');
 
+const validateEntityName = (name) => /^[A-Za-z0-9-]+$/.test(name);
+
 module.exports = function(external) {
   const app = express.Router();
 
@@ -102,6 +104,10 @@ module.exports = function(external) {
 
   app.get('/~:domain', async (req, res) => {
     const { domain } = req.params;
+    if (!validateEntityName(domain)) {
+      await render(res, domain, `We couldn't find ~${domain}`);
+      return;
+    }
     const project = await getProject(domain);
     if (!project) {
       await render(res, domain, `We couldn't find ~${domain}`);
@@ -115,6 +121,10 @@ module.exports = function(external) {
 
   app.get('/@:name', async (req, res) => {
     const { name } = req.params;
+    if (!validateEntityName(name)) {
+      await render(res, name, `We couldn't find @${name}`);
+      return;
+    }
     const team = await getTeam(name);
     if (team) {
       const description = team.description ? cheerio.load(md.render(team.description)).text() : '';
@@ -138,6 +148,10 @@ module.exports = function(external) {
 
   app.get('/@:name/:collection', async (req, res) => {
     const { name, collection } = req.params;
+    if (!validateEntityName(name) || !validateEntityName(collection)) {
+      await render(res, `${collection}`, `We couldn't find @${name}/${collection}`);
+      return;
+    }
     const collectionObj = await getCollection(`${name}/${collection}`);
     const author = name;
 


### PR DESCRIPTION
Update: taking a different approach on this one

## Links
* Remix link: https://sideways-decimal.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328347/unescaped-characters-in-user-team-names

## Changes
* On the server, only fetch data from the API (which is used for populating page metadata) if the user/project/etc name is valid, i.e. it contains only ascii letters, numbers, and dashes 

## How To Test
* join https://glitch.com/edit/#!/sideways-decimal (the project belongs to `@community`, so you should be able to add yourself)
* open the console
* visit https://sideways-decimal.glitch.me/~💩
* there should be no errors in the console
* open the https://glitch.com/edit/#!/community console
* visit https://glitch.com/~💩
* there will be an error in the console (and a new Sentry error)

## Things to consider
* should this be incorporated into the client side routing / API calls?
* why are only these characters valid for names? Seems a little eurocentric, no?
* should we be doing something more interesting with server-side rendering if we're fetching the data already?