### PR TITLE
cassey-community: remove role=presentation from Image component

### DIFF
--- a/src/components/images/image.js
+++ b/src/components/images/image.js
@@ -21,7 +21,7 @@ const handleDefaultSrc = (defaultSrc) => (event) => {
   }
 };
 
-const Image = ({ alt, backgroundColor, backgroundImage, backgroundRatio, className, height, role, src, srcSet, sizes, width, defaultSrc }) =>
+const Image = ({ alt, backgroundColor, backgroundImage, backgroundRatio, className, height, src, srcSet, sizes, width, defaultSrc }) =>
   !backgroundImage ? (
     <img
       alt={alt}
@@ -55,7 +55,6 @@ Image.propTypes = {
   backgroundRatio: PropTypes.number,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Object)]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  role: PropTypes.string,
   src: PropTypes.string.isRequired,
   srcSet: PropTypes.array,
   sizes: PropTypes.string,

--- a/src/components/images/image.js
+++ b/src/components/images/image.js
@@ -27,7 +27,6 @@ const Image = ({ alt, backgroundColor, backgroundImage, backgroundRatio, classNa
       alt={alt}
       className={className || undefined}
       height={height || undefined}
-      role={role}
       sizes={sizes}
       src={src}
       srcSet={srcSet.length > 0 ? srcSet : undefined}
@@ -38,7 +37,6 @@ const Image = ({ alt, backgroundColor, backgroundImage, backgroundRatio, classNa
   ) : (
     <div
       className={className || undefined}
-      role={role}
       style={{
         backgroundColor,
         backgroundImage: `url(${src})`,
@@ -71,7 +69,6 @@ Image.defaultProps = {
   backgroundRatio: 65,
   className: '',
   height: '100%',
-  role: 'presentation',
   srcSet: [],
   sizes: '',
   width: '100%',

--- a/src/presenters/pages/error.js
+++ b/src/presenters/pages/error.js
@@ -20,7 +20,7 @@ export const NotFoundPage = () => (
   <Layout>
     <Helmet title="👻 Page not found" />
     <main className="error-page-container">
-      <Image className="error-image" src={telescopeImageUrl} role="presentation" width="318px" height="297px" />
+      <Image className="error-image" src={telescopeImageUrl} alt="" width="318px" height="297px" />
       <div className="error-msg">
         <Heading tagName="h1">Page Not Found</Heading>
         <Text>Maybe a typo, or perhaps it's moved?</Text>


### PR DESCRIPTION
## Links
* [Remix link](https://cassey-community.glitch.me/)
* [Manuscript link](https://glitch.manuscript.com/f/cases/3328607/All-images-using-Image-component-are-screenreader-invisible)

## GIF/Screenshots:
- no visual changes

## Changes:
* If an image has role = presentation, the alt will be ignored and the image won't be discoverable for screenreaders. See discussion [here](https://fogcreek.slack.com/archives/CB4EHAJ2J/p15584710221992000)

## How To Test:
* Can test this by navigating to an image in voiceover; a full accessibility audit is underway though so you can also just trust. :) There shouldn't be any visual changes corresponding to this PR. 
