### PR TITLE
Lemon molecule: Add User / Team Toggle to Add project to collection pop

### DIFF
--- a/src/components/buttons/segmented-buttons.styl
+++ b/src/components/buttons/segmented-buttons.styl
@@ -1,9 +1,9 @@
 @require '../constants'
 
 .segmentedButtons
-  margin-bottom: 12px
   button
     margin: 0
+    display: inline
     &:first-child
       border-top-right-radius: 0
       border-bottom-right-radius: 0

--- a/src/components/inputs/text-input.styl
+++ b/src/components/inputs/text-input.styl
@@ -47,3 +47,10 @@
   box-shadow: 0px 0px 3px 0px input-border-focused
 .inputBorder:focus-within .input:focus
   box-shadow: none
+  
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance:none;
+}

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -1,9 +1,13 @@
 // add-project-to-collection-pop -> Add a project to a collection via a project item's menu
 import React from 'react';
 import PropTypes from 'prop-types';
-import { orderBy, remove } from 'lodash';
+import { flatten, orderBy } from 'lodash';
 import Loader from 'Components/loader';
+import SegmentedButtons from 'Components/buttons/segmented-buttons';
+import TextInput from 'Components/inputs/text-input';
+import { getAllPages } from 'Shared/api';
 import { captureException } from '../../utils/sentry';
+import useDebouncedValue from '../../hooks/use-debounced-value';
 
 import { useTrackedFunc } from '../segment-analytics';
 import { getAvatarUrl } from '../../models/project';
@@ -15,9 +19,11 @@ import CollectionResultItem from '../includes/collection-result-item';
 
 import { NestedPopover, NestedPopoverTitle } from './popover-nested';
 
-const NoSearchResultsPlaceholder = <p className="info-description">No matching collections found – add to a new one?</p>;
+const filterTypes = ['Your collections', 'Team collections'];
 
