### PR TITLE
Darkened tilapia: check for presence of result in filter

### DIFF
--- a/src/presenters/pop-overs/add-collection-project-pop.js
+++ b/src/presenters/pop-overs/add-collection-project-pop.js
@@ -187,7 +187,7 @@ class AddCollectionProjectPop extends React.Component {
     let nonCollectionResults = [];
     if (searchByUrl) {
       // get the single result that matches the URL exactly - check with https://community.glitch.me/
-      nonCollectionResults = results.filter((result) => result.domain === query);
+      nonCollectionResults = results.filter((result) => result && result.domain === query);
 
       // check if the project is already in the collection
       if (nonCollectionResults.length > 0 && collectionProjectIds.includes(nonCollectionResults[0].id)) {


### PR DESCRIPTION
## Links
* Remix link: https://darkened-tilapia.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3328546/Cannot-read-property-domain-of-null-in-add-collection-project-pop

## Changes:
* check for presence of result when filtering in add-collection-project-pop

## Future work in this area:
- switch this to using the search API when componentizing this file https://glitch.manuscript.com/f/cases/3328551/Componentize-AddCollectionProjectPop
