### PR TITLE
wandering-save: Show which collections a project is already in

### DIFF
--- a/src/components/badges/badge.styl
+++ b/src/components/badges/badge.styl
@@ -27,5 +27,8 @@
     background-position: center
     padding: 3px 10px
     height: 20px
+  &.inline
+    margin: 0 1px
+    vertical-align: middle
     
   

--- a/src/components/badges/badge.styl
+++ b/src/components/badges/badge.styl
@@ -27,8 +27,3 @@
     background-position: center
     padding: 3px 10px
     height: 20px
-  &.inline
-    margin: 0 1px
-    vertical-align: middle
-    
-  

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -1,9 +1,11 @@
 // add-project-to-collection-pop -> Add a project to a collection via a project item's menu
 import React from 'react';
 import PropTypes from 'prop-types';
+import Pluralize from 'react-pluralize';
 import { flatten, orderBy } from 'lodash';
 import Loader from 'Components/loader';
 import TextInput from 'Components/inputs/text-input';
+import { CollectionLink } from 'Components/link';
 import { getAllPages } from 'Shared/api';
 import { captureException } from '../../utils/sentry';
 import useDebouncedValue from '../../hooks/use-debounced-value';
@@ -18,7 +20,7 @@ import CollectionResultItem from '../includes/collection-result-item';
 
 import { NestedPopover, NestedPopoverTitle } from './popover-nested';
 
-const NoSearchResultsPlaceholder = () => <p className="info-description">No matching collections found – add to a new one?</p>;
+const NoSearchResultsPlaceholder = () => <p className="info-description">No matching collections found – add to a new one?</p>;
 
 const NoCollectionPlaceholder = () => <p className="info-description">Create collections to organize your favorite projects.</p>;
 
