### PR TITLE
Workable salad: fix timestamp in super user banner

### DIFF
--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -18,7 +18,9 @@ const SuperUserBanner = () => {
 
   if (persistentToken && (superUser || canBecomeSuperUser)) {
     console.log(superUser.expiresAt)
-    const expirationDate = superUser && new Date(superUser.expiresAt).toUTCString();
+    const localBrowserOffset = new Date().getTimezoneOffset()
+    const expirationDate = superUser && new Date(superUser.expiresAt);
+    console.log(localBrowserOffset, expirationDate)
     const displayText = `SUPER USER MODE ${superUser ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
     const toggleSuperUser = async () => {
       await api.post(`https://support-toggle.glitch.me/support/${superUser ? 'disable' : 'enable'}`);

--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -17,10 +17,7 @@ const SuperUserBanner = () => {
   const superUser = currentUser.features && currentUser.features.find((feature) => feature.name === 'super_user');
 
   if (persistentToken && (superUser || canBecomeSuperUser)) {
-    console.log(superUser.expiresAt)
-    const localBrowserOffset = new Date().getTimezoneOffset()
-    const expirationDate = superUser && new Date(superUser.expiresAt);
-    console.log(localBrowserOffset, expirationDate)
+    const expirationDate = superUser && new Date(superUser.expiresAt).toLocaleString();
     const displayText = `SUPER USER MODE ${superUser ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
     const toggleSuperUser = async () => {
       await api.post(`https://support-toggle.glitch.me/support/${superUser ? 'disable' : 'enable'}`);

--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -17,6 +17,7 @@ const SuperUserBanner = () => {
   const superUser = currentUser.features && currentUser.features.find((feature) => feature.name === 'super_user');
 
   if (persistentToken && (superUser || canBecomeSuperUser)) {
+    console.log(superUser.expiresAt)
     const expirationDate = superUser && new Date(superUser.expiresAt).toUTCString();
     const displayText = `SUPER USER MODE ${superUser ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
     const toggleSuperUser = async () => {


### PR DESCRIPTION
## Links
* https://workable-salad.glitch.me/
* https://glitch.fogbugz.com/f/cases/3328589/Support-user-toggle-should-display-expires_at-in-the-user-s-timezone

## GIF/Screenshots:
![Screen Shot 2019-05-21 at 3 35 33 PM](https://user-images.githubusercontent.com/6620164/58125348-604b1400-7bde-11e9-85ce-a7b0e629ce17.png)

## Changes:
* should show expiration of super user banner in local time

## How To Test:
* I downloaded a browser extension that let me mess around with my local time, I got different times that all sounded approximately right to me, I think that is probs the best way. Although you might glean more from [reading the docs on Date objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString), I gave it a good effort, but its highly possible I misunderstood something.

## Feedback I'm looking for:
apologies I think I made this way more confusing than it needed to be lol! time/timezones always get me, so feel free to let me know if I'm still confused, but I think this is right now.
