### PR TITLE
Revert "Coconut restaurant: Fixing up Project Options Popovers"

### DIFF
--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -87,6 +87,7 @@ const CollectionPageContents = ({
   ...props
 }) => {
   const collectionHasProjects = !!collection && !!collection.projects;
+  const userIsLoggedIn = currentUser && currentUser.login;
   let featuredProject = null;
   let { projects } = collection;
   if (collection.featuredProjectId) {
@@ -163,24 +164,46 @@ const CollectionPageContents = ({
                     hideNote={hideNote}
                   />
                 )}
-                <ProjectsList
-                  layout="gridCompact"
-                  {...props}
-                  projects={projects}
-                  collection={collection}
-                  noteOptions={{
-                    hideNote,
-                    updateNote,
-                    isAuthorized: currentUserIsAuthor,
-                  }}
-                  projectOptions={{
-                    removeProjectFromCollection,
-                    addProjectToCollection,
-                    displayNewNote,
-                    featureProject,
-                    isAuthorized: currentUserIsAuthor,
-                  }}
-                />
+                {currentUserIsAuthor && (
+                  <ProjectsList
+                    layout="gridCompact"
+                    {...props}
+                    projects={projects}
+                    collection={collection}
+                    noteOptions={{
+                      hideNote,
+                      updateNote,
+                      isAuthorized: true,
+                    }}
+                    projectOptions={{
+                      removeProjectFromCollection,
+                      addProjectToCollection,
+                      displayNewNote,
+                      featureProject,
+                    }}
+                  />
+                )}
+                {!currentUserIsAuthor && userIsLoggedIn && (
+                  <ProjectsList
+                    layout="gridCompact"
+                    {...props}
+                    projects={collection.projects}
+                    collection={collection}
+                    noteOptions={{ isAuthorized: false }}
+                    projectOptions={{
+                      addProjectToCollection,
+                    }}
+                  />
+                )}
+                {!currentUserIsAuthor && !userIsLoggedIn && (
+                  <ProjectsList
+                    layout="gridCompact"
+                    projects={collection.projects}
+                    collection={collection}
+                    projectOptions={{}}
+                    noteOptions={{ isAuthorized: false }}
+                  />
+                )}
               </div>
             </>
           )}

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -79,11 +79,12 @@ class TeamPage extends React.Component {
       addProjectToCollection: this.addProjectToCollection,
       deleteProject: this.props.deleteProject,
       leaveTeamProject: this.props.leaveTeamProject,
-      removeProjectFromTeam: this.props.removeProject,
-      joinTeamProject: this.props.joinTeamProject,
-      featureProject: this.props.featureProject,
-      isAuthorized: this.props.currentUserIsOnTeam,
     };
+    if (this.props.currentUserIsOnTeam) {
+      projectOptions.removeProjectFromTeam = this.props.removeProject;
+      projectOptions.joinTeamProject = this.props.joinTeamProject;
+      projectOptions.featureProject = this.props.featureProject;
+    }
 
     return projectOptions;
   }
@@ -164,8 +165,9 @@ class TeamPage extends React.Component {
             }
             projects={pinnedProjects}
             isAuthorized={this.props.currentUserIsOnTeam}
+            removePin={this.props.removePin}
             projectOptions={{
-              removePin: this.props.removePin,
+              removePin: this.props.currentUserIsOnTeam ? this.props.removePin : undefined,
               ...this.getProjectOptions(),
             }}
           />
@@ -181,7 +183,7 @@ class TeamPage extends React.Component {
             enablePagination
             enableFiltering={recentProjects.length > 6}
             projectOptions={{
-              addPin: this.props.addPin,
+              addPin: this.props.currentUserIsOnTeam ? this.props.addPin : undefined,
               ...this.getProjectOptions(),
             }}
           />

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -153,12 +153,11 @@ const UserPage = ({
           }
           projects={pinnedProjects}
           projectOptions={{
-            removePin,
-            featureProject,
+            removePin: isAuthorized ? removePin : undefined,
+            featureProject: isAuthorized ? featureProject : undefined,
             leaveProject,
             deleteProject,
             addProjectToCollection,
-            isAuthorized,
           }}
         />
       )}
@@ -184,12 +183,11 @@ const UserPage = ({
           enablePagination
           enableFiltering={recentProjects.length > 6}
           projectOptions={{
-            addPin,
-            featureProject,
+            addPin: isAuthorized ? addPin : undefined,
+            featureProject: isAuthorized ? featureProject : undefined,
             leaveProject,
             deleteProject,
             addProjectToCollection,
-            isAuthorized,
           }}
         />
       )}

