### PR TITLE
Imported cafe: fix add project to collections bug

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -3,7 +3,6 @@
 const axios = require('axios');
 const { Cache } = require('memory-cache');
 const dayjs = require('dayjs');
-const punycode = require('punycode');
 const { captureException } = require('@sentry/node');
 
 const { API_URL } = require('./constants').current;

--- a/src/presenters/pop-overs/add-collection-project-pop.js
+++ b/src/presenters/pop-overs/add-collection-project-pop.js
@@ -187,7 +187,7 @@ class AddCollectionProjectPop extends React.Component {
     let nonCollectionResults = [];
     if (searchByUrl) {
       // get the single result that matches the URL exactly - check with https://community.glitch.me/
-      nonCollectionResults = results.filter((result) => result.domain === query);
+      nonCollectionResults = results.filter((result) => result && result.domain === query);
 
       // check if the project is already in the collection
       if (nonCollectionResults.length > 0 && collectionProjectIds.includes(nonCollectionResults[0].id)) {


### PR DESCRIPTION
## Links
* https://imported-cafe.glitch.me
* https://glitch.manuscript.com/f/cases/3328144/

## How To Test:
* To recreate the bug: go to a collection, click add project to collection and search for a url for a project that doesn't exist (https://glitch.com/~nothinghereatall works for me), notice in the console, an error fires off
* notice on my remix that does not in fact happen! yay!
