### PR TITLE
Important alfalfa: avoid unnecessary 404s in search result images

### DIFF
--- a/src/components/search-form/autocomplete.js
+++ b/src/components/search-form/autocomplete.js
@@ -22,7 +22,7 @@ const StarterKitResult = ({ value: starterKit }) => (
 const TeamResult = ({ value: team }) => (
   <TeamLink team={team} className={styles.resultContainer}>
     <div className={styles.avatarContainer}>
-      <TeamAvatar hideTooltip team={{ ...team, hasAvatarImage: true }} />
+      <TeamAvatar hideTooltip team={{ ...team }} />
     </div>
     <div className={styles.infoContainer}>
       <div className={styles.infoPrimary}>{team.name}</div>

--- a/src/components/search-result-cover-bar/index.js
+++ b/src/components/search-result-cover-bar/index.js
@@ -2,32 +2,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Image from 'Components/images/image';
+import { getCoverUrl as getTeamCoverUrl } from 'Models/team';
+import { getCoverUrl as getUserCoverUrl } from 'Models/user';
 import styles from './search-result-cover-bar.styl';
 
 const cacheBuster = Math.floor(Math.random() * 1000);
 
 const defaultCoverURL = 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fdefault-cover-wide.svg?1503518400625';
 
-const TeamCoverBar = ({ size, id, cache = cacheBuster }) => (
-  <div className={styles.cover}>
-    <Image src={`${CDN_URL}/team-cover/${id}/${size}?${cache}`} defaultSrc={defaultCoverURL} alt="" />
-  </div>
-);
+const coverUrlForType = {
+  team: getTeamCoverUrl,
+  user: getUserCoverUrl,
+};
 
-const UserCoverBar = ({ size, id, cache = cacheBuster }) => (
-  <div className={styles.cover}>
-    <Image src={`${CDN_URL}/user-cover/${id}/${size}?${cache}`} defaultSrc={defaultCoverURL} alt="" />
-  </div>
-);
+const SearchResultCoverBar = ({ type, item, size, cache = cacheBuster }) => {
+  const getCoverUrl = coverUrlForType[type];
 
-const SearchResultCoverBar = ({ type, item, size }) => {
-  if (type === 'team') {
-    return <TeamCoverBar size={size} id={item.id} />;
-  }
-  if (type === 'user') {
-    return <UserCoverBar size={size} id={item.id} />;
-  }
-  return null;
+  return (
+    <div className={styles.cover}>
+      <Image src={getCoverUrl({ ...item, size, cache })} defaultSrc={defaultCoverURL} alt="" />
+    </div>
+  );
 };
 
 SearchResultCoverBar.propTypes = {

--- a/src/components/search-result-cover-bar/index.js
+++ b/src/components/search-result-cover-bar/index.js
@@ -1,4 +1,3 @@
-/* globals CDN_URL */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Image from 'Components/images/image';

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -41,11 +41,15 @@ export function getAvatarStyle({ avatarUrl, color }) {
   };
 }
 
-export function getProfileStyle({ id, hasCoverImage, coverColor, cache = cacheBuster, size = 'large' }) {
+export function getCoverUrl({ id, hasCoverImage, cache = cacheBuster, size = 'large' }) {
   const customImage = `${CDN_URL}/user-cover/${id}/${size}?${cache}`;
   const defaultImage = 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fdefault-cover-wide.svg?1503518400625';
+  return hasCoverImage ? customImage : defaultImage
+}
+
+export function getProfileStyle(params) {
   return {
-    backgroundColor: coverColor,
-    backgroundImage: `url('${hasCoverImage ? customImage : defaultImage}')`,
+    backgroundColor: params.coverColor,
+    backgroundImage: `url('${getCoverUrl(params)}')`,
   };
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -44,7 +44,7 @@ export function getAvatarStyle({ avatarUrl, color }) {
 export function getCoverUrl({ id, hasCoverImage, cache = cacheBuster, size = 'large' }) {
   const customImage = `${CDN_URL}/user-cover/${id}/${size}?${cache}`;
   const defaultImage = 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fdefault-cover-wide.svg?1503518400625';
-  return hasCoverImage ? customImage : defaultImage
+  return hasCoverImage ? customImage : defaultImage;
 }
 
 export function getProfileStyle(params) {

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -95,6 +95,7 @@ const formatByType = {
   }),
   team: (team) => ({
     isVerified: false,
+    hasAvatarImage: false,
     ...team,
     id: Number(team.objectID.replace('team-', '')),
   }),


### PR DESCRIPTION
## Links
* Remix link: https://important-alfalfa.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328451/Lots-of-missing-cover-images-are-resulting-in-404s-on-search-results-pages

## Changes:
* look for hasCoverImage & hasAvatarImage in search results instead of relying on defaultSrc in images

## How To Test:
* search for "react" using the search bar
* users, teams, & projects in autocomplete results should have custom avatar images
* there should be fewer network errors in the console than on production
* view the search results page
* users, teams, & projects in autocomplete results should have custom avatar images
* some users and teams should have custom cover image previews
* there should be fewer network errors in the console than on production
* note that images _may_ still 404 and show the default image, but this will be much less common 