--- a/src/presenters/pop-overs/project-options-pop.js
+++ b/src/presenters/pop-overs/project-options-pop.js
@@ -8,154 +8,123 @@ import { useCurrentUser } from '../../state/current-user';
 
 import AddProjectToCollectionPop from './add-project-to-collection-pop';
 
-const isTeamProject = ({ currentUser, project }) => {
-  for (const team of currentUser.teams) {
-    if (project.teamIds.includes(team.id)) {
-      return true;
-    }
-  }
-  return false;
-};
-
-const promptThenLeaveProject = ({ event, project, leaveProject, currentUser }) => {
-  if (isTeamProject({ currentUser, project })) {
-    leaveProject(project.id, event);
-    return;
-  }
-
-  const prompt = `Once you leave this project, you'll lose access to it unless someone else invites you back. \n\n Are sure you want to leave ${
-    project.domain
-  }?`;
-  if (window.confirm(prompt)) {
-    leaveProject(project.id, event);
-  }
-};
-
-
-const determineProjectOptionsFunctions = ({ currentUser, project, projectOptions }) => {
-  const isAnon = !(currentUser && currentUser.login);
-  const projectUserIds = project && project.users && project.users.map((projectUser) => projectUser.id);
-  const isProjectMember = currentUser && projectUserIds && projectUserIds.includes(currentUser.id);
-  const currentUserProjectPermissions = currentUser && project && project.permissions && project.permissions.find((p) => p.userId === currentUser.id);
-  const isProjectAdmin = currentUserProjectPermissions && currentUserProjectPermissions.accessLevel === 30;
-  const {
-    isAuthorized,
-    featureProject,
-    addPin,
-    removePin,
-    displayNewNote,
-    addProjectToCollection,
-    joinTeamProject,
-    leaveTeamProject,
-    leaveProject,
-    removeProjectFromTeam,
-    deleteProject,
-    removeProjectFromCollection,
-  } = projectOptions;
-
-  return {
-    featureProject: featureProject && !project.private && !isAnon && isAuthorized
-      ? () => featureProject(project.id)
-      : null,
-    addPin: addPin && !isAnon && isAuthorized
-      ? () => addPin(project.id)
-      : null,
-    removePin: removePin && !isAnon && isAuthorized
-      ? () => removePin(project.id)
-      : null,
-    displayNewNote: !(project.note || project.isAddingANewNote) && displayNewNote && !isAnon && isAuthorized
-      ? () => displayNewNote(project.id)
-      : null,
-    addProjectToCollection: addProjectToCollection && !isAnon
-      ? addProjectToCollection
-      : null,
-    joinTeamProject: joinTeamProject && !isProjectMember && !isAnon && isAuthorized
-      ? () => joinTeamProject(project.id, currentUser.id)
-      : null,
-    leaveTeamProject: leaveTeamProject && isProjectMember && !isAnon && !isProjectAdmin && isAuthorized
-      ? () => leaveTeamProject(project.id, currentUser.id)
-      : null,
-    leaveProject: leaveProject && project.users.length > 1 && isProjectMember && !isProjectAdmin && isAuthorized
-      ? (event) => promptThenLeaveProject({ event, project, leaveProject, currentUser })
-      : null,
-    removeProjectFromTeam: removeProjectFromTeam && !removeProjectFromCollection && !isAnon && isAuthorized
-      ? () => removeProjectFromTeam(project.id)
-      : null,
-    deleteProject: !removeProjectFromCollection && deleteProject && isProjectAdmin
-      ? () => deleteProject(project.id)
-      : null,
-    removeProjectFromCollection: removeProjectFromCollection && !isAnon && isAuthorized
-      ? () => removeProjectFromCollection(project)
-      : null,
-  };
-};
-
 const PopoverButton = ({ onClick, text, emoji }) => (
   <button className="button-small has-emoji button-tertiary" onClick={onClick} type="button">
     <span>{`${text} `}</span>
     <span className={`emoji ${emoji}`} />
   </button>
 );
-PopoverButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  text: PropTypes.string.isRequired,
-  emoji: PropTypes.string.isRequired,
-};
 
