### PR TITLE
Subsequent atmosphere: encode `+` in API calls

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -15,7 +15,7 @@ const api = axios.create({
 });
 
 function getProjectFromApi(domain) {
-  return getSingleItem(api, `v1/projects/by/domain?domain=${punycode.toASCII(domain)}`, domain);
+  return getSingleItem(api, `v1/projects/by/domain?domain=${domain}`, domain);
 }
 
 function getTeamFromApi(url) {

--- a/server/api.js
+++ b/server/api.js
@@ -18,11 +18,11 @@ async function getProjectFromApi(domain) {
 }
 
 async function getTeamFromApi(url) {
-  return await getSingleItem(api, `v1/teams/by/url?url=${url}`, url);
+  return await getSingleItem(api, `v1/teams/by/url?url=${encodeURIComponent(url)}`, url);
 }
 
 async function getUserFromApi(login) {
-  return await getSingleItem(api, `v1/users/by/login?login=${login}`, login);
+  return await getSingleItem(api, `v1/users/by/login?login=${encodeURIComponent(login)}`, login);
 }
 
 async function getCollectionFromApi(url) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,7 +4,7 @@ const enforce = require('express-sslify');
 const fs = require('fs');
 const util = require('util');
 const dayjs = require('dayjs');
-const punycode = require('punycode');	
+const punycode = require('punycode');
 
 const MarkdownIt = require('markdown-it');
 const md = new MarkdownIt();

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,6 +4,7 @@ const enforce = require('express-sslify');
 const fs = require('fs');
 const util = require('util');
 const dayjs = require('dayjs');
+const punycode = require('punycode');	
 
 const MarkdownIt = require('markdown-it');
 const md = new MarkdownIt();
@@ -102,7 +103,7 @@ module.exports = function(external) {
 
   app.get('/~:domain', async (req, res) => {
     const { domain } = req.params;
-    const project = await getProject(domain);
+    const project = await getProject(punycode.toASCII(domain));
     if (!project) {
       await render(res, domain, `We couldn't find ~${domain}`);
       return;

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -66,8 +66,8 @@ CollectionWide.propTypes = {
 
 const loadCollection = async (api, { owner, name }) => {
   try {
-    const collection = await getSingleItem(api, `/v1/collections/by/fullUrl?fullUrl=${owner}/${name}`, `${owner}/${name}`);
-    collection.projects = await getSingleItem(api, `/v1/collections/by/fullUrl/projects?limit=20&fullUrl=${owner}/${name}`, 'items');
+    const collection = await getSingleItem(api, `/v1/collections/by/fullUrl?fullUrl=${encodeURIComponent(owner)}/${name}`, `${owner}/${name}`);
+    collection.projects = await getSingleItem(api, `/v1/collections/by/fullUrl/projects?limit=20&fullUrl=${encodeURIComponent(owner)}/${name}`, 'items');
     collection.team = await getSingleItem(api, `/v1/teams/by/id?id=${collection.team.id}`, collection.team.id);
     collection.projectCount = collection.projects.length;
     collection.projects = sampleSize(collection.projects, 3);

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -242,10 +242,10 @@ CollectionPageContents.defaultProps = {
 
 async function loadCollection(api, ownerName, collectionName) {
   try {
-    const collection = await getSingleItem(api, `v1/collections/by/fullUrl?fullUrl=${ownerName}/${collectionName}`, `${ownerName}/${collectionName}`);
+    const collection = await getSingleItem(api, `v1/collections/by/fullUrl?fullUrl=${encodeURIComponent(ownerName)}/${collectionName}`, `${ownerName}/${collectionName}`);
     const collectionProjects = await getAllPages(
       api,
-      `v1/collections/by/fullUrl/projects?fullUrl=${ownerName}/${collectionName}&orderKey=updatedAt&orderDirection=ASC&limit=100`,
+      `v1/collections/by/fullUrl/projects?fullUrl=${encodeURIComponent(ownerName)}/${collectionName}&orderKey=updatedAt&orderDirection=ASC&limit=100`,
     );
 
     if (collection.user) {

--- a/src/presenters/pages/team-or-user.js
+++ b/src/presenters/pages/team-or-user.js
@@ -27,12 +27,13 @@ const getUserById = async (api, id) => {
 };
 
 const getUserByLogin = async (api, name) => {
+  const encoded = encodeURIComponent(name);
   const data = await allByKeys({
-    user: getSingleItem(api, `v1/users/by/login?login=${name}`, name),
-    pins: getAllPages(api, `v1/users/by/login/pinnedProjects?login=${name}&limit=100&orderKey=createdAt&orderDirection=DESC`),
-    projects: getAllPages(api, `v1/users/by/login/projects?login=${name}&limit=100&orderKey=createdAt&orderDirection=DESC`),
-    teams: getAllPages(api, `v1/users/by/login/teams?login=${name}&limit=100&orderKey=createdAt&orderDirection=DESC`),
-    collections: getAllPages(api, `v1/users/by/login/collections?login=${name}&limit=100&orderKey=createdAt&orderDirection=DESC`),
+    user: getSingleItem(api, `v1/users/by/login?login=${encoded}`, name),
+    pins: getAllPages(api, `v1/users/by/login/pinnedProjects?login=${encoded}&limit=100&orderKey=createdAt&orderDirection=DESC`),
+    projects: getAllPages(api, `v1/users/by/login/projects?login=${encoded}&limit=100&orderKey=createdAt&orderDirection=DESC`),
+    teams: getAllPages(api, `v1/users/by/login/teams?login=${encoded}&limit=100&orderKey=createdAt&orderDirection=DESC`),
+    collections: getAllPages(api, `v1/users/by/login/collections?login=${encoded}&limit=100&orderKey=createdAt&orderDirection=DESC`),
   });
   return mergeUserData(data);
 };
@@ -45,7 +46,7 @@ const parseTeam = (team) => {
 };
 
 const getTeam = async (api, name) => {
-  const team = await getSingleItem(api, `v1/teams/by/url?url=${name}`, name);
+  const team = await getSingleItem(api, `v1/teams/by/url?url=${encodeURIComponent(name)}`, name);
   if (team) {
     const [users, pinnedProjects, projects, collections] = await Promise.all([
       // load all users, need to handle pagination


### PR DESCRIPTION
## Links
* Remix link: https://subsequent-atmosphere.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328525/Can-t-load-profile-page-for-users-with-in-login

## Changes:
* encode API calls using `by/login`, `by/url`, `by/fullUrl`
* refactor server-side calls to encode in api.js instead of routes.js
* (projects use punycode and cannot actually have non-url characters in their names, and are therefore unaffected by this)

## How To Test:
* user with + in name should load: https://subsequent-atmosphere.glitch.me/@justin+test3
* collection belonging to user with + in name should load: https://subsequent-atmosphere.glitch.me/@justin+test3/test-collection

## Future work:
- replace bare API calls with helper functions/resource manager that does all of this for us