### PR TITLE
Bronze gibbon: Fix dropdown permissions on search page, and super user bug fix

### DIFF
--- a/src/presenters/overlays/super-user-banner.js
+++ b/src/presenters/overlays/super-user-banner.js
@@ -8,10 +8,10 @@ const SuperUserBanner = () => {
   const { currentUser, persistentToken } = useCurrentUser();
   const api = useAPI();
   const [showSupportBanner, setShowSupportBanner] = useLocalStorage('showSupportBanner', false);
-  const isSupporter = currentUser && currentUser.projects && currentUser.projects.filter((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff').length > 0;
+  const canBecomeSuperUser = currentUser && currentUser.projects && currentUser.projects.filter((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff').length > 0;
+  const superUser = currentUser.features && currentUser.features.find((feature) => feature.name === 'super_user');
 
-  if (isSupporter && persistentToken) {
-    const superUser = currentUser.features && currentUser.features.find((feature) => feature.name === 'super_user');
+  if (persistentToken && (superUser || canBecomeSuperUser)) {
     const expirationDate = superUser && new Date(superUser.expiresAt).toUTCString();
     const displayText = `SUPER USER MODE ${superUser ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
     const toggleSuperUser = async () => {

--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -211,7 +211,8 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
   }
 
   function currentUserIsAdminOnProject(user) {
-    const projectPermissions = project.permissions.find((p) => p.userId === user.id);
+    const project1 = undefined
+    const projectPermissions = project1 && project1.permissions.find((p) => p.userId === user.id);
     return projectPermissions && projectPermissions.accessLevel === 30;
   }
 

--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -211,8 +211,7 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
   }
 
   function currentUserIsAdminOnProject(user) {
-    const project1 = undefined
-    const projectPermissions = project1 && project1.permissions && project1.permissions.find((p) => p.userId === user.id);
+    const projectPermissions = project && project.permissions && project.permissions.find((p) => p.userId === user.id);
     return projectPermissions && projectPermissions.accessLevel === 30;
   }
 

--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -212,7 +212,7 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
 
   function currentUserIsAdminOnProject(user) {
     const project1 = undefined
-    const projectPermissions = project1 && project1.permissions.find((p) => p.userId === user.id);
+    const projectPermissions = project1 && project1.permissions && project1.permissions.find((p) => p.userId === user.id);
     return projectPermissions && projectPermissions.accessLevel === 30;
   }
 


### PR DESCRIPTION
## Links
* https://bronze-gibbon.glitch.me/
* https://glitch.manuscript.com/f/cases/3328450/n-permissions-is-undefined
* and somewhat related to https://glitch.manuscript.com/f/cases/3328449/

## Changes:
* don't start filtering through the permissions array if it doesn't exist. I had originally made the assumption that the permissions array existed always on every project, but this is not the case. I see this on the search page if you click on a project's dropdown arrow to add it to collection the site breaks 😭 because there is no permissions array there. I believe this is because of how we load projects on the search page vs the user page, I had made the assumption that these 2 pages had similarly shaped projects, but they do not have permissions here. Potentially you should be able to delete a project from the search page as well, but if that's the case we need to refactor how we load a project, which seems like a project for another pr. 
* small fix the the super user banner. In order to enable/disable the banner you need to be part of a sekret project, so I never showed the banner unless we saw you were in that project. Unfortunately we recently had a bug about loading projects and so the banner did not show even when you had your super_user feature enabled, which could be risky. Now if you have the feature enabled it will always show no matter what. If it's not enabled but you are part of the sekret project you can use the javascript console to turn on a banner that let's you enable/disable the feature if you want.

## How To Test:
* if you're a super user that it still works as it should
* that you are able to use the dropdown arrow on the project items on the search page. (and the user page, team page, and collection page!)

