### PR TITLE
Sideways sound: don't fetch team invitees if there aren't any

### DIFF
--- a/src/presenters/includes/team-users.js
+++ b/src/presenters/includes/team-users.js
@@ -196,7 +196,8 @@ const JoinTeam = ({ onClick }) => (
 
 const useInvitees = createAPIHook(async (api, team, currentUserIsOnTeam) => {
   if (!currentUserIsOnTeam) return [];
-
+  // if (!team.tokens.length) return [];
+  
   try {
     const idString = team.tokens.map(({ userId }) => `id=${userId}`).join(',');
     const { data } = await api.get(`v1/users/by/id?${idString}`);

--- a/src/presenters/includes/team-users.js
+++ b/src/presenters/includes/team-users.js
@@ -196,8 +196,8 @@ const JoinTeam = ({ onClick }) => (
 
 const useInvitees = createAPIHook(async (api, team, currentUserIsOnTeam) => {
   if (!currentUserIsOnTeam) return [];
-  // if (!team.tokens.length) return [];
-  
+  if (!team.tokens.length) return [];
+
   try {
     const idString = team.tokens.map(({ userId }) => `id=${userId}`).join(',');
     const { data } = await api.get(`v1/users/by/id?${idString}`);

--- a/src/presenters/includes/team-users.js
+++ b/src/presenters/includes/team-users.js
@@ -199,7 +199,7 @@ const useInvitees = createAPIHook(async (api, team, currentUserIsOnTeam) => {
   if (!team.tokens.length) return [];
 
   try {
-    const idString = team.tokens.map(({ userId }) => `id=${userId}`).join(',');
+    const idString = team.tokens.map(({ userId }) => `id=${userId}`).join('&');
     const { data } = await api.get(`v1/users/by/id?${idString}`);
     const invitees = Object.values(data);
     return invitees;


### PR DESCRIPTION
## Links
* Remix link: https://sideways-sound.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328530/400-error-when-visiting-a-team-page-for-which-current-user-is-only-member

## Changes:
* don't try to fetch users corresponding to a team's invites if there aren't any

## How To Test:
* visit https://sideways-sound.glitch.me/@false-troop
* there should be no network error for /users/by/id 
* visit https://glitch.com/@false-troop
* there will be a network error for /users/by/id

## Future considerations
* maybe invited team users should be at `/team/by/url/invitedMembers`?
