### PR TITLE
Glossy wednesday: fix spellcheck issue on safari on email input

### DIFF
--- a/src/components/inputs/text-input.js
+++ b/src/components/inputs/text-input.js
@@ -60,7 +60,7 @@ const TextInput = ({
           placeholder={placeholder}
           type={type}
           value={value}
-          autoCapitalize="none"
+          spellCheck={type !== 'email' && type !== 'password'}
         />
         {!!error && (
           <InputPart className={styles.errorIcon}>

--- a/src/components/inputs/text-input.js
+++ b/src/components/inputs/text-input.js
@@ -60,6 +60,7 @@ const TextInput = ({
           placeholder={placeholder}
           type={type}
           value={value}
+          autoCapitalize="none"
         />
         {!!error && (
           <InputPart className={styles.errorIcon}>


### PR DESCRIPTION
## Links
* https://glossy-wednesday.glitch.me/
* https://glitch.manuscript.com/f/cases/3328488/

## GIF/Screenshots:
http://g.recordit.co/pQsCdng8tG.gif

## Changes:
* stop spellcheck on email and password inputs. this is annoying because you'd think giving an input a type of email or password would fix this issue, but at least on safari on email inputs it's a no go. I tried passing  autoCapitalization=false (and also "off" and also "none" lol) but it turns out those are already done for you with type=email (as you'd expect!) unfortunately if your email contains your name it runs the spellchecker, which then autocorrects if you have a `.` right after your name (ex: `firstname.lastname@email.com` Fun fact, I also tried just turning off the autocorrect, but that doesn't seem to help.

## How To Test:
* try typing in the input field to sign in with email and ensure it doesn't auto capitalize anything.

