### PR TITLE
Profuse tea: Fix text fields trimming the value while you're typing

### DIFF
--- a/src/components/fields/optimistic-markdown-input.js
+++ b/src/components/fields/optimistic-markdown-input.js
@@ -5,7 +5,7 @@ import MarkdownInput from '../inputs/markdown-input';
 import useOptimisticText from './use-optimistic-text';
 
 const OptimisticMarkdownInput = ({ value, onChange, ...props }) => {
-  const [optimisticValue, optimisticError, optimisticOnChange] = useOptimisticText(value, onChange);
+  const [optimisticValue, optimisticOnChange, optimisticError] = useOptimisticText(value, onChange);
   return <MarkdownInput {...props} value={optimisticValue} error={optimisticError} onChange={optimisticOnChange} />;
 };
 

--- a/src/components/fields/optimistic-text-input.js
+++ b/src/components/fields/optimistic-text-input.js
@@ -5,7 +5,7 @@ import TextInput from '../inputs/text-input';
 import useOptimisticText from './use-optimistic-text';
 
 const OptimisticTextInput = ({ value, onChange, ...props }) => {
-  const [optimisticValue, optimisticError, optimisticOnChange] = useOptimisticText(value, onChange);
+  const [optimisticValue, optimisticOnChange, optimisticError] = useOptimisticText(value, onChange);
   return <TextInput {...props} value={optimisticValue} error={optimisticError} onChange={optimisticOnChange} />;
 };
 

--- a/src/components/fields/optimistic-wrapping-text-input.js
+++ b/src/components/fields/optimistic-wrapping-text-input.js
@@ -5,7 +5,7 @@ import WrappingTextInput from '../inputs/wrapping-text-input';
 import useOptimisticText from './use-optimistic-text';
 
 const OptimisticWrappingTextInput = ({ value, onChange, ...props }) => {
-  const [optimisticValue, optimisticError, optimisticOnChange] = useOptimisticText(value, onChange);
+  const [optimisticValue, optimisticOnChange, optimisticError] = useOptimisticText(value, onChange);
   return <WrappingTextInput {...props} value={optimisticValue} error={optimisticError} onChange={optimisticOnChange} />;
 };
 

--- a/src/components/fields/use-optimistic-text.js
+++ b/src/components/fields/use-optimistic-text.js
@@ -1,7 +1,16 @@
+import { useState } from 'react';
 import useOptimisticValue from './use-optimistic-value';
 
 const useOptimisticText = (realValue, setRealValueAsync) => {
-  return useOptimisticValue(realValue, (newValue) => setRealValueAsync(newValue.trim()))
+  const [inputValue, setInputValue] = useState({ trimmed: realValue, input: realValue });
+  const [optimisticValue, errorMessage, setOptimisticValue] = useOptimisticValue(realValue, setRealValueAsync);
+
+  const inputValue = optimisticValue === trimmed ? input : optimisticValue;
+  const setInputValue = (value) => {
+    setValue({ trimmed: value.trim(), input: value });
+    setOptimisticValue(value.trim());
+  };
+  return [inputValue, errorMessage, setInputValue];
 };
 
 export default useOptimisticText;

--- a/src/components/fields/use-optimistic-text.js
+++ b/src/components/fields/use-optimistic-text.js
@@ -3,14 +3,14 @@ import useOptimisticValue from './use-optimistic-value';
 
 const useOptimisticText = (realValue, setRealValueAsync) => {
   const [optimisticValue, setOptimisticValue, errorMessage] = useOptimisticValue(realValue, setRealValueAsync);
-  const [inputValue, setInputValue] = useState(realValue);
+  const [untrimmedValue, setUntrimmedValue] = useState(realValue);
 
-  const trimmedValue = optimisticValue === inputValue.trim() ? inputValue : optimisticValue;
-  const setTrimmedValue = (value) => {
-    setInputValue(value);
+  const inputValue = optimisticValue === untrimmedValue.trim() ? untrimmedValue : optimisticValue;
+  const setInputValue = (value) => {
+    setUntrimmedValue(value);
     setOptimisticValue(value.trim());
   };
-  return [trimmedValue, setTrimmedValue, errorMessage];
+  return [inputValue, setInputValue, errorMessage];
 };
 
 export default useOptimisticText;

--- a/src/components/fields/use-optimistic-text.js
+++ b/src/components/fields/use-optimistic-text.js
@@ -2,15 +2,15 @@ import { useState } from 'react';
 import useOptimisticValue from './use-optimistic-value';
 
 const useOptimisticText = (realValue, setRealValueAsync) => {
-  const [inputValue, setInputValue] = useState({ trimmed: realValue, input: realValue });
-  const [optimisticValue, errorMessage, setOptimisticValue] = useOptimisticValue(realValue, setRealValueAsync);
+  const [optimisticValue, setOptimisticValue, errorMessage] = useOptimisticValue(realValue, setRealValueAsync);
+  const [inputValue, setInputValue] = useState(realValue);
 
-  const inputValue = optimisticValue === trimmed ? input : optimisticValue;
-  const setInputValue = (value) => {
-    setValue({ trimmed: value.trim(), input: value });
+  const trimmedValue = optimisticValue === inputValue.trim() ? inputValue : optimisticValue;
+  const setTrimmedValue = (value) => {
+    setInputValue(value);
     setOptimisticValue(value.trim());
   };
-  return [inputValue, errorMessage, setInputValue];
+  return [trimmedValue, setTrimmedValue, errorMessage];
 };
 
 export default useOptimisticText;

--- a/src/components/fields/use-optimistic-text.js
+++ b/src/components/fields/use-optimistic-text.js
@@ -1,7 +1,7 @@
 import useOptimisticValue from './use-optimistic-value';
 
-const useOptimisticText = (realValue, setRealValueAsync) => (
-  useOptimisticValue(realValue, (newValue) => setRealValueAsync(newValue.trim()))
-);
+const useOptimisticText = (realValue, setRealValueAsync) => {
+  return useOptimisticValue(realValue, (newValue) => setRealValueAsync(newValue.trim()))
+};
 
 export default useOptimisticText;

--- a/src/components/fields/use-optimistic-value.js
+++ b/src/components/fields/use-optimistic-value.js
@@ -29,7 +29,7 @@ const useOptimisticValue = (realValue, setValueAsync) => {
     setState((prevState) => ({ ...prevState, value: newValue }));
   };
 
-  return [optimisticValue, state.error, setOptimisticValue];
+  return [optimisticValue, setOptimisticValue, state.error];
 };
 
 export default useOptimisticValue;


### PR DESCRIPTION
## Links
https://profuse-tea.glitch.me/
https://glitch.fogbugz.com/f/cases/3328616/Don-t-trim-whitespace-from-the-field-in-useOptimisticText

## Changes:
- useOptimisticText tracks the input value and sends a trimmed copy to the api. If the value sent to the api hasn't changed, then it returns the untrimmed input value.
- I swapped the return order of useOptimisticValue and useOptimisticText, from [value,error,set] to [value,set,error] to be more like useState

## How To Test:
Try using the three different types of fields: text inputs, wrapping text inputs (collection name), and markdown areas. They should all still set the values correctly, not cut off whitespace while you are typing, and (excluding markdown) show an error message when empty.