-const ProjectOptionsContent = (props) => {
-  function toggleAndCB(cb) {
-    props.togglePopover();
-    cb();
+const ProjectOptionsContent = ({ addToCollectionPopover, ...props }) => {
+  function isTeamProject() {
+    const { currentUser, project } = props;
+    for (const team of currentUser.teams) {
+      if (project.teamIds.includes(team.id)) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  const onClickLeaveTeamProject = useTrackedFunc(props.leaveTeamProject, 'Leave Project clicked');
-  const onClickLeaveProject = useTrackedFunc(props.leaveProject, 'Leave Project clicked');
-  const onClickDeleteProject = useTrackedFunc(() => toggleAndCB(props.deleteProject), 'Delete Project clicked');
+  function leaveProject(event) {
+    if (isTeamProject()) {
+      props.leaveProject(props.project.id, event);
+      return;
+    }
 
-  const showPinOrFeatureSection = props.addPin || props.removePin || props.featureProject;
-  const showDangerZone = props.removeProjectFromTeam || props.deleteProject || props.removeProjectFromCollection;
+    const prompt = `Once you leave this project, you'll lose access to it unless someone else invites you back. \n\n Are sure you want to leave ${
+      props.project.domain
+    }?`;
+    if (window.confirm(prompt)) {
+      props.leaveProject(props.project.id, event);
+    }
+  }
+
+  function leaveTeamProject() {
+    props.leaveTeamProject(props.project.id, props.currentUser.id);
+  }
+
+  function joinTeamProject() {
+    props.joinTeamProject(props.project.id, props.currentUser);
+  }
+
+  function animateThenAddPin() {
+    props.addPin(props.project.id);
+    props.togglePopover();
+  }
+
+  function animateThenRemovePin() {
+    props.removePin(props.project.id);
+    props.togglePopover();
+  }
+
+  function animateThenDeleteProject() {
+    props.deleteProject(props.project.id);
+    props.togglePopover();
+  }
+
+  function animateThenRemoveProjectFromTeam() {
+    props.removeProjectFromTeam(props.project.id);
+    props.togglePopover();
+  }
+
+  function featureProject() {
+    props.featureProject(props.project.id);
+    props.togglePopover();
+  }
+
+  function toggleAndDisplayNote() {
+    props.togglePopover();
+    props.displayNewNote(props.project.id);
+  }
+
+  const showLeaveProject = props.leaveProject && props.project.users.length > 1 && props.currentUserIsOnProject;
+  const showAddNote = !(props.project.note || props.project.isAddingANewNote) && !!props.displayNewNote;
+  const showPinOrFeatureSection = props.addPin || props.removePin || (props.featureProject && !props.project.private);
+  const showRemoveProjectFromTeam = !!props.removeProjectFromTeam && !props.removeProjectFromCollection;
+  const showDeleteProject = props.currentUserIsAdminOnProject && !props.removeProjectFromCollection;
+  const showDangerZone = showRemoveProjectFromTeam || showDeleteProject || props.removeProjectFromCollection;
+
+  const onClickAddPin = useTrackedFunc(animateThenAddPin, 'Project Pinned');
+  const onClickRemovePin = useTrackedFunc(animateThenRemovePin, 'Project Un-Pinned');
+  const onClickLeaveTeamProject = useTrackedFunc(leaveTeamProject, 'Leave Project clicked');
+  const onClickLeaveProject = useTrackedFunc(leaveProject, 'Leave Project clicked');
+  const onClickDeleteProject = useTrackedFunc(animateThenDeleteProject, 'Delete Project clicked');
 
   return (
     <dialog className="pop-over project-options-pop" ref={props.focusFirstElement}>
       {showPinOrFeatureSection && (
         <section className="pop-over-actions">
-          {props.featureProject && (
-            <PopoverButton onClick={() => toggleAndCB(props.featureProject)} text="Feature" emoji="clapper" />
-          )}
-          {props.addPin && (
-            <PopoverButton onClick={() => toggleAndCB(props.addPin)} text="Pin " emoji="pushpin" />
-          )}
-          {props.removePin && (
-            <PopoverButton onClick={() => toggleAndCB(props.removePin)} text="Un-Pin " emoji="pushpin" />
-          )}
+          {!!props.featureProject && !props.project.private && <PopoverButton onClick={featureProject} text="Feature" emoji="clapper" />}
+          {!!props.addPin && <PopoverButton onClick={onClickAddPin} text="Pin " emoji="pushpin" />}
+          {!!props.removePin && <PopoverButton onClick={onClickRemovePin} text="Un-Pin " emoji="pushpin" />}
         </section>
       )}
-
-      {props.displayNewNote && (
+      {showAddNote && (
         <section className="pop-over-actions">
-          <PopoverButton onClick={() => toggleAndCB(props.displayNewNote)} text="Add Note" emoji="spiral_note_pad" />
+          <PopoverButton onClick={toggleAndDisplayNote} {...props} text="Add Note" emoji="spiral_note_pad" />
         </section>
       )}
 
-      {props.addProjectToCollection && (
+      {!!props.addProjectToCollection && (
         <section className="pop-over-actions">
-          <PopoverButton onClick={props.addToCollectionPopover} text="Add to Collection " emoji="framed-picture" />
+          <PopoverButton onClick={addToCollectionPopover} {...props} text="Add to Collection " emoji="framed-picture" />
         </section>
       )}
 
-      {props.joinTeamProject && (
+      {props.joinTeamProject && !props.currentUserIsOnProject && (
         <section className="pop-over-actions collaborator-actions">
-          <PopoverButton onClick={props.joinTeamProject} text="Join Project " emoji="rainbow" />
+          <PopoverButton onClick={joinTeamProject} text="Join Project " emoji="rainbow" />
         </section>
       )}
 
-      {props.leaveTeamProject && (
+      {props.leaveTeamProject && props.currentUserIsOnProject && (
         <section className="pop-over-actions collaborator-actions">
           <PopoverButton onClick={onClickLeaveTeamProject} text="Leave Project " emoji="wave" />
         </section>
       )}
 
-      {props.leaveProject && (
+      {showLeaveProject && (
         <section className="pop-over-actions collaborator-actions">
           <PopoverButton onClick={onClickLeaveProject} text="Leave Project " emoji="wave" />
         </section>
@@ -163,58 +132,80 @@ const ProjectOptionsContent = (props) => {
 
       {showDangerZone && (
         <section className="pop-over-actions danger-zone last-section">
-          {props.removeProjectFromTeam && (
-            <PopoverButton onClick={() => toggleAndCB(props.removeProjectFromTeam)} text="Remove Project " emoji="thumbs_down" />
-          )}
+          {showRemoveProjectFromTeam && <PopoverButton onClick={animateThenRemoveProjectFromTeam} text="Remove Project " emoji="thumbs_down" />}
 
-          {props.deleteProject && (
-            <PopoverButton onClick={onClickDeleteProject} text="Delete Project " emoji="bomb" />
-          )}
+          {showDeleteProject && <PopoverButton onClick={onClickDeleteProject} text="Delete Project " emoji="bomb" />}
 
           {props.removeProjectFromCollection && (
-            <PopoverButton onClick={props.removeProjectFromCollection} text="Remove from Collection" emoji="thumbs_down" />
+            <PopoverButton onClick={() => props.removeProjectFromCollection(props.project)} text="Remove from Collection" emoji="thumbs_down" />
           )}
         </section>
       )}
-
     </dialog>
   );
 };
 
-ProjectOptionsContent.propTypes = {
-  addPin: PropTypes.func,
-  addProjectToCollection: PropTypes.func,
-  deleteProject: PropTypes.func,
-  displayNewNote: PropTypes.func,
-  featureProject: PropTypes.func,
-  joinTeamProject: PropTypes.func,
-  leaveProject: PropTypes.func,
-  leaveTeamProject: PropTypes.func,
-  removePin: PropTypes.func,
-  removeProjectFromTeam: PropTypes.func,
+// Project Options Pop
+const ProjectOptionsPop = ({ ...props }) => (
+  <NestedPopover
+    alternateContent={() => <AddProjectToCollectionPop {...props} togglePopover={props.togglePopover} focusFirstElement={props.focusFirstElement} />}
+  >
+    {(addToCollectionPopover) => (
+      <ProjectOptionsContent {...props} addToCollectionPopover={addToCollectionPopover} focusFirstElementg={props.focusFirstElementg} />
+    )}
+  </NestedPopover>
+);
+
+ProjectOptionsPop.propTypes = {
+  currentUser: PropTypes.object.isRequired,
+  project: PropTypes.shape({
+    users: PropTypes.array.isRequired,
+  }).isRequired,
   togglePopover: PropTypes.func.isRequired,
   focusFirstElement: PropTypes.func.isRequired,
+  addPin: PropTypes.func,
+  removePin: PropTypes.func,
+  deleteProject: PropTypes.func,
+  leaveProject: PropTypes.func,
+  removeProjectFromTeam: PropTypes.func,
+  joinTeamProject: PropTypes.func,
+  leaveTeamProject: PropTypes.func,
+  featureProject: PropTypes.func,
+  currentUserIsOnProject: PropTypes.bool,
+  displayNewNote: PropTypes.func,
 };
-ProjectOptionsContent.defaultProps = {
+ProjectOptionsPop.defaultProps = {
+  currentUserIsOnProject: false,
   addPin: null,
-  addProjectToCollection: null,
-  deleteProject: null,
-  displayNewNote: null,
-  featureProject: null,
-  joinTeamProject: null,
-  leaveProject: null,
-  leaveTeamProject: null,
   removePin: null,
+  deleteProject: null,
+  leaveProject: null,
   removeProjectFromTeam: null,
+  joinTeamProject: null,
+  leaveTeamProject: null,
+  featureProject: null,
+  displayNewNote: null,
 };
 
-export default function ProjectOptionsPop(props) {
+// Project Options Container
+// create as stateful react component
+export default function ProjectOptions({ projectOptions, project }, { ...props }) {
   const { currentUser } = useCurrentUser();
-  const projectOptions = determineProjectOptionsFunctions({ currentUser, ...props });
-  const noProjectOptions = Object.values(projectOptions).every((option) => !option);
-
-  if (noProjectOptions) {
+  if (Object.keys(projectOptions).length === 0) {
     return null;
+  }
+
+  function currentUserIsOnProject(user) {
+    const projectUsers = project.users.map((projectUser) => projectUser.id);
+    if (projectUsers.includes(user.id)) {
+      return true;
+    }
+    return false;
+  }
+
+  function currentUserIsAdminOnProject(user) {
+    const projectPermissions = project && project.permissions && project.permissions.find((p) => p.userId === user.id);
+    return projectPermissions && projectPermissions.accessLevel === 30;
   }
 
   return (
@@ -224,29 +215,26 @@ export default function ProjectOptionsPop(props) {
       containerClass="project-options-pop-btn"
     >
       {({ togglePopover, focusFirstElement }) => (
-        <NestedPopover
-          alternateContent={() => <AddProjectToCollectionPop {...props} togglePopover={props.togglePopover} focusFirstElement={focusFirstElement} />}
-        >
-          {(addToCollectionPopover) => (
-            <ProjectOptionsContent
-              {...props}
-              {...projectOptions}
-              addToCollectionPopover={addToCollectionPopover}
-              togglePopover={togglePopover}
-              focusFirstElement={focusFirstElement}
-            />
-          )}
-        </NestedPopover>
+        <ProjectOptionsPop
+          {...props}
+          {...projectOptions}
+          project={project}
+          currentUser={currentUser}
+          currentUserIsOnProject={currentUserIsOnProject(currentUser)}
+          currentUserIsAdminOnProject={currentUserIsAdminOnProject(currentUser)}
+          togglePopover={togglePopover}
+          focusFirstElement={focusFirstElement}
+        />
       )}
     </PopoverWithButton>
   );
 }
 
-ProjectOptionsPop.propTypes = {
+ProjectOptions.propTypes = {
   project: PropTypes.object.isRequired,
   projectOptions: PropTypes.object,
 };
 
-ProjectOptionsPop.defaultProps = {
+ProjectOptions.defaultProps = {
   projectOptions: {},
 };

--- a/src/presenters/user-editor.js
+++ b/src/presenters/user-editor.js
@@ -77,7 +77,7 @@ class UserEditor extends React.Component {
   async leaveProject(id) {
     await this.props.api.delete(`/projects/${id}/authorization`, {
       data: {
-        targetUserId: this.props.currentUser.id,
+        targetUserId: this.state.id,
       },
     });
     this.setState(({ projects }) => ({


### PR DESCRIPTION
Reverts FogCreek/Glitch-Community#508

something went wrong here, I guess related to a merge commit I think that was resolved incorrectly, I'm seeing issues on the search page, when I click addProjectToCollection

definitely this line at least was wrong, :
```
          alternateContent={() => <AddProjectToCollectionPop {...props} togglePopover={props.togglePopover} focusFirstElement={focusFirstElement} />}
```

```
          alternateContent={() => <AddProjectToCollectionPop {...props} togglePopover={togglePopover} focusFirstElement={focusFirstElement} currentUser={currentUser} />}
````

but there's more I think too
