### PR TITLE
Relieved fox: remove blue support banner and move it into user-options-pop

### DIFF
--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -9,7 +9,7 @@ const SuperUserBanner = () => {
   if (!superUserFeature) {
     return null;
   }
-  
+
   const expirationDate = superUserFeature && new Date(superUserFeature.expiresAt).toLocaleString();
   const displayText = `SUPER USER MODE ENABLED UNTIL: ${expirationDate} `;
   return (

--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -3,15 +3,13 @@ import classNames from 'classnames/bind';
 
 import { useCurrentUser } from 'State/current-user';
 
-import useLocalStorage from 'State/local-storage';
-
 import styles from './super-user.styl';
 
 const cx = classNames.bind(styles);
 
 const SuperUserBanner = () => {
   const { superUserHelpers } = useCurrentUser();
-  const { superUserFeature, canBecomeSuperUser, toggleSuperUser } = superUserHelpers;
+  const { superUserFeature, toggleSuperUser } = superUserHelpers;
 
   if (superUserFeature) {
     const expirationDate = superUserFeature && new Date(superUserFeature.expiresAt).toLocaleString();

--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -1,32 +1,23 @@
 import React from 'react';
-import classNames from 'classnames/bind';
-
 import { useCurrentUser } from 'State/current-user';
-
 import styles from './super-user.styl';
-
-const cx = classNames.bind(styles);
 
 const SuperUserBanner = () => {
   const { superUserHelpers } = useCurrentUser();
   const { superUserFeature, toggleSuperUser } = superUserHelpers;
 
-  if (superUserFeature) {
-    const expirationDate = superUserFeature && new Date(superUserFeature.expiresAt).toLocaleString();
-    const displayText = `SUPER USER MODE ${superUserFeature ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
-
-    if (superUserFeature) {
-      const className = cx({ container: true, isDisabled: !superUserFeature });
-      return (
-        <div className={className}>
-          {displayText}
-          <button onClick={toggleSuperUser}>Click to {superUserFeature ? 'disable' : 'enable'}</button>
-        </div>
-      );
-    }
+  if (!superUserFeature) {
+    return null;
   }
-
-  return null;
+  
+  const expirationDate = superUserFeature && new Date(superUserFeature.expiresAt).toLocaleString();
+  const displayText = `SUPER USER MODE ENABLED UNTIL: ${expirationDate} `;
+  return (
+    <div className={styles.container}>
+      {displayText}
+      <button onClick={toggleSuperUser}>Click to disable</button>
+    </div>
+  );
 };
 
 export default SuperUserBanner;

--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -12,19 +12,17 @@ const cx = classNames.bind(styles);
 const SuperUserBanner = () => {
   const { superUserHelpers } = useCurrentUser();
   const { superUserFeature, canBecomeSuperUser, toggleSuperUser } = superUserHelpers;
-  const [showSupportBanner, setShowSupportBanner] = useLocalStorage('showSupportBanner', false);
 
-  if (superUserFeature || canBecomeSuperUser) {
+  if (superUserFeature) {
     const expirationDate = superUserFeature && new Date(superUserFeature.expiresAt).toLocaleString();
     const displayText = `SUPER USER MODE ${superUserFeature ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
 
-    if (superUserFeature || showSupportBanner) {
+    if (superUserFeature) {
       const className = cx({ container: true, isDisabled: !superUserFeature });
       return (
         <div className={className}>
           {displayText}
           <button onClick={toggleSuperUser}>Click to {superUserFeature ? 'disable' : 'enable'}</button>
-          {!superUserFeature && <button onClick={() => setShowSupportBanner(false)}>Hide</button>}
         </div>
       );
     }

--- a/src/components/banners/super-user.js
+++ b/src/components/banners/super-user.js
@@ -1,36 +1,30 @@
 import React from 'react';
 import classNames from 'classnames/bind';
 
-import { useCurrentUser } from '../../state/current-user';
-import useLocalStorage from '../../state/local-storage';
-import { useAPI } from '../../state/api';
+import { useCurrentUser } from 'State/current-user';
+
+import useLocalStorage from 'State/local-storage';
 
 import styles from './super-user.styl';
 
 const cx = classNames.bind(styles);
 
 const SuperUserBanner = () => {
-  const { currentUser, persistentToken } = useCurrentUser();
-  const api = useAPI();
+  const { superUserHelpers } = useCurrentUser();
+  const { superUserFeature, canBecomeSuperUser, toggleSuperUser } = superUserHelpers;
   const [showSupportBanner, setShowSupportBanner] = useLocalStorage('showSupportBanner', false);
-  const canBecomeSuperUser = currentUser && currentUser.projects && currentUser.projects.filter((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff').length > 0;
-  const superUser = currentUser.features && currentUser.features.find((feature) => feature.name === 'super_user');
 
-  if (persistentToken && (superUser || canBecomeSuperUser)) {
-    const expirationDate = superUser && new Date(superUser.expiresAt).toLocaleString();
-    const displayText = `SUPER USER MODE ${superUser ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
-    const toggleSuperUser = async () => {
-      await api.post(`https://support-toggle.glitch.me/support/${superUser ? 'disable' : 'enable'}`);
-      window.location.reload();
-    };
+  if (superUserFeature || canBecomeSuperUser) {
+    const expirationDate = superUserFeature && new Date(superUserFeature.expiresAt).toLocaleString();
+    const displayText = `SUPER USER MODE ${superUserFeature ? `ENABLED UNTIL: ${expirationDate}` : 'DISABLED'} `;
 
-    if (superUser || showSupportBanner) {
-      const className = cx({ container: true, isDisabled: !superUser });
+    if (superUserFeature || showSupportBanner) {
+      const className = cx({ container: true, isDisabled: !superUserFeature });
       return (
         <div className={className}>
           {displayText}
-          <button onClick={toggleSuperUser}>Click to {superUser ? 'disable' : 'enable'}</button>
-          {!superUser && <button onClick={() => setShowSupportBanner(false)}>Hide</button>}
+          <button onClick={toggleSuperUser}>Click to {superUserFeature ? 'disable' : 'enable'}</button>
+          {!superUserFeature && <button onClick={() => setShowSupportBanner(false)}>Hide</button>}
         </div>
       );
     }

--- a/src/components/banners/super-user.styl
+++ b/src/components/banners/super-user.styl
@@ -3,6 +3,3 @@
   padding: 10px 100px 10px 10px
   font-weight: bold
   text-align: center
-    
-.isDisabled
-  background-image: linear-gradient(to right, lightblue, white)

--- a/src/components/buttons/checkbox-button.js
+++ b/src/components/buttons/checkbox-button.js
@@ -7,7 +7,7 @@ import useUniqueId from '../../hooks/use-unique-id';
 import styles from './button.styl';
 import checkboxStyles from './checkbox-button.styl';
 
-const CheckboxButton = ({ children, onChange, value }) => {
+const CheckboxButton = ({ children, onChange, value, matchBackground }) => {
   const id = useUniqueId();
   const className = classNames(styles.btn, styles.small, checkboxStyles.label);
   return (
@@ -28,6 +28,7 @@ CheckboxButton.propTypes = {
   children: PropTypes.node.isRequired,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.bool.isRequired,
+  matchBackground: PropTypes.bool,
 };
 
 export default CheckboxButton;

--- a/src/components/buttons/checkbox-button.js
+++ b/src/components/buttons/checkbox-button.js
@@ -7,11 +7,9 @@ import useUniqueId from '../../hooks/use-unique-id';
 import styles from './button.styl';
 import checkboxStyles from './checkbox-button.styl';
 
-const cx = classNames.bind(styles);
-
-const CheckboxButton = ({ children, onChange, value, matchBackground }) => {
+const CheckboxButton = ({ children, onChange, value, matchBackground, type }) => {
   const id = useUniqueId();
-  const className = cx({ btn: true, small: true, label: true, matchBackground });
+  const className = classNames({ [styles.matchBackground]: matchBackground, [styles.tertiary]: type === 'tertiary' }, styles.btn, styles.small, checkboxStyles.label);
   return (
     <label className={className} htmlFor={id}>
       <input
@@ -31,10 +29,12 @@ CheckboxButton.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.bool.isRequired,
   matchBackground: PropTypes.bool,
+  type: PropTypes.string,
 };
 
 CheckboxButton.defaultProps = {
   matchBackground: false,
+  type: null,
 };
 
 export default CheckboxButton;

--- a/src/components/buttons/checkbox-button.js
+++ b/src/components/buttons/checkbox-button.js
@@ -7,9 +7,11 @@ import useUniqueId from '../../hooks/use-unique-id';
 import styles from './button.styl';
 import checkboxStyles from './checkbox-button.styl';
 
+const cx = classNames.bind(styles);
+
 const CheckboxButton = ({ children, onChange, value, matchBackground }) => {
   const id = useUniqueId();
-  const className = classNames(styles.btn, styles.small, checkboxStyles.label);
+  const className = cx({ btn: true, small: true, label: true, matchBackground });
   return (
     <label className={className} htmlFor={id}>
       <input
@@ -29,6 +31,10 @@ CheckboxButton.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.bool.isRequired,
   matchBackground: PropTypes.bool,
+};
+
+CheckboxButton.defaultProps = {
+  matchBackground: false,
 };
 
 export default CheckboxButton;

--- a/src/components/buttons/checkbox-button.styl
+++ b/src/components/buttons/checkbox-button.styl
@@ -7,3 +7,6 @@
   margin-right: 4px
   vertical-align: top
   width: unset //counter some of our default input styling
+  
+.matchBackground
+  background-color: inherit

--- a/src/components/buttons/checkbox-button.styl
+++ b/src/components/buttons/checkbox-button.styl
@@ -1,12 +1,12 @@
 .label
   margin: 0 !important //button small has a bottom margin with higher priority
   user-select: none
-
+  // &.matchBackground
+  //   background-color: inherit
+  
 .input
   margin: 0
   margin-right: 4px
   vertical-align: top
   width: unset //counter some of our default input styling
   
-.matchBackground
-  background-color: inherit

--- a/src/components/buttons/checkbox-button.styl
+++ b/src/components/buttons/checkbox-button.styl
@@ -1,9 +1,10 @@
 .label
   margin: 0 !important //button small has a bottom margin with higher priority
   user-select: none
-  
+
 .input
   margin: 0
   margin-right: 4px
   vertical-align: top
   width: unset //counter some of our default input styling
+

--- a/src/components/buttons/checkbox-button.styl
+++ b/src/components/buttons/checkbox-button.styl
@@ -1,12 +1,9 @@
 .label
   margin: 0 !important //button small has a bottom margin with higher priority
   user-select: none
-  // &.matchBackground
-  //   background-color: inherit
   
 .input
   margin: 0
   margin-right: 4px
   vertical-align: top
   width: unset //counter some of our default input styling
-  

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -21,7 +21,7 @@ const ResumeCoding = () => (
 );
 
 const Header = ({ searchQuery, showNewStuffOverlay }) => {
-  const { currentUser, clear } = useCurrentUser();
+  const { currentUser, clear, superUserHelpers } = useCurrentUser();
   return (
     <header role="banner" className={styles.header}>
       <Link to="/" className={styles.logoWrap}>
@@ -48,7 +48,7 @@ const Header = ({ searchQuery, showNewStuffOverlay }) => {
           )}
           {!!currentUser && currentUser.login && (
             <li className={styles.buttonWrap}>
-              <UserOptionsPop user={currentUser} signOut={clear} showNewStuffOverlay={showNewStuffOverlay} />
+              <UserOptionsPop user={currentUser} signOut={clear} showNewStuffOverlay={showNewStuffOverlay} superUserHelpers={superUserHelpers} />
             </li>
           )}
         </ul>

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -5,7 +5,7 @@
 export const featuredCollections = [
   { owner: 'glitch', name: 'glitch-this-week-may-22-2019' },
   { owner: 'glitch', name: 'digital-deliciousness' },
-  { owner: 'glitch', name: 'so-useful' },
+  { owner: 'glitch', name: 'so-useful' }
 ];
 
 // More ideas is populated from this team

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -3,9 +3,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'glitch-this-week-may-15-2019' },
-  { owner: 'glitch', name: 'enlightening-games' },
-  { owner: 'glitch', name: 'glitch-flix' },
+  { owner: 'glitch', name: 'glitch-this-week-may-22-2019' },
+  { owner: 'glitch', name: 'digital-deliciousness' },
+  { owner: 'glitch', name: 'so-useful' },
 ];
 
 // More ideas is populated from this team

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -205,6 +205,7 @@ const UserOrTeamSegmentedButtons = ({ activeType, setType }) => {
 
 export const AddProjectToCollectionBase = (props) => {
   const { project, togglePopover, focusFirstElement } = props;
+
   const api = useAPI();
   const { currentUser } = useCurrentUser();
 

--- a/src/presenters/pop-overs/add-project-to-collection-pop.js
+++ b/src/presenters/pop-overs/add-project-to-collection-pop.js
@@ -205,7 +205,6 @@ const UserOrTeamSegmentedButtons = ({ activeType, setType }) => {
 
 export const AddProjectToCollectionBase = (props) => {
   const { project, togglePopover, focusFirstElement } = props;
-
   const api = useAPI();
   const { currentUser } = useCurrentUser();
 

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -129,7 +129,7 @@ Are you sure you want to sign out?`)
       </UserLink>
       <TeamList teams={user.teams} showCreateTeam={showCreateTeam} userIsAnon={!user.login} />
       <section className="pop-over-info">
-        {canBecomeSuperUser && (
+        {(canBecomeSuperUser || !!superUserFeature) && (
           <div className="user-options-pop-checkbox">
             <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser} type="tertiary" matchBackground>
               Super User

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -125,6 +125,11 @@ Are you sure you want to sign out?`)
               </p>
             )}
           </div>
+          {canBecomeSuperUser && (
+            <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser}>
+              Super User
+            </CheckboxButton>
+          )}
         </section>
       </UserLink>
       <TeamList teams={user.teams} showCreateTeam={showCreateTeam} userIsAnon={!user.login} />
@@ -135,9 +140,6 @@ Are you sure you want to sign out?`)
         <Link to="https://support.glitch.com" className="button button-small has-emoji button-tertiary button-on-secondary-background">
           Support <span className="emoji ambulance" />
         </Link>
-        {canBecomeSuperUser && (
-          <CheckboxButton value={!!superUserFeature}
-        )}
         <button type="button" onClick={clickSignout} className="button-small has-emoji button-tertiary button-on-secondary-background">
           Sign Out <span className="emoji balloon" />
         </button>

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -6,6 +6,7 @@ import { getAvatarUrl as getTeamAvatarUrl } from 'Models/team';
 import { getAvatarThumbnailUrl as getUserAvatarUrl } from 'Models/user';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
 import Link, { TeamLink, UserLink } from 'Components/link';
+import CheckboxButton from 'Components/buttons/checkbox-button';
 import { useTrackedFunc, useTracker } from 'State/segment-analytics';
 
 import PopoverContainer from './popover-container';
@@ -79,7 +80,9 @@ TeamList.propTypes = {
 
 // User Options 🧕
 
-const UserOptionsPop = ({ togglePopover, showCreateTeam, user, signOut, showNewStuffOverlay, focusFirstElement }) => {
+const UserOptionsPop = ({ togglePopover, showCreateTeam, user, signOut, showNewStuffOverlay, focusFirstElement, superUserHelpers }) => {
+  const { superUserFeature, canBecomeSuperUser, toggleSuperUser } = superUserHelpers;
+
   const trackLogout = useTracker('Logout');
 
   const clickNewStuff = (event) => {
@@ -132,7 +135,9 @@ Are you sure you want to sign out?`)
         <Link to="https://support.glitch.com" className="button button-small has-emoji button-tertiary button-on-secondary-background">
           Support <span className="emoji ambulance" />
         </Link>
-        
+        {canBecomeSuperUser && (
+          <CheckboxButton value={!!superUserFeature}
+        )}
         <button type="button" onClick={clickSignout} className="button-small has-emoji button-tertiary button-on-secondary-background">
           Sign Out <span className="emoji balloon" />
         </button>

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -130,7 +130,7 @@ Are you sure you want to sign out?`)
       <TeamList teams={user.teams} showCreateTeam={showCreateTeam} userIsAnon={!user.login} />
       <section className="pop-over-info">
         {canBecomeSuperUser && (
-          <div className="">
+          <div className="user-options-pop-checkbox">
             <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser}>
               Super User
             </CheckboxButton>

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -131,7 +131,7 @@ Are you sure you want to sign out?`)
       <section className="pop-over-info">
         {canBecomeSuperUser && (
           <div className="user-options-pop-checkbox">
-            <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser}>
+            <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser} type="tertiary" matchBackground>
               Super User
             </CheckboxButton>
           </div>

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -125,15 +125,17 @@ Are you sure you want to sign out?`)
               </p>
             )}
           </div>
-          {canBecomeSuperUser && (
-            <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser}>
-              Super User
-            </CheckboxButton>
-          )}
         </section>
       </UserLink>
       <TeamList teams={user.teams} showCreateTeam={showCreateTeam} userIsAnon={!user.login} />
       <section className="pop-over-info">
+        {canBecomeSuperUser && (
+          <div className="">
+            <CheckboxButton value={!!superUserFeature} onChange={toggleSuperUser}>
+              Super User
+            </CheckboxButton>
+          </div>
+        )}
         <button type="button" onClick={clickNewStuff} className="button-small has-emoji button-tertiary button-on-secondary-background">
           New Stuff <span className="emoji dog-face" />
         </button>

--- a/src/presenters/pop-overs/user-options-pop.js
+++ b/src/presenters/pop-overs/user-options-pop.js
@@ -132,6 +132,7 @@ Are you sure you want to sign out?`)
         <Link to="https://support.glitch.com" className="button button-small has-emoji button-tertiary button-on-secondary-background">
           Support <span className="emoji ambulance" />
         </Link>
+        
         <button type="button" onClick={clickSignout} className="button-small has-emoji button-tertiary button-on-secondary-background">
           Sign Out <span className="emoji balloon" />
         </button>

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -255,7 +255,7 @@ class CurrentUserManager extends React.Component {
     return {
       toggleSuperUser: async () => {
         await this.api().post(`https://support-toggle.glitch.me/support/${superUserFeature ? 'disable' : 'enable'}`);
-        window.scrollTo(0,0);
+        window.scrollTo(0, 0);
         window.location.reload();
       },
       canBecomeSuperUser: cachedUser && cachedUser.projects && cachedUser.projects.filter((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff').length > 0,

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -255,6 +255,7 @@ class CurrentUserManager extends React.Component {
     return {
       toggleSuperUser: async () => {
         await this.api().post(`https://support-toggle.glitch.me/support/${superUserFeature ? 'disable' : 'enable'}`);
+        window.scrollTo(0,0);
         window.location.reload();
       },
       canBecomeSuperUser: cachedUser && cachedUser.projects && cachedUser.projects.filter((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff').length > 0,

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -248,6 +248,20 @@ class CurrentUserManager extends React.Component {
     this.props.setCachedUser(undefined);
   }
 
+  superUserHelpers() {
+    const { cachedUser } = this.props;
+    const superUserFeature = cachedUser && cachedUser.features && cachedUser.features.find((feature) => feature.name === 'super_user');
+
+    return {
+      toggleSuperUser: async () => {
+        await this.api().post(`https://support-toggle.glitch.me/support/${superUserFeature ? 'disable' : 'enable'}`);
+        window.location.reload();
+      },
+      canBecomeSuperUser: cachedUser && cachedUser.projects && cachedUser.projects.filter((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff').length > 0,
+      superUserFeature,
+    };
+  }
+
   render() {
     const { children, sharedUser, cachedUser } = this.props;
     return children({
@@ -258,6 +272,7 @@ class CurrentUserManager extends React.Component {
       login: (user) => this.login(user),
       update: (changes) => this.update(changes),
       clear: () => this.logout(),
+      superUserHelpers: this.superUserHelpers(),
     });
   }
 }

--- a/styles/pop-overs.styl
+++ b/styles/pop-overs.styl
@@ -208,6 +208,9 @@ popover-secondary-background()
     padding-top: 12px
     img
       border-radius: 50%
+
+.user-options-pop-checkbox
+  margin-bottom: 10px
   
 .create-team-pop
   right: 0


### PR DESCRIPTION
## Links
* https://relieved-fox.glitch.me/
* https://glitch.manuscript.com/f/cases/3328257/

## GIF/Screenshots:
![Screen Shot 2019-05-22 at 11 01 29 AM](https://user-images.githubusercontent.com/6620164/58186671-5af3d500-7c83-11e9-9f97-6a4c29c178b7.png)
![Screen Shot 2019-05-22 at 11 01 46 AM](https://user-images.githubusercontent.com/6620164/58186672-5b8c6b80-7c83-11e9-968b-14370ecc7cf2.png)

## Changes:
* move super user helpers to current user so they are available anywhere we need them for the future
* remove "blue super user banner" which used to only show if your local storage was set a certain way. It was meant to allow super users to toggle their super powers more easily without altering the ui (with the option to hide for live streams). The issue with this approach was that it was tricky to remember how to set up when moving between remixes/devices.
* create a super user checkbox in user-options-pop. This is a permanent button for anyone with the power to turn super user features on/off. It will not show to users who don't have the ability to turn super user powers on/off. 

## How To Test:
* try turning your super user powers on/off via the user dropdown shown in the screenshots. If you don't have the ability to use super user features, ensure you do not see this dropdown

## Feedback I'm looking for:
- I'm using cached user here as that was the one that seemed to work in my testing (which makes sense given how we auth on remixes), but I'm a little fuzzy on the diffs between default user, shared user, and cached user, if I'm doing something wonky here definitely let me know!
- any reason I'm not thinking about on why this is a bad idea? any improvements we should make?
