### PR TITLE
Petalite yarn: fix mobile view of recent projects on the homepage

### DIFF
--- a/src/presenters/recent-projects.js
+++ b/src/presenters/recent-projects.js
@@ -74,12 +74,20 @@ RecentProjectsContainer.propTypes = {
 
 const RecentProjects = () => {
   const { currentUser: user, fetched, clear } = useCurrentUser();
+//   return (
+//     <RecentProjectsContainer user={user} clearUser={clear}>
+//         <Loader />
+//     </RecentProjectsContainer>
+
+//   )
   return (
     <RecentProjectsContainer user={user} clearUser={clear}>
       {fetched ? (
         <ProjectsLoader projects={user.projects.slice(0, 3)}>{(projects) => <ProjectsList layout="row" projects={projects} />}</ProjectsLoader>
       ) : (
-        <Loader />
+        <div>
+          <Loader />
+        </div>
       )}
     </RecentProjectsContainer>
   );

--- a/src/presenters/recent-projects.js
+++ b/src/presenters/recent-projects.js
@@ -74,18 +74,13 @@ RecentProjectsContainer.propTypes = {
 
 const RecentProjects = () => {
   const { currentUser: user, fetched, clear } = useCurrentUser();
-//   return (
-//     <RecentProjectsContainer user={user} clearUser={clear}>
-//         <Loader />
-//     </RecentProjectsContainer>
 
-//   )
   return (
     <RecentProjectsContainer user={user} clearUser={clear}>
       {fetched ? (
         <ProjectsLoader projects={user.projects.slice(0, 3)}>{(projects) => <ProjectsList layout="row" projects={projects} />}</ProjectsLoader>
       ) : (
-        <div>
+        <div className="recent-projects-loader-wrapper">
           <Loader />
         </div>
       )}

--- a/styles/profile.styl
+++ b/styles/profile.styl
@@ -61,10 +61,12 @@
 .recent-projects__projects-wrap
   display: inline-block
   margin: -1rem
-  // margin: 0
   padding: 0
   width: 78%
   vertical-align: top
   @media(max-width: 800px)
     width: 100%
     margin-left: 0
+    
+.recent-projects-loader-wrapper
+  margin: 1rem 0;

--- a/styles/profile.styl
+++ b/styles/profile.styl
@@ -66,3 +66,4 @@
   vertical-align: top
   @media(max-width: 800px)
     width: 100%
+    margin-left: 0

--- a/styles/profile.styl
+++ b/styles/profile.styl
@@ -61,6 +61,7 @@
 .recent-projects__projects-wrap
   display: inline-block
   margin: -1rem
+  // margin: 0
   padding: 0
   width: 78%
   vertical-align: top


### PR DESCRIPTION
TIL what [petalite](https://en.wikipedia.org/wiki/Petalite) means, fun to think about what that might look like in yarn form

## Links
* https://petalite-yarn.glitch.me/
* https://glitch.manuscript.com/f/cases/3328563/

## GIF/Screenshots:
before and after
![Screen Shot 2019-05-21 at 11 33 44 AM](https://user-images.githubusercontent.com/6620164/58109977-9c6d7d00-7bbc-11e9-9f82-fb8f61c5318f.png)

## Changes:
* add some margin back on mobile to our recent projects
* add a wrapper around the loader to ensure it has good margins even on mobile. 

## How To Test:
* login and check out the homepage and check out the recent projects section

## Feedback I'm looking for:
- any suggestions for better ways to fix? anything might be missing?