@@ -32,21 +34,21 @@ AddProjectPopoverTitle.propTypes = {
 };
 
 const AddProjectToCollectionResultItem = React.memo(({ onClick, collection, ...props }) => {
-  const onClickTracked = useTrackedFunc(onClick, 'Project Added to Collection', {}, {
-    groupId: collection.team ? collection.team.id : 0,
-  });
-  return (
-    <CollectionResultItem
-      onClick={onClickTracked}
-      collection={collection}
-      {...props}
-    />
+  const onClickTracked = useTrackedFunc(
+    onClick,
+    'Project Added to Collection',
+    {},
+    {
+      groupId: collection.team ? collection.team.id : 0,
+    },
   );
+  return <CollectionResultItem onClick={onClickTracked} collection={collection} {...props} />;
 });
 
 const AddProjectToCollectionPopContents = ({
   addProjectToCollection,
   collections,
+  collectionsWithProject,
   createCollectionPopover,
   currentUser,
   fromProject,
@@ -55,10 +57,11 @@ const AddProjectToCollectionPopContents = ({
 }) => {
   const [query, setQuery] = React.useState('');
   const debouncedQuery = useDebouncedValue(query.toLowerCase().trim(), 300);
-  const filteredCollections = React.useMemo(
-    () => collections.filter((collection) => collection.name.toLowerCase().includes(debouncedQuery)),
-    [debouncedQuery, collections],
-  );
+  const filteredCollections = React.useMemo(() => collections.filter((collection) => collection.name.toLowerCase().includes(debouncedQuery)), [
+    debouncedQuery,
+    collections,
+  ]);
+
   return (
     <dialog className="pop-over add-project-to-collection-pop wide-pop">
       {/* Only show this nested popover title from project-options */}
@@ -89,6 +92,15 @@ const AddProjectToCollectionPopContents = ({
       ) : (
         <section className="pop-over-info">{query ? <NoSearchResultsPlaceholder /> : <NoCollectionPlaceholder />}</section>
       )}
+
+      {collectionsWithProject.length ? (
+        <section className="pop-over-info">
+          <strong>{project.domain}</strong> is already in <Pluralize count={collectionsWithProject.length} showCount={false} singular="collection" />{' '}
+          {collectionsWithProject
+            .map((collection) => <CollectionLink key={collection.id} collection={collection}>{collection.name}</CollectionLink>)
+            .reduce((prev, curr) => [prev, ', ', curr])}
+        </section>
+      ) : null}
 
       <section className="pop-over-actions">
         <button className="create-new-collection button-small button-tertiary" onClick={createCollectionPopover}>
@@ -122,48 +134,51 @@ const AddProjectToCollectionPop = (props) => {
   const api = useAPI();
   const { currentUser } = useCurrentUser();
   const [maybeCollections, setMaybeCollections] = React.useState(null);
+  const [collectionsWithProject, setCollectionsWithProject] = React.useState([]);
 
-  React.useEffect(() => {
-    let canceled = false;
+  React.useEffect(
+    () => {
+      let canceled = false;
 
-    const orderParams = 'orderKey=url&orderDirection=ASC&limit=100';
-    const loadUserCollections = async (user) => {
-      const collections = await getAllPages(api, `v1/users/by/id/collections?id=${user.id}&${orderParams}`);
-      return collections.map((collection) => ({ ...collection, user }));
-    };
-    const loadTeamCollections = async (team) => {
-      const collections = await getAllPages(api, `v1/teams/by/id/collections?id=${team.id}&${orderParams}`);
-      return collections.map((collection) => ({ ...collection, team }));
-    };
-    const loadCollections = async () => {
-      const requests = [
-        getAllPages(api, `v1/projects/by/id/collections?id=${project.id}&${orderParams}`),
-        loadUserCollections(currentUser),
-        ...currentUser.teams.map((team) => loadTeamCollections(team)),
-      ];
-      const [projectCollections, ...collectionArrays] = await Promise.all(requests);
+      const orderParams = 'orderKey=url&orderDirection=ASC&limit=100';
+      const loadUserCollections = async (user) => {
+        const collections = await getAllPages(api, `v1/users/by/id/collections?id=${user.id}&${orderParams}`);
+        return collections.map((collection) => ({ ...collection, user }));
+      };
+      const loadTeamCollections = async (team) => {
+        const collections = await getAllPages(api, `v1/teams/by/id/collections?id=${team.id}&${orderParams}`);
+        return collections.map((collection) => ({ ...collection, team }));
+      };
+      const loadCollections = async () => {
+        const requests = [
+          getAllPages(api, `v1/projects/by/id/collections?id=${project.id}&${orderParams}`),
+          loadUserCollections(currentUser),
+          ...currentUser.teams.map((team) => loadTeamCollections(team)),
+        ];
+        const [projectCollections, ...collectionArrays] = await Promise.all(requests);
 
-      const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
-      const collections = flatten(collectionArrays).filter((c) => !alreadyInCollectionIds.has(c.id));
+        const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
+        const collections = flatten(collectionArrays).filter((c) => !alreadyInCollectionIds.has(c.id));
 
-      const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
+        const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
 
-      if (!canceled) {
-        setMaybeCollections(orderedCollections);
-      }
-    };
+        if (!canceled) {
+          setMaybeCollections(orderedCollections);
+          setCollectionsWithProject(projectCollections);
+        }
+      };
 
-    loadCollections().catch(captureException);
-    return () => {
-      canceled = true;
-    };
-  }, [project.id, currentUser.id]);
+      loadCollections().catch(captureException);
+      return () => {
+        canceled = true;
+      };
+    },
+    [project.id, currentUser.id],
+  );
 
   return (
     <NestedPopover
-      alternateContent={() => (
-        <CreateCollectionPop {...props} collections={maybeCollections} togglePopover={togglePopover} />
-      )}
+      alternateContent={() => <CreateCollectionPop {...props} collections={maybeCollections} togglePopover={togglePopover} />}
       startAlternateVisible={false}
     >
       {(createCollectionPopover) => {
@@ -178,7 +193,12 @@ const AddProjectToCollectionPop = (props) => {
           );
         }
         return (
-          <AddProjectToCollectionPopContents {...props} collections={maybeCollections} createCollectionPopover={createCollectionPopover} />
+          <AddProjectToCollectionPopContents
+            {...props}
+            collections={maybeCollections}
+            collectionsWithProject={collectionsWithProject}
+            createCollectionPopover={createCollectionPopover}
+          />
         );
       }}
     </NestedPopover>

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -156,9 +156,9 @@ const AddProjectToCollectionPop = (props) => {
           ...currentUser.teams.map((team) => loadTeamCollections(team)),
         ];
         const [projectCollections, ...collectionArrays] = await Promise.all(requests);
-
+        
         const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
-        const collections = flatten(collectionArrays).filter((c) => !alreadyInCollectionIds.has(c.id));
+        const [collections, collectionsWithProject] = partition(flatten(collectionArrays), (c) => !alreadyInCollectionIds.has(c.id));
 
         const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -131,7 +131,7 @@ const AddProjectToCollectionPopContents = ({
         <AddProjectToCollectionResults {...{ addProjectToCollection, collections, currentUser, project, togglePopover, query }} />
       )}
 
-      {collectionsWithProject.length ? (
+      {collections && collectionsWithProject.length ? (
         <section className="pop-over-info">
           <strong>{project.domain}</strong> is already in <Pluralize count={collectionsWithProject.length} showCount={false} singular="collection" />{' '}
           {collectionsWithProject

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -107,7 +107,10 @@ const AddProjectToCollectionPopContents = ({
             .reduce((prev, curr) => [prev, ', ', curr])}
           {collectionsWithProject.length > 3 && (
             <>
-              , and <Badge>{collectionsWithProject.length - 3}</Badge>{' '}
+              , and{' '}
+              <div className="more-collections-badge">
+                <Badge>{collectionsWithProject.length - 3}</Badge>
+              </div>{' '}
               <Pluralize count={collectionsWithProject.length - 3} singular="other" showCount={false} />
             </>
           )}

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -109,27 +109,15 @@ const AddProjectToCollectionPopContents = ({
   setCollectionType,
 }) => {
   const [query, setQuery] = React.useState('');
-<<<<<<< HEAD
-  const debouncedQuery = useDebouncedValue(query.toLowerCase().trim(), 300);
-  const filteredCollections = React.useMemo(() => collections.filter((collection) => collection.name.toLowerCase().includes(debouncedQuery)), [
-    debouncedQuery,
-    collections,
-  ]);
 
-=======
->>>>>>> 03364399e99fb534c36a3333ffd88eabb4873479
   return (
     <dialog className="pop-over add-project-to-collection-pop wide-pop">
       {/* Only show this nested popover title from project-options */}
       {!fromProject && <AddProjectPopoverTitle project={project} />}
 
-<<<<<<< HEAD
-      {collections.length > 2 && (
-=======
       {currentUser.teams.length > 0 && <UserOrTeamSegmentedButtons activeType={collectionType} setType={setCollectionType} />}
 
       {collections && collections.length > 3 && (
->>>>>>> 03364399e99fb534c36a3333ffd88eabb4873479
         <section className="pop-over-info">
           <TextInput value={query} onChange={setQuery} placeholder="Filter collections" labelText="Filter collections" opaque type="search" />
         </section>
@@ -215,34 +203,38 @@ const AddProjectToCollectionPop = (props) => {
   const [collectionType, setCollectionType] = React.useState(filterTypes[0]);
 
   const [maybeCollections, setMaybeCollections] = React.useState(null);
-<<<<<<< HEAD
   const [collectionsWithProject, setCollectionsWithProject] = React.useState([]);
 
   React.useEffect(
     () => {
       let canceled = false;
+      setMaybeCollections(null); // reset maybCollections on reload to show loader
 
       const orderParams = 'orderKey=url&orderDirection=ASC&limit=100';
+
       const loadUserCollections = async (user) => {
         const collections = await getAllPages(api, `v1/users/by/id/collections?id=${user.id}&${orderParams}`);
         return collections.map((collection) => ({ ...collection, user }));
       };
+
       const loadTeamCollections = async (team) => {
         const collections = await getAllPages(api, `v1/teams/by/id/collections?id=${team.id}&${orderParams}`);
         return collections.map((collection) => ({ ...collection, team }));
       };
+
       const loadCollections = async () => {
-        const requests = [
-          getAllPages(api, `v1/projects/by/id/collections?id=${project.id}&${orderParams}`),
-          loadUserCollections(currentUser),
-          ...currentUser.teams.map((team) => loadTeamCollections(team)),
-        ];
+        const projectCollectionsRequest = getAllPages(api, `v1/projects/by/id/collections?id=${project.id}&${orderParams}`);
+        const userCollectionsRequest = loadUserCollections(currentUser);
+
+        const requests =
+          collectionType === filterTypes[0]
+            ? [projectCollectionsRequest, userCollectionsRequest]
+            : [projectCollectionsRequest, ...currentUser.teams.map((team) => loadTeamCollections(team))];
+
         const [projectCollections, ...collectionArrays] = await Promise.all(requests);
 
         const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
-        console.log(alreadyInCollectionIds);
         const [collections, _collectionsWithProject] = partition(flatten(collectionArrays), (c) => !alreadyInCollectionIds.has(c.id));
-        console.log(_collectionsWithProject);
 
         const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
 
@@ -257,91 +249,24 @@ const AddProjectToCollectionPop = (props) => {
         canceled = true;
       };
     },
-    [project.id, currentUser.id],
+    [project.id, currentUser.id, collectionType],
   );
-=======
-
-  React.useEffect(() => {
-    let canceled = false;
-    setMaybeCollections(null); // reset maybCollections on reload to show loader
-
-    const orderParams = 'orderKey=url&orderDirection=ASC&limit=100';
-
-    const loadUserCollections = async (user) => {
-      const collections = await getAllPages(api, `v1/users/by/id/collections?id=${user.id}&${orderParams}`);
-      return collections.map((collection) => ({ ...collection, user }));
-    };
-
-    const loadTeamCollections = async (team) => {
-      const collections = await getAllPages(api, `v1/teams/by/id/collections?id=${team.id}&${orderParams}`);
-      return collections.map((collection) => ({ ...collection, team }));
-    };
-
-    const loadCollections = async () => {
-      const projectCollectionsRequest = getAllPages(api, `v1/projects/by/id/collections?id=${project.id}&${orderParams}`);
-      const userCollectionsRequest = loadUserCollections(currentUser);
-
-      const requests =
-        collectionType === filterTypes[0]
-          ? [projectCollectionsRequest, userCollectionsRequest]
-          : [projectCollectionsRequest, ...currentUser.teams.map((team) => loadTeamCollections(team))];
-
-      const [projectCollections, ...collectionArrays] = await Promise.all(requests);
-
-      const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
-      const collections = flatten(collectionArrays).filter((c) => !alreadyInCollectionIds.has(c.id));
-
-      const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
-
-      if (!canceled) {
-        setMaybeCollections(orderedCollections);
-      }
-    };
-
-    loadCollections().catch(captureException);
-    return () => {
-      canceled = true;
-    };
-  }, [project.id, currentUser.id, collectionType]);
->>>>>>> 03364399e99fb534c36a3333ffd88eabb4873479
 
   return (
     <NestedPopover
       alternateContent={() => <CreateCollectionPop {...props} collections={maybeCollections} togglePopover={togglePopover} />}
       startAlternateVisible={false}
     >
-<<<<<<< HEAD
-      {(createCollectionPopover) => {
-        if (!maybeCollections) {
-          return (
-            <dialog className="pop-over add-project-to-collection-pop wide-pop">
-              {!fromProject && <AddProjectPopoverTitle project={project} />}
-              <div className="loader-container">
-                <Loader />
-              </div>
-            </dialog>
-          );
-        }
-        return (
-          <AddProjectToCollectionPopContents
-            {...props}
-            collections={maybeCollections}
-            collectionsWithProject={collectionsWithProject}
-            createCollectionPopover={createCollectionPopover}
-          />
-        );
-      }}
-=======
       {(createCollectionPopover) => (
         <AddProjectToCollectionPopContents
           {...props}
           collections={maybeCollections}
+          collectionsWithProject={collectionsWithProject}
           createCollectionPopover={createCollectionPopover}
           collectionType={collectionType}
           setCollectionType={setCollectionType}
         />
       )}
->>>>>>> 03364399e99fb534c36a3333ffd88eabb4873479
     </NestedPopover>
   );
 };

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -67,7 +67,7 @@ const AddProjectToCollectionPopContents = ({
       {/* Only show this nested popover title from project-options */}
       {!fromProject && <AddProjectPopoverTitle project={project} />}
 
-      {collections.length > 3 && (
+      {collections.length > 2 && (
         <section className="pop-over-info">
           <TextInput value={query} onChange={setQuery} placeholder="Filter collections" labelText="Filter collections" opaque type="search" />
         </section>
@@ -103,6 +103,11 @@ const AddProjectToCollectionPopContents = ({
               </CollectionLink>
             ))
             .reduce((prev, curr) => [prev, ', ', curr])}
+          {collectionsWithProject.length > 3 && (
+            <>
+              &nbsp;, and <Pluralize count={collectionsWithProject.length - 3} singular="other" />
+            </>
+          )}
         </section>
       ) : null}
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Pluralize from 'react-pluralize';
 import { flatten, orderBy, partition } from 'lodash';
 import Loader from 'Components/loader';
+import Badge from 'Components/badges/badge';
 import TextInput from 'Components/inputs/text-input';
 import { CollectionLink } from 'Components/link';
 import { getAllPages } from 'Shared/api';
@@ -97,6 +98,7 @@ const AddProjectToCollectionPopContents = ({
         <section className="pop-over-info">
           <strong>{project.domain}</strong> is already in <Pluralize count={collectionsWithProject.length} showCount={false} singular="collection" />{' '}
           {collectionsWithProject
+            .slice(0, 3)
             .map((collection) => (
               <CollectionLink key={collection.id} collection={collection}>
                 {collection.name}
@@ -105,7 +107,8 @@ const AddProjectToCollectionPopContents = ({
             .reduce((prev, curr) => [prev, ', ', curr])}
           {collectionsWithProject.length > 3 && (
             <>
-              &nbsp;, and <Pluralize count={collectionsWithProject.length - 3} singular="other" />
+              , and <Badge>{collectionsWithProject.length - 3}</Badge>{' '}
+              <Pluralize count={collectionsWithProject.length - 3} singular="other" showCount={false} />
             </>
           )}
         </section>

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -93,7 +93,7 @@ const AddProjectToCollectionPopContents = ({
         <section className="pop-over-info">{query ? <NoSearchResultsPlaceholder /> : <NoCollectionPlaceholder />}</section>
       )}
 
-      {collectionsWithProject.length && (
+      {collectionsWithProject.length ? (
         <section className="pop-over-info">
           <strong>{project.domain}</strong> is already in <Pluralize count={collectionsWithProject.length} showCount={false} singular="collection" />{' '}
           {collectionsWithProject
@@ -104,7 +104,7 @@ const AddProjectToCollectionPopContents = ({
             ))
             .reduce((prev, curr) => [prev, ', ', curr])}
         </section>
-      )}
+      ) : null}
 
       <section className="pop-over-actions">
         <button className="create-new-collection button-small button-tertiary" onClick={createCollectionPopover}>
@@ -138,7 +138,7 @@ const AddProjectToCollectionPop = (props) => {
   const api = useAPI();
   const { currentUser } = useCurrentUser();
   const [maybeCollections, setMaybeCollections] = React.useState(null);
-  const [collectionsWithProject, setCollectionsWithProject] = React.useState(null);
+  const [collectionsWithProject, setCollectionsWithProject] = React.useState([]);
 
   React.useEffect(
     () => {
@@ -162,12 +162,13 @@ const AddProjectToCollectionPop = (props) => {
         const [projectCollections, ...collectionArrays] = await Promise.all(requests);
 
         const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
-        const [collections, collectionsWithProject] = partition(flatten(collectionArrays), (c) => !alreadyInCollectionIds.has(c.id));
+        const [collections, _collectionsWithProject] = partition(flatten(collectionArrays), (c) => !alreadyInCollectionIds.has(c.id));
 
         const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
 
         if (!canceled) {
           setMaybeCollections(orderedCollections);
+          setCollectionsWithProject(_collectionsWithProject);
         }
       };
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -170,7 +170,9 @@ const AddProjectToCollectionPop = (props) => {
         const [projectCollections, ...collectionArrays] = await Promise.all(requests);
 
         const alreadyInCollectionIds = new Set(projectCollections.map((c) => c.id));
+        console.log(alreadyInCollectionIds);
         const [collections, _collectionsWithProject] = partition(flatten(collectionArrays), (c) => !alreadyInCollectionIds.has(c.id));
+        console.log(_collectionsWithProject);
 
         const orderedCollections = orderBy(collections, (collection) => collection.updatedAt, 'desc');
 

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -302,7 +302,8 @@ popover-secondary-background()
       width: 15px
       border-radius: 3px
   .more-collections-badge
-    margin: 0 1px
+    margin: 2px 1px 0 1px
+    display: inline-block
     vertical-align: middle
     // remove margin on Badge component, ideally the Badge component would not specify margin
     > *

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -128,10 +128,12 @@ popover-secondary-background()
     .tall-text
       min-height: 150px
     .label
-     font-weight: bold
-     font-size: 12px
-     margin-bottom: 10px
-     display: block
+      font-weight: bold
+      font-size: 12px
+      margin-bottom: 10px
+      display: block      
+    strong
+      font-weight: 600
     input.content-editable, textarea.content-editable
       background-color: white
       border: 1px solid #ccc
@@ -295,6 +297,7 @@ popover-secondary-background()
     left: 0
 .add-project-to-collection-pop, .create-collection-pop
   .pop-over-info
+    color: text-on-secondary-background
     img
       width: 15px
       border-radius: 3px

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -301,6 +301,12 @@ popover-secondary-background()
     img
       width: 15px
       border-radius: 3px
+  .more-collections-badge
+    margin: 0 1px
+    vertical-align: middle
+    // remove margin on Badge component, ideally the Badge component would not specify margin
+    > *
+      margin: 0
   .loader-container
     margin: 0.5em
   form


### PR DESCRIPTION

## Links
* [wandering-save.glitch.me](https://wandering-save.glitch.me)
* [Manuscript](https://glitch.fogbugz.com/f/cases/3328305/Add-to-collection-pop-indicate-if-the-project-is-already-in-a-given-collection)
* Spec:
![image](https://user-images.githubusercontent.com/7584833/57649482-569a2e80-7596-11e9-94fd-1146f1b3443d.png)

## GIF/Screenshots:
**Project in no collections**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/7584833/57649801-243d0100-7597-11e9-9dd7-a80c644fbe20.png">

**Project in one collection**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/7584833/57649812-2bfca580-7597-11e9-8e80-ea8f9dc82fcd.png">

**Project in many collections**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/7584833/57649833-33bc4a00-7597-11e9-8aca-199597a12d82.png">

## Changes:
This adds a section to `add-project-to-collection-pop` that lists which collections a project is already included in.

## How To Test:
Add a project to a collection