### PR TITLE
Quixotic-rocket: Filter passwords from sentry logs

### DIFF
--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -3,10 +3,9 @@ const onProductionSite = (projectDomain, apiEnvironment) => productionDomains.in
 
 const filterSecrets = function(jsonEvent) {
   const secrets = ['\\w+Token', 'email', 'password'];
-  secrets.forEach((secret) => {
-    const regexp = new RegExp(`("${secret}":\\s*)"[^"]+"`, 'g');
-    jsonEvent = jsonEvent.replace(regexp, '$1"****"');
-  });
+  const reSecrets = `(?:${secrets.join('|')})`;
+  const regexp = new RegExp(`("${reSecrets}":\\s*)"[^"]+"`, 'g');
+  jsonEvent = jsonEvent.replace(regexp, '$1"****"');
   return jsonEvent;
 };
 

--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -3,9 +3,10 @@ const onProductionSite = (projectDomain, apiEnvironment) => productionDomains.in
 
 const filterSecrets = function(jsonEvent) {
   const secrets = ['\\w+Token', 'email', 'password'];
-  const reSecrets = `(?:${secrets.join('|')})`;
-  const regexp = new RegExp(`("${reSecrets}":\\s*)"[^"]+"`, 'g');
-  jsonEvent = jsonEvent.replace(regexp, '$1"****"');
+  secrets.forEach((secret) => {
+    const regexp = new RegExp(`("${secret}":\\s*)"[^"]+"`, 'g');
+    jsonEvent = jsonEvent.replace(regexp, '$1"****"');
+  });
   return jsonEvent;
 };
 

--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -2,10 +2,10 @@ const productionDomains = ['community', 'community-staging'];
 const onProductionSite = (projectDomain, apiEnvironment) => productionDomains.includes(projectDomain) && apiEnvironment === 'production';
 
 const filterSecrets = function(jsonEvent) {
-  const secrets = ['\\w+Token', 'email'];
+  const secrets = ['\\w+Token', 'email', 'password'];
   secrets.forEach((secret) => {
-    const regexp = new RegExp(`"${secret}":\\s*"[^"]+"`, 'g');
-    jsonEvent = jsonEvent.replace(regexp, `"${secret}":"****"`);
+    const regexp = new RegExp(`("${secret}":\\s*)"[^"]+"`, 'g');
+    jsonEvent = jsonEvent.replace(regexp, '$1"****"');
   });
   return jsonEvent;
 };


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/

## Changes:
- Filter `password` out of user objects before sending them to sentry
- Fix a bug where xToken fields got renamed to `\w+Token`
- Preserve whitespace in the json

## How To Test:
Copy the filterSecrets function into a js console and run it against some different objects (such as `localStorage['community-cachedUser']`)