### PR TITLE
Quilted day: componentize RelatedProjects

### DIFF
--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -22,7 +22,7 @@ const containers = {
   gridCompact: (props) => <Grid className={styles.projectsGridCompact} {...props} />,
 };
 
-const ProjectsUL = ({ collection, projects, noteOptions, layout, projectOptions }) => {
+const ProjectsUL = ({ collection, projects, noteOptions, layout, projectOptions, fetchMembers }) => {
   const Container = containers[layout];
   return (
     <Container items={projects}>
@@ -39,7 +39,7 @@ const ProjectsUL = ({ collection, projects, noteOptions, layout, projectOptions 
               />
             </div>
           )}
-          <ProjectItem key={project.id} project={project} projectOptions={projectOptions} />
+          <ProjectItem key={project.id} project={project} projectOptions={projectOptions} fetchMembers={fetchMembers} />
         </>
       )}
     </Container>
@@ -144,6 +144,7 @@ function ProjectsList({
   placeholder,
   enableFiltering,
   enablePagination,
+  fetchMembers,
   projectsPerPage,
   collection,
   noteOptions,
@@ -166,6 +167,7 @@ function ProjectsList({
                   noteOptions={noteOptions}
                   layout={layout}
                   projectOptions={projectOptions}
+                  fetchMembers={fetchMembers}
                 />
               )}
             </PaginationController>
@@ -183,6 +185,7 @@ ProjectsList.propTypes = {
   placeholder: PropTypes.node,
   enableFiltering: PropTypes.bool,
   enablePagination: PropTypes.bool,
+  fetchMembers: PropTypes.bool,
   projectsPerPage: PropTypes.number,
   collection: PropTypes.object,
   noteOptions: PropTypes.object,
@@ -194,6 +197,7 @@ ProjectsList.defaultProps = {
   placeholder: null,
   enableFiltering: false,
   enablePagination: false,
+  fetchMembers: false,
   projectsPerPage: 6,
   collection: null,
   noteOptions: {},

--- a/src/components/data-loader/index.js
+++ b/src/components/data-loader/index.js
@@ -8,18 +8,24 @@ const DataLoader = ({ children, get, renderError, renderLoader, captureException
   const [{ status, value }, setState] = useState({ status: 'loading', value: null });
   const api = useAPI();
   useEffect(() => {
+    let isCurrent = true;
     get(api).then(
       (data) => {
+        if (!isCurrent) return;
         setState({ status: 'ready', value: data });
       },
       (error) => {
         console.error(error);
+        if (!isCurrent) return;
         setState({ status: 'error', value: error });
         if (shouldCaptureException) {
           captureException(error);
         }
       },
     );
+    return () => {
+      isCurrent = false;
+    };
   }, [api]);
   if (status === 'ready') return children(value);
   if (status === 'error') return renderError(value);

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -10,8 +10,8 @@ import { ProjectLink } from 'Components/link';
 import AnimationContainer from 'Components/animation-container';
 import { FALLBACK_AVATAR_URL, getAvatarUrl } from 'Models/project';
 import { getAllPages } from 'Shared/api';
+import { createAPIHook } from 'State/api';
 import ProjectOptionsPop from '../../presenters/pop-overs/project-options-pop';
-import { createAPIHook } from '../../state/api';
 import styles from './project-item.styl';
 
 const PrivateIcon = () => <span className="project-badge private-project-badge" aria-label="private" />;

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -9,6 +9,7 @@ import ProfileList from 'Components/profile-list';
 import { ProjectLink } from 'Components/link';
 import AnimationContainer from 'Components/animation-container';
 import { FALLBACK_AVATAR_URL, getAvatarUrl } from 'Models/project';
+import { getAllPages } from 'Shared/api';
 import ProjectOptionsPop from '../../presenters/pop-overs/project-options-pop';
 import { createAPIHook } from '../../state/api';
 import styles from './project-item.styl';
@@ -23,26 +24,6 @@ const getLinkBodyStyles = (project) =>
   });
 
 const hasOptions = (projectOptions) => Object.keys(projectOptions).length > 0;
-
-const useUsers = createAPIHook(async (api, userIDs) => {
-  if (!userIDs.length) {
-    return undefined;
-  }
-  const idString = userIDs.map((id) => `id=${id}`).join('&');
-
-  const { data } = await api.get(`/v1/users/by/id/?${idString}`);
-  return Object.values(data);
-});
-
-const useTeams = createAPIHook(async (api, teamIDs) => {
-  if (!teamIDs.length) {
-    return undefined;
-  }
-  const idString = teamIDs.map((id) => `id=${id}`).join('&');
-
-  const { data } = await api.get(`/v1/teams/by/id/?${idString}`);
-  return Object.values(data);
-});
 
 const ProjectItem = ({ project, projectOptions }) => {
   const dispatch = (projectOptionName, ...args) => projectOptions[projectOptionName](...args);
@@ -116,9 +97,13 @@ ProjectItem.defaultProps = {
   projectOptions: {},
 };
 
+const useUsers = createAPIHook((api, project) => getAllPages(api, `/v1/projects/by/id/users?id=${project.id}`));
+
+const useTeams = createAPIHook(async (api, project) => getAllPages(api, `/v1/projects/by/id/teams?id=${project.id}`));
+
 function ProjectWithDataLoading({ project, ...props }) {
-  const { value: users } = useUsers(project.userIDs);
-  const { value: teams } = useTeams(project.teamIDs);
+  const { value: users } = useUsers(project);
+  const { value: teams } = useTeams(project);
   const projectWithData = { ...project, users, teams };
   return <ProjectItem project={projectWithData} {...props} />;
 }

--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -97,7 +97,7 @@ RelatedProjects.propTypes = {
     id: PropTypes.string.isRequired,
     teams: PropTypes.array,
     users: PropTypes.array,
-  }),
+  }).isRequired,
 };
 
 export default RelatedProjects;

--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -6,14 +6,15 @@ import ProjectsList from 'Components/containers/projects-list';
 import CoverContainer from 'Components/containers/cover-container';
 import DataLoader from 'Components/data-loader';
 import { TeamLink, UserLink } from 'Components/link';
-import { getDisplayName } from '../../models/user';
+import { getDisplayName } from 'Models/user';
+import styles from './styles.styl';
 
 const PROJECT_COUNT = 3;
 
 const RelatedProjectsBody = ({ projects, type, item }) =>
   projects.length > 0 ? (
     <CoverContainer type={type} item={item}>
-      <div className="related-projects__projects-wrap">
+      <div className={styles.projectsWrap}>
         <ProjectsList layout="row" projects={projects} fetchMembers />
       </div>
     </CoverContainer>
@@ -30,12 +31,12 @@ async function getProjects(api, { type, id, ignoreProjectId }) {
   ]);
 
   pins = pins.filter((project) => project.id !== ignoreProjectId);
-  recents = recents.filter((project) => project.id !== ignoreProjectId);
-  
-  const sampledPins = 
-  
-  const allProjects = pins.concat(recents)
-  return sampleSize(allProjects, PROJECT_COUNT);
+  const sampledPins = sampleSize(pins, PROJECT_COUNT);
+  const sampledPinIDs = sampledPins.map((project) => project.id);
+
+  recents = recents.filter((project) => project.id !== ignoreProjectId && !sampledPinIDs.includes(project.id));
+  const sampledRecents = sampleSize(recents, PROJECT_COUNT - sampledPins.length);
+  return [...sampledPins, ...sampledRecents];
 }
 
 function useSample(items, count) {
@@ -54,7 +55,7 @@ function RelatedProjects({ teams: allTeams, users: allUsers, ignoreProjectId }) 
     return null;
   }
   return (
-    <ul className="related-projects">
+    <ul className={styles.container}>
       {teams.map((team) => (
         <li key={team.id}>
           <DataLoader get={(api) => getProjects(api, { type: 'team', id: team.id, ignoreProjectId })}>

--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -47,9 +47,10 @@ function useSample(items, count) {
   return sample;
 }
 
-function RelatedProjects({ teams: allTeams, users: allUsers, ignoreProjectId }) {
-  const teams = useSample(allTeams, 1);
-  const users = useSample(allUsers, 2 - teams.length);
+function RelatedProjects({ project }) {
+  const teams = useSample(project.teams || [], 1);
+  const users = useSample(project.users || [], 2 - teams.length);
+  const ignoreProjectId = project.id;
 
   if (!teams.length && !users.length) {
     return null;
@@ -92,14 +93,11 @@ function RelatedProjects({ teams: allTeams, users: allUsers, ignoreProjectId }) 
   );
 }
 RelatedProjects.propTypes = {
-  ignoreProjectId: PropTypes.string.isRequired,
-  teams: PropTypes.array,
-  users: PropTypes.array,
-};
-
-RelatedProjects.defaultProps = {
-  teams: [],
-  users: [],
+  project: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    teams: PropTypes.array,
+    users: PropTypes.array,
+  }),
 };
 
 export default RelatedProjects;

--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { sampleSize, difference } from 'lodash';
 
@@ -23,16 +23,30 @@ RelatedProjectsBody.propTypes = {
   projects: PropTypes.array.isRequired,
 };
 
+
+const getProjects = {
+  team: {
+    pinned: (id) => `/v1/teams/by/id/pinnedProjects
+  }
+}
+
 const getTeam = (api, id) => api.get(`teams/${id}`).then(({ data }) => data);
 const getTeamPins = (api, id) => api.get(`teams/${id}/pinned-projects`).then(({ data }) => data);
 const getUser = (api, id) => api.get(`users/${id}`).then(({ data }) => data);
 const getUserPins = (api, id) => api.get(`users/${id}/pinned-projects`).then(({ data }) => data);
 
 async function getProjects(api, { type, id, ignoreProjectId }) {
-  const getPins = type === 'team' ? getTeamPins : getUserPins
-  const getAllProjects = type === 'team' ? getTeam : getUser
+  const getPins = type === 'team' ? getTeamPins : getUserPins;
+  const getAllProjects = type === 'team' ? getTeam : getUser;
 
-  const pins = await getPins(api, id);
+  const [pins, recents] = await Promise.all([
+    api.get(`/v1/${type}s/by/id/pinnedProjects?id=${id}`).then(res => res.data.items),
+    api.get(`/v1/${type}s/by/id/projects?id=${id}`).then(res => res.data.items),
+  ])
+  
+  const allProjects = pins.concat(recents).filter(project => project.id !== ignoreProjectId)
+  const sample = sampleSize(allProjects,
+  
   const pinIds = pins.map((pin) => pin.projectId);
   let ids = sampleSize(difference(pinIds, [ignoreProjectId]), PROJECT_COUNT);
 
@@ -52,65 +66,57 @@ async function getProjects(api, { type, id, ignoreProjectId }) {
   return null;
 }
 
-function useSample (items, count) {
-  const [sample, setSample] = useState(sampleSize
+function useSample(items, count) {
+  const [sample, setSample] = useState([]);
+  useEffect(() => {
+    setSample(sampleSize(items, count));
+  }, [count, ...items.map((item) => item.id)]);
+  return sample;
 }
 
+function RelatedProjects({ teams: allTeams, users: allUsers, ignoreProjectId }) {
+  const teams = useSample(allTeams, 1);
+  const users = useSample(allUsers, 2 - teams.length);
 
-function RelatedProjects ({ teams, users, ignoreProjectId }) {
-  constructor(props) {
-    super(props);
-    const teams = sampleSize(props.teams, 1);
-    const users = sampleSize(props.users, 2 - teams.length);
-    this.state = { teams, users };
+  if (!teams.length && !users.length) {
+    return null;
   }
-
-  render() {
-    const sampledTeams = useSample(teams, 1);
-    const sampledUsers = useSample(users, 2 - teams.length);
-    
-    
-    const { teams, users } = this.state;
-    if (!teams.length && !users.length) {
-      return null;
-    }
-    return (
-      <ul className="related-projects">
-        {teams.map((team) => (
-          <li key={team.id}>
-            <DataLoader get={(api) => this.getProjects(api, team.id, getTeamPins, getTeam)}>
-              {(projects) =>
-                projects && (
-                  <>
-                    <h2>
-                      <TeamLink team={team}>More by {team.name} →</TeamLink>
-                    </h2>
-                    <RelatedProjectsBody projects={projects} type="team" item={team} />
-                  </>
-                )
-              }
-            </DataLoader>
-          </li>
-        ))}
-        {users.map((user) => (
-          <li key={user.id}>
-            <DataLoader get={(api) => this.getProjects(api, user.id, getUserPins, getUser)}>
-              {(projects) =>
-                projects && (
-                  <>
-                    <h2>
-                      <UserLink user={user}>More by {getDisplayName(user)} →</UserLink>
-                    </h2>
-                    <RelatedProjectsBody projects={projects} type="user" item={user} />
-                  </>
-                )
-              }
-            </DataLoader>
-          </li>
-        ))}
-      </ul>
-    );
-  }
+  return (
+    <ul className="related-projects">
+      {teams.map((team) => (
+        <li key={team.id}>
+          <DataLoader get={(api) => getProjects(api, { type: 'team', id: team.id, ignoreProjectId })}>
+            {(projects) =>
+              projects && (
+                <>
+                  <h2>
+                    <TeamLink team={team}>More by {team.name} →</TeamLink>
+                  </h2>
+                  <RelatedProjectsBody projects={projects} type="team" item={team} />
+                </>
+              )
+            }
+          </DataLoader>
+        </li>
+      ))}
+      {users.map((user) => (
+        <li key={user.id}>
+          <DataLoader get={(api) => getProjects(api, { type: 'user', id: user.id, ignoreProjectId })}>
+            {(projects) =>
+              projects && (
+                <>
+                  <h2>
+                    <UserLink user={user}>More by {getDisplayName(user)} →</UserLink>
+                  </h2>
+                  <RelatedProjectsBody projects={projects} type="user" item={user} />
+                </>
+              )
+            }
+          </DataLoader>
+        </li>
+      ))}
+    </ul>
+  );
 }
 RelatedProjects.propTypes = {
   ignoreProjectId: PropTypes.string.isRequired,

--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -24,12 +24,17 @@ RelatedProjectsBody.propTypes = {
 };
 
 async function getProjects(api, { type, id, ignoreProjectId }) {
-  const [pins, recents] = await Promise.all([
+  let [pins, recents] = await Promise.all([
     api.get(`/v1/${type}s/by/id/pinnedProjects?id=${id}`).then((res) => res.data.items),
     api.get(`/v1/${type}s/by/id/projects?id=${id}`).then((res) => res.data.items),
   ]);
 
-  const allProjects = pins.concat(recents).filter((project) => project.id !== ignoreProjectId);
+  pins = pins.filter((project) => project.id !== ignoreProjectId);
+  recents = recents.filter((project) => project.id !== ignoreProjectId);
+  
+  const sampledPins = 
+  
+  const allProjects = pins.concat(recents)
   return sampleSize(allProjects, PROJECT_COUNT);
 }
 

--- a/src/components/related-projects/styles.styl
+++ b/src/components/related-projects/styles.styl
@@ -1,0 +1,6 @@
+.container
+  margin: 0
+  padding: 0
+  list-style-type: none
+.projectsWrap
+  margin: -1rem 0

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -18,6 +18,7 @@ import ProjectDomainInput from 'Components/fields/project-domain-input';
 import { ProjectProfileContainer } from 'Components/containers/profile';
 import DataLoader from 'Components/data-loader';
 import Row from 'Components/containers/row';
+import RelatedProjects from 'Components/related-projects';
 
 import PopoverWithButton from '../pop-overs/popover-with-button';
 
@@ -28,7 +29,6 @@ import ProjectEditor from '../project-editor';
 import Expander from '../includes/expander';
 import AuthDescription from '../includes/auth-description';
 import { ShowButton, EditButton } from '../includes/project-actions';
-import RelatedProjects from 'Components/related-projects';
 import { addBreadcrumb } from '../../utils/sentry';
 
 import { useCurrentUser } from '../../state/current-user';

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -252,7 +252,7 @@ const ProjectPage = ({
         <IncludedInCollections projectId={project.id} />
       </section>
       <section id="related">
-        <RelatedProjects ignoreProjectId={project.id} {...{ teams, users }} />
+        <RelatedProjects project={project} />
       </section>
     </main>
   );

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -28,7 +28,7 @@ import ProjectEditor from '../project-editor';
 import Expander from '../includes/expander';
 import AuthDescription from '../includes/auth-description';
 import { ShowButton, EditButton } from '../includes/project-actions';
-import RelatedProjects from '../includes/related-projects';
+import RelatedProjects from 'Components/related-projects';
 import { addBreadcrumb } from '../../utils/sentry';
 
 import { useCurrentUser } from '../../state/current-user';

--- a/styles/pages/project.styl
+++ b/styles/pages/project.styl
@@ -21,13 +21,6 @@
       height: 100%
     & + .buttons
       margin-top: 5px
-
-  .related-projects
-    padding: 0
-    > li
-      display: block
-    .related-projects__projects-wrap
-      margin: -1rem 0
   
   .buttons.space-between
     a


### PR DESCRIPTION
## Links
* Remix link: https://quilted-day.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328586/

## GIF/Screenshots:
![Screen Shot 2019-05-20 at 1 52 44 PM](https://user-images.githubusercontent.com/938722/58041753-e6942700-7b06-11e9-9532-e2ae12bb3064.png)

## Changes:
* componentize RelatedProjects styles
* use v1 API for fetching projects
* add `fetchMembers` to ProjectItem to allow projects to get their own users/teams
* fix setState leak in DataLoader (see https://twitter.com/ryanflorence/status/1129487337375690752)

## How To Test:
* visit https://quilted-day.glitch.me/~community
* there should be a set of related projects from a glitch team
* there should be a set of related projects from someone who has edited community