-const NoCollectionPlaceholder = <p className="info-description">Create collections to organize your favorite projects.</p>;
+const NoSearchResultsPlaceholder = () => <p className="info-description">No matching collections found – add to a new one?</p>;
+
+const NoCollectionPlaceholder = () => <p className="info-description">Create collections to organize your favorite projects.</p>;
 
 const AddProjectPopoverTitle = ({ project }) => (
   <NestedPopoverTitle>
@@ -28,97 +34,98 @@ AddProjectPopoverTitle.propTypes = {
   project: PropTypes.object.isRequired,
 };
 
-const AddProjectToCollectionResultItem = ({ onClick, collection, ...props }) => {
-  const onClickTracked = useTrackedFunc(onClick, 'Project Added to Collection', {}, {
-    groupId: collection.team ? collection.team.id : 0,
-  });
-  return (
-    <CollectionResultItem
-      onClick={onClickTracked}
-      collection={collection}
-      {...props}
-    />
+const AddProjectToCollectionResultItem = React.memo(({ onClick, collection, ...props }) => {
+  const onClickTracked = useTrackedFunc(
+    onClick,
+    'Project Added to Collection',
+    {},
+    {
+      groupId: collection.team ? collection.team.id : 0,
+    },
   );
-};
+  return <CollectionResultItem onClick={onClickTracked} collection={collection} {...props} />;
+});
 
-class AddProjectToCollectionPopContents extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      query: '', // value of filter input field
-      filteredCollections: this.props.collections, // collections filtered from search query
-    };
-    this.updateFilter = this.updateFilter.bind(this);
-    this.renderCollectionsThatDontHaveProject = this.renderCollectionsThatDontHaveProject.bind(this);
-  }
-
-  updateFilter(query) {
-    query = query.toLowerCase().trim();
-    const filteredCollections = this.props.collections.filter((collection) => collection.name.toLowerCase().includes(query));
-    this.setState({ filteredCollections, query });
-  }
-
-  // filter out collections that already contain the selected project
-  renderCollectionsThatDontHaveProject(collection) {
-    if (!collection.projects) {
-      return null;
-    }
-    const currentProjectNotIncluded = collection.projects.every((project) => project.id !== this.props.project.id);
-
-    if (!currentProjectNotIncluded) {
-      return null;
-    }
-
-    return (
-      <li key={collection.id}>
-        <AddProjectToCollectionResultItem
-          onClick={this.props.addProjectToCollection}
-          project={this.props.project}
-          collection={collection}
-          togglePopover={this.props.togglePopover}
-          currentUser={this.props.currentUser}
-        />
-      </li>
-    );
-  }
-
-  render() {
-    const { filteredCollections, query } = this.state;
+const AddProjectToCollectionPopContents = ({
+  addProjectToCollection,
+  collections,
+  createCollectionPopover,
+  currentUser,
+  fromProject,
+  project,
+  togglePopover,
+  collectionType,
+  setCollectionType,
+}) => {
+  if (!collections) {
     return (
       <dialog className="pop-over add-project-to-collection-pop wide-pop">
         {/* Only show this nested popover title from project-options */}
-        {!this.props.fromProject && <AddProjectPopoverTitle project={this.props.project} />}
+        {!fromProject && <AddProjectPopoverTitle project={project} />}
 
-        {this.props.collections.length > 3 && (
-          <section className="pop-over-info">
-            <input
-              className="pop-over-input search-input pop-over-search"
-              onChange={(evt) => {
-                this.updateFilter(evt.target.value);
-              }}
-              placeholder="Filter collections"
-              aria-label="Filter collections"
-            />
-          </section>
-        )}
+        {currentUser.teams.length > 0 && <UserOrTeamSegmentedButtons activeType={collectionType} setType={setCollectionType} />}
 
-        {filteredCollections.length ? (
-          <section className="pop-over-actions results-list">
-            <ul className="results">{filteredCollections.map(this.renderCollectionsThatDontHaveProject)}</ul>
-          </section>
-        ) : (
-          <section className="pop-over-info">{query ? NoSearchResultsPlaceholder : NoCollectionPlaceholder}</section>
-        )}
-
-        <section className="pop-over-actions">
-          <button className="create-new-collection button-small button-tertiary" onClick={this.props.createCollectionPopover}>
-            Add to a new collection
-          </button>
-        </section>
+        <div className="loader-container">
+          <Loader />
+        </div>
       </dialog>
     );
   }
-}
+
+  const [query, setQuery] = React.useState('');
+  const debouncedQuery = useDebouncedValue(query.toLowerCase().trim(), 300);
+  const filteredCollections = React.useMemo(() => collections.filter((collection) => collection.name.toLowerCase().includes(debouncedQuery)), [
+    debouncedQuery,
+    collections,
+  ]);
+
+  return (
+    <dialog className="pop-over add-project-to-collection-pop wide-pop">
+      {/* Only show this nested popover title from project-options */}
+      {!fromProject && <AddProjectPopoverTitle project={project} />}
+
+      {currentUser.teams.length > 0 && <UserOrTeamSegmentedButtons activeType={collectionType} setType={setCollectionType} />}
+
+      {collections.length > 3 && (
+        <section className="pop-over-info">
+          <TextInput value={query} onChange={setQuery} placeholder="Filter collections" labelText="Filter collections" opaque type="search" />
+        </section>
+      )}
+
+      {!collections && (
+        <div className="loader-container">
+          <Loader />
+        </div>
+      )}
+
+      {filteredCollections.length ? (
+        <section className="pop-over-actions results-list">
+          <ul className="results">
+            {filteredCollections.map((collection) => (
+              <li key={collection.id}>
+                <AddProjectToCollectionResultItem
+                  onClick={addProjectToCollection}
+                  project={project}
+                  collection={collection}
+                  togglePopover={togglePopover}
+                  currentUser={currentUser}
+                />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <section className="pop-over-info">{query ? <NoSearchResultsPlaceholder /> : <NoCollectionPlaceholder />}</section>
+      )}
+
+      <section className="pop-over-actions">
+        <button className="create-new-collection button-small button-tertiary" onClick={createCollectionPopover}>
+          Add to a new collection
+        </button>
+      </section>
+    </dialog>
+  );
+};
 
 AddProjectToCollectionPopContents.propTypes = {
   addProjectToCollection: PropTypes.func,
@@ -127,6 +134,8 @@ AddProjectToCollectionPopContents.propTypes = {
   togglePopover: PropTypes.func, // required but added dynamically
   project: PropTypes.object.isRequired,
   fromProject: PropTypes.bool,
+  collectionType: PropTypes.string.isRequired,
+  setCollectionType: PropTypes.func.isRequired,
 };
 
 AddProjectToCollectionPopContents.defaultProps = {
@@ -137,89 +146,98 @@ AddProjectToCollectionPopContents.defaultProps = {
   fromProject: false,
 };
 
-class AddProjectToCollectionPop extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      maybeCollections: null, // null means still loading
+const UserOrTeamSegmentedButtons = ({ activeType, setType }) => {
+  const buttons = filterTypes.map((name) => ({
+    name,
+    contents: name,
+  }));
+  return (
+    <section className="pop-over-actions">
+      <SegmentedButtons value={activeType} buttons={buttons} onChange={setType} />
+    </section>
+  );
+};
+
+const AddProjectToCollectionPop = (props) => {
+  const { project, togglePopover } = props;
+
+  const api = useAPI();
+  const { currentUser } = useCurrentUser();
+
+  const [collectionType, setCollectionType] = React.useState(filterTypes[0]);
+
+  const [maybeCollections, setMaybeCollections] = React.useState(null);
+
+  React.useEffect(() => {
+    let canceled = false;
+    setMaybeCollections(null); // reset maybCollections on reload to show loader
+
+    const orderParams = 'orderKey=url&orderDirection=ASC&limit=100';
+
+    const loadUserCollections = async (user) => {
+      const collections = await getAllPages(api, `v1/users/by/id/collections?id=${user.id}&${orderParams}`);
+      return collections.map((collection) => ({ ...collection, user }));
     };
-  }
 
-  async componentDidMount() {
-    this.loadCollections();
-  }
+    const loadTeamCollections = async (team) => {
+      const collections = await getAllPages(api, `v1/teams/by/id/collections?id=${team.id}&${orderParams}`);
+      return collections.map((collection) => ({ ...collection, team }));
+    };
 
-  componentWillUnmount() {
-    this.unmounted = true;
-  }
+    const loadCollections = async () => {
+      const projectCollectionsRequest = getAllPages(api, `v1/projects/by/id/collections?id=${project.id}&${orderParams}`);
+      const userCollectionsRequest = loadUserCollections(currentUser);
 
-  async loadCollections() {
-    try {
-      const { data: allCollections } = await this.props.api.get(`collections/?userId=${this.props.currentUser.id}&includeTeams=true`);
-      const deletedCollectionIds = []; // collections from deleted teams
-      // add user / team to each collection
-      allCollections.forEach((collection) => {
-        if (collection.teamId === -1) {
-          collection.user = this.props.currentUser;
-        } else {
-          collection.team = this.props.currentUser.teams.find((userTeam) => userTeam.id === collection.teamId);
-          if (!collection.team) {
-            deletedCollectionIds.push(collection.id);
-          }
-        }
-      });
+      const requests =
+        collectionType === filterTypes[0]
+          ? [projectCollectionsRequest, userCollectionsRequest]
+          : [projectCollectionsRequest, ...currentUser.teams.map((team) => loadTeamCollections(team))];
 
-      // remove deleted collections
-      remove(allCollections, (collection) => deletedCollectionIds.includes(collection.id));
+      const [projectCollections, ...collectionArrays] = await Promise.all(requests);
 
-      const orderedCollections = orderBy(allCollections, (collection) => collection.updatedAt, ['desc']);
+      const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
+      const collections = flatten(collectionArrays).filter((c) => !alreadyInCollectionIds.has(c.id));
 
-      if (!this.unmounted) {
-        this.setState({ maybeCollections: orderedCollections });
+      const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
+
+      if (!canceled) {
+        setMaybeCollections(orderedCollections);
       }
-    } catch (error) {
-      captureException(error);
-    }
-  }
+    };
 
-  render() {
-    const { maybeCollections } = this.state;
-    return (
-      <NestedPopover
-        alternateContent={() => (
-          <CreateCollectionPop {...this.props} collections={this.state.maybeCollections} togglePopover={this.props.togglePopover} />
-        )}
-        startAlternateVisible={false}
-      >
-        {(createCollectionPopover) => {
-          if (maybeCollections) {
-            return (
-              <AddProjectToCollectionPopContents {...this.props} collections={maybeCollections} createCollectionPopover={createCollectionPopover} />
-            );
-          }
-          return (
-            <dialog className="pop-over add-project-to-collection-pop wide-pop">
-              {!this.props.fromProject && <AddProjectPopoverTitle project={this.props.project} />}
-              <div className="loader-container">
-                <Loader />
-              </div>
-            </dialog>
-          );
-        }}
-      </NestedPopover>
-    );
-  }
-}
+    loadCollections().catch(captureException);
+    return () => {
+      canceled = true;
+    };
+  }, [project.id, currentUser.id, collectionType]);
+
+  return (
+    <NestedPopover
+      alternateContent={() => <CreateCollectionPop {...props} collections={maybeCollections} togglePopover={togglePopover} />}
+      startAlternateVisible={false}
+    >
+      {(createCollectionPopover) => (
+        <AddProjectToCollectionPopContents
+          {...props}
+          collections={maybeCollections}
+          createCollectionPopover={createCollectionPopover}
+          collectionType={collectionType}
+          setCollectionType={setCollectionType}
+        />
+      )}
+    </NestedPopover>
+  );
+};
 
 AddProjectToCollectionPop.propTypes = {
-  api: PropTypes.func.isRequired,
-  currentUser: PropTypes.object.isRequired,
+  fromProject: PropTypes.bool,
+  project: PropTypes.object.isRequired,
+  togglePopover: PropTypes.func,
 };
 
-const AddProjectToCollectionPopWrap = (props) => {
-  const { currentUser } = useCurrentUser();
-  const api = useAPI();
-  return <AddProjectToCollectionPop {...props} currentUser={currentUser} api={api} />;
+AddProjectToCollectionPop.defaultProps = {
+  fromProject: false,
+  togglePopover: null,
 };
 
-export default AddProjectToCollectionPopWrap;
+export default AddProjectToCollectionPop;


### PR DESCRIPTION
## Links
* Remix link: https://lemon-molecule.glitch.me/~lemon-molecule
* Manuscript link: https://glitch.manuscript.com/f/cases/edit/3328498/Use-segmented-buttons-to-segment-collections-team-collections-in-add-project-to-collection-pop

## GIF/Screenshots:
![segmented-button-toggle](https://user-images.githubusercontent.com/519336/57643118-ffd92880-7586-11e9-84aa-c1eb60155140.gif)

## Changes:
* by default, load user collections and load team collections on demand using segmented buttons in `add-project-to-collection-pop` 

## How To Test:
Log in and try testing these cases:

* if user has no collections and isn't part of any teams, they should see the default message without any segmented buttons:
![image](https://user-images.githubusercontent.com/519336/57643216-40d13d00-7587-11e9-9210-eba6cc4960ba.png)

* if user isn't part of any teams, they should not see the segmented button toggles:
![image](https://user-images.githubusercontent.com/519336/57643194-3020c700-7587-11e9-8aef-fd5bd915eed7.png)

* if user is part of team(s) but none of the teams have any collections, show segmented buttons + default hint text:
![image](https://user-images.githubusercontent.com/519336/57643452-c5bc5680-7587-11e9-8c2e-93f139807fce.png)

* if user is part of teams that have collections, those collections should show up under the team collections
![image](https://user-images.githubusercontent.com/519336/57643485-d4a30900-7587-11e9-996d-dd1a7ecc8a98.png)

## Feedback I'm looking for:
* I did some refactoring of `add-project-to-collection-pop` so that the loader appears within the results section when toggling between the segmented buttons (as opposed to reloading the entire pop-over contents, including the segmented buttons + filter input) but this means that some of the hooks are only conditionally rendered, which gives these warnings:
```
 77:29  error  React Hook "React.useState" is called conditionally. React Hooks must be called in the exact same order in every component render     react-hooks/rules-of-hooks

  78:26  error  React Hook "useDebouncedValue" is called conditionally. React Hooks must be called in the exact same order in every component render  react-hooks/rules-of-hooks

  79:31  error  React Hook "React.useMemo" is called conditionally. React Hooks must be called in the exact same order in every component render      react-hooks/rules-of-hooks

```
https://glitch.com/edit/#!/lemon-molecule?path=src/presenters/pop-overs/add-project-to-collection-pop.js:77:1

Any suggestions for a good way to move the hooks out of the conditional?  (note that it's an issue when `collections` is null, which is the case when we're reloading the results list to show teams / user collections)
