### PR TITLE
Superb guide: Sort projects locally instead of using the api sort

### DIFF
--- a/src/models/project.js
+++ b/src/models/project.js
@@ -25,13 +25,15 @@ export function getRemixUrl(domain, editorUrl = EDITOR_URL) {
   return `${editorUrl}#!/remix/${domain}`;
 }
 
-export function sortByLastAccess(projects) {
+export function sortProjectsByLastAccess(projects) {
   return projects.sort((a, b) => {
     if (a.permission.userLastAccess && b.permission.userLastAccess) {
       return Date.parse(b.permission.userLastAccess) - Date.parse(a.permission.userLastAccess);
-    } else if (a.permission.userLastAccess) {
+    }
+    if (a.permission.userLastAccess) {
       return -1;
-    } else if (b.permission.userLastAccess) {
+    }
+    if (b.permission.userLastAccess) {
       return 1;
     }
     return Date.parse(b.lastAccess) - Date.parse(a.lastAccess);

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -24,3 +24,16 @@ export function getEditorUrl(domain, path, line, character, editorUrl = EDITOR_U
 export function getRemixUrl(domain, editorUrl = EDITOR_URL) {
   return `${editorUrl}#!/remix/${domain}`;
 }
+
+export function sortByLastAccess(projects) {
+  return projects.sort((a, b) => {
+    if (a.permission.userLastAccess && b.permission.userLastAccess) {
+      return Date.parse(b.permission.userLastAccess) - Date.parse(a.permission.userLastAccess);
+    } else if (a.permission.userLastAccess) {
+      return -1;
+    } else if (b.permission.userLastAccess) {
+      return 1;
+    }
+    return Date.parse(b.lastAccess) - Date.parse(a.lastAccess);
+  });
+}

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -162,13 +162,7 @@ class CurrentUserManager extends React.Component {
         teams: getAllPages(api, makeOrderedUrl('teams', 'url', 'ASC')),
         collections: getAllPages(api, makeUrl('collections')),
       });
-      const sortedProjects = projects.sort((a, b) => {
-        if (
-        const aLastAccess = Date.parse(a.permission.userLastAccess || a.lastAccess);
-        const bLastAccess = Date.parse(b.permission.userLastAccess || b.lastAccess);
-        return bLastAccess - aLastAccess;
-      });
-      const user = { ...baseUser, emails, projects: sortedProjects, teams, collections };
+      const user = { ...baseUser, emails, projects: sortProjectsByLastAccess(projects), teams, collections };
       if (!usersMatch(sharedUser, user)) {
         return 'error';
       }

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -157,11 +157,18 @@ class CurrentUserManager extends React.Component {
       } = await allByKeys({
         baseUser: getSingleItem(api, `v1/users/by/id?id=${sharedUser.id}`, sharedUser.id),
         emails: getAllPages(api, makeUrl('emails')),
-        projects: getAllPages(api, makeOrderedUrl('projects', 'userLastAccess', 'DESC')),
+        projects: getAllPages(api, makeOrderedUrl('projects', 'domain', 'ASC')),
         teams: getAllPages(api, makeOrderedUrl('teams', 'url', 'ASC')),
         collections: getAllPages(api, makeUrl('collections')),
       });
-      const user = { ...baseUser, emails, projects, teams, collections };
+      const sortedProjects = projects.sort((a, b) => {
+        const aLastAccess = Date.parse(a.permission.userLastAccess || a.lastAccess);
+        const bLastAccess = Date.parse(b.permission.userLastAccess || b.lastAccess);
+        if (aLastAccess > bLastAccess) return -1;
+        if (aLastAccess < bLastAccess) return 1;
+        return 0;
+      });
+      const user = { ...baseUser, emails, projects: sortedProjects, teams, collections };
       if (!usersMatch(sharedUser, user)) {
         return 'error';
       }

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getSingleItem, getAllPages, allByKeys } from 'Shared/api';
-import { configureScope, captureException, captureMessage, addBreadcrumb } from '../utils/sentry';
+import { sortProjectsByLastAccess } from 'Models/project';
+import { configureScope, captureException, captureMessage, addBreadcrumb } from 'Utils/sentry';
 import useLocalStorage from './local-storage';
 import { getAPIForToken } from './api';
 
@@ -162,11 +163,10 @@ class CurrentUserManager extends React.Component {
         collections: getAllPages(api, makeUrl('collections')),
       });
       const sortedProjects = projects.sort((a, b) => {
+        if (
         const aLastAccess = Date.parse(a.permission.userLastAccess || a.lastAccess);
         const bLastAccess = Date.parse(b.permission.userLastAccess || b.lastAccess);
-        if (aLastAccess > bLastAccess) return -1;
-        if (aLastAccess < bLastAccess) return 1;
-        return 0;
+        return bLastAccess - aLastAccess;
       });
       const user = { ...baseUser, emails, projects: sortedProjects, teams, collections };
       if (!usersMatch(sharedUser, user)) {


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/
https://glitch.manuscript.com/f/cases/3328449/odd-behavior-on-the-community-site

## Changes:
Stop using orderKey=userLastAccess and do the sort locally. Old projects (seemingly before March 2019, so not that old) don't have userLastAccess set, so it ends up looping the requests once it tries to make a request with `?lastOrderValue=&`. This sorts locally, using the lastAccess field for projects without a userLastAccess field. (Projects with userLastAccess are always put before projects without it)