### PR TITLE
deep-liver: collection-item AnimationContainer fix for un-authed users

### DIFF
--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -61,7 +61,7 @@ ProjectsPreview.propTypes = {
 
 
 const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurator }) => (
-  <AnimationContainer type="slideDown" onAnimationEnd={deleteCollection}>
+  <AnimationContainer type="slideDown" onAnimationEnd={deleteCollection || (() => {})}>
     {(animateAndDeleteCollection) => (
       <div className={styles.collectionItem}>
         {(showCurator || isAuthorized) && (


### PR DESCRIPTION
## Links
* [deep-liver.glitch.me](https://deep-liver.glitch.me)
* [Manuscript](https://glitch.fogbugz.com/f/cases/3328553/AnimationContainer-onAnimationEnd-is-sometimes-null-if-user-is-not-authorized): `AnimationContainer`'s `onAnimationEnd` is sometimes `null` if user is not authorized

## Changes:
This makes sure `onAnimationEnd` is never `null` in `collection-item.js` when a user is not authenticated

## How To Test:
* Visit [a project page](https://deep-liver.glitch.me/~sponcron) while *not logged in*, you should not see any errors in the console
* To reproduce:
   Visit [a project page](https://tourmaline-fox.glitch.me/~sponcron) on another remix while *not logged in*, you should see errors in the console (errors are suppressed in production builds so you won't see this on community.glitch.me)

## Feedback I'm looking for:
- Is this approach sound?
  Would it make more sense to check for `isAuthed` and only wrap `CollectionLink`s in `AnimationContainer`s if the user is logged in?
- Did I miss any `AnimationContainer`s that will have this same issue?
