### PR TITLE
Abaft side: specify production api

### DIFF
--- a/src/components/header/new-project-pop.js
+++ b/src/components/header/new-project-pop.js
@@ -83,7 +83,8 @@ const useNewProjectAPI = createAPIHook(async (api) => {
   ];
   const idString = projectIds.map((id) => `id=${id}`).join('&');
   // always request against the production API, with no token
-  const { data } = await api.get(`/v1/projects/by/id?${idString}`, {
+  // (this is necessary for it to work on glitch.development)
+  const { data } = await api.get(`https://api.glitch.com/v1/projects/by/id?${idString}`, {
     headers: {
       Authorization: '',
     },

--- a/src/curated/featured-embed.js
+++ b/src/curated/featured-embed.js
@@ -1,13 +1,13 @@
 const body =
-  '<p>Style and remix themeable components, so you can create your own custom version of Material Design.</p><p>Define your theme, see it in action, and get the code.</p>';
+  '<p>90,000 developers shared their opinions about jobs, tech, and where the industry\'s going.</p><p>Remix our app to explore the data and discover your own insights.</p>';
 
 // make sure image urls use https
 export default {
-  image: 'https://culture-zine.glitch.me/culture/content/images/2019/04/Glitch_Illo_MaterialApps-Headline-v1--1--4.png',
+  image: 'https://culture-zine.glitch.me/culture/content/images/2019/05/stackFullDevSurveyBanner.png',
   mask: 'mask-4',
-  title: 'Build Your Own Material Theme',
-  appDomain: 'material-theme-builder',
-  blogUrl: '/build-material-design-themes-on-glitch/',
+  title: 'Explore Stack Overflow Dev Survey Results',
+  appDomain: '2019-stackoverflow-public-data',
+  blogUrl: '/discover-insights-explore-developer-survey-results-2019/',
   body,
   color: '#f5f5f5'
 };


### PR DESCRIPTION
## Links
* Remix link https://abaft-side.glitch.me/

## Changes:
* specify that starter projects are being fetched from the production API, so that they can be used on glitch.development (which ordinarily fetches from the dev API)