### PR TITLE
Coconut restaurant: anonymous users don't see project item dropdown

### DIFF
--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -92,7 +92,6 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
   const onClickLeaveTeamProject = useTrackedFunc(leaveTeamProject, 'Leave Project clicked');
   const onClickLeaveProject = useTrackedFunc(leaveProject, 'Leave Project clicked');
   const onClickDeleteProject = useTrackedFunc(animateThenDeleteProject, 'Delete Project clicked');
-
   return (
     <dialog className="pop-over project-options-pop">
       {showPinOrFeatureSection && (
@@ -114,7 +113,7 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
         </section>
       )}
 
-      {!!props.addProjectToCollection && !props.currentUserIsAnon && (
+      {!!props.addProjectToCollection && (
         <section className="pop-over-actions">
           <PopoverButton onClick={addToCollectionPopover} {...props} text="Add to Collection " emoji="framed-picture" />
         </section>
@@ -198,7 +197,6 @@ ProjectOptionsPop.defaultProps = {
 // create as stateful react component
 export default function ProjectOptions({ projectOptions, project }, { ...props }) {
   const { currentUser } = useCurrentUser();
-  console.log("currentUser", currentUser)
   if (Object.keys(projectOptions).length === 0) {
     return null;
   }
@@ -215,10 +213,9 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
     const projectPermissions = project && project.permissions && project.permissions.find((p) => p.userId === user.id);
     return projectPermissions && projectPermissions.accessLevel === 30;
   }
-  
-  function currentUserIsAnon(user) {
-    return !(currentUser && currentUser.login)
-  }
+
+  // anonymous users can't take actions on projects
+  if (!(currentUser && currentUser.login)) return null;
 
   return (
     <PopoverWithButton
@@ -234,7 +231,6 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
           currentUser={currentUser}
           currentUserIsOnProject={currentUserIsOnProject(currentUser)}
           currentUserIsAdminOnProject={currentUserIsAdminOnProject(currentUser)}
-          currentUserIsAnon={currentUserIsAnon(currentUser)}
           togglePopover={togglePopover}
         />
       )}

--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -95,7 +95,7 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
 
   return (
     <dialog className="pop-over project-options-pop">
-      { showPinOrFeatureSection && (
+      {showPinOrFeatureSection && (
         <section className="pop-over-actions">
           {!!props.featureProject && !props.project.private && (
             <PopoverButton onClick={featureProject} text="Feature" emoji="clapper" />
@@ -114,7 +114,7 @@ const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
         </section>
       )}
 
-      {!!props.addProjectToCollection && (
+      {!!props.addProjectToCollection && !props.currentUserIsAnon && (
         <section className="pop-over-actions">
           <PopoverButton onClick={addToCollectionPopover} {...props} text="Add to Collection " emoji="framed-picture" />
         </section>
@@ -198,6 +198,7 @@ ProjectOptionsPop.defaultProps = {
 // create as stateful react component
 export default function ProjectOptions({ projectOptions, project }, { ...props }) {
   const { currentUser } = useCurrentUser();
+  console.log("currentUser", currentUser)
   if (Object.keys(projectOptions).length === 0) {
     return null;
   }
@@ -214,6 +215,10 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
     const projectPermissions = project && project.permissions && project.permissions.find((p) => p.userId === user.id);
     return projectPermissions && projectPermissions.accessLevel === 30;
   }
+  
+  function currentUserIsAnon(user) {
+    return !(currentUser && currentUser.login)
+  }
 
   return (
     <PopoverWithButton
@@ -229,6 +234,7 @@ export default function ProjectOptions({ projectOptions, project }, { ...props }
           currentUser={currentUser}
           currentUserIsOnProject={currentUserIsOnProject(currentUser)}
           currentUserIsAdminOnProject={currentUserIsAdminOnProject(currentUser)}
+          currentUserIsAnon={currentUserIsAnon(currentUser)}
           togglePopover={togglePopover}
         />
       )}


### PR DESCRIPTION
## Links
* https://coconut-restaurant.glitch.me/
* https://glitch.manuscript.com/f/cases/3328445/

## Changes:
* removes the project options dropdown on project items for anonymous users

## How To Test:
* go to https://coconut-restaurant.glitch.me/@sarahzinger notice you can't add any of my projects to collections anymore

## Feedback I'm looking for:
- this seemed like the quickest fix, but it does remove some functionality for anonymous users. Right now it looks like anonymous users can feature/pin/delete a project from their anonymous user page. If I deploy this as is they won't be able to feature/ping a project until they get a login. They can still delete the project from their project page though. I think this makes sense but I could see an argument for making this logic more complicated if we want where we keep that functionality. The thing is projects made by anonymous users I think delete after 2 weeks or something like that? So why are you pinning/featuring projects at all? I guess I could see an argument that this lets you test out the features...? I guess my inclination is to remove it just to simplify, but if we think testing those features out is useful I can definitely change my approach. 

