### PR TITLE
Superb guide: Reorder projects in collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react-pluralize": "^1.5.0",
     "react-router-dom": "^4.3.1",
     "react-select": "^2.4.0",
+    "react-sortable-hoc": "^1.9.1",
     "react-textarea-autosize": "^7.1.0",
     "speed-measure-webpack-plugin": "^1.3.1",
     "stats-webpack-plugin": "^0.7.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -70,6 +70,7 @@ dependencies:
   react-pluralize: 1.5.0
   react-router-dom: 4.3.1
   react-select: 2.4.2
+  react-sortable-hoc: 1.9.1
   react-textarea-autosize: 7.1.0
   speed-measure-webpack-plugin: 1.3.1
   stats-webpack-plugin: 0.7.0
@@ -2072,6 +2073,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
+  /@babel/runtime/7.4.5:
+    dependencies:
+      regenerator-runtime: 0.13.2
+    dev: false
+    resolution:
+      integrity: sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
   /@babel/template/7.4.0:
     dependencies:
       '@babel/code-frame': 7.0.0
@@ -10548,6 +10555,17 @@ packages:
       react: ^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==
+  /react-sortable-hoc/1.9.1:
+    dependencies:
+      '@babel/runtime': 7.4.5
+      invariant: 2.2.4
+      prop-types: 15.7.2
+    dev: false
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0
+      react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
+    resolution:
+      integrity: sha512-2VeofjRav8+eZeE5Nm/+b8mrA94rQ+gBsqhXi8pRBSjOWNqslU3ZEm+0XhSlfoXJY2lkgHipfYAUuJbDtCixRg==
   /react-syntax-highlighter/8.1.0/react@16.8.6:
     dependencies:
       babel-runtime: 6.26.0
@@ -12833,6 +12851,7 @@ specifiers:
   react-pluralize: ^1.5.0
   react-router-dom: ^4.3.1
   react-select: ^2.4.0
+  react-sortable-hoc: ^1.9.1
   react-textarea-autosize: ^7.1.0
   speed-measure-webpack-plugin: ^1.3.1
   stats-webpack-plugin: ^0.7.0

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -18,33 +18,11 @@ const GridContainer = ({ children, gap, minWidth, className, style }) => (
   </ul>
 );
 
-GridContainer.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  style: PropTypes.object,
-  gap: PropTypes.oneOfType([
-    PropTypes.shape({ row: PropTypes.node.isRequired, column: PropTypes.node.isRequired }).isRequired,
-    PropTypes.node.isRequired,
-  ]),
-  minWidth: PropTypes.node,
-};
-
-GridContainer.defaultProps = {
-  className: '',
-  style: {},
-  gap: undefined,
-  minWidth: undefined,
-};
-
 const GridItem = ({ children, ...props }) => (
   <li className={styles.item} {...props}>
     {children}
   </li>
 );
-
-GridItem.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 const SortableGridContainer = SortableContainer(GridContainer);
 const SortableGridItem = SortableElement(GridItem);

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -52,7 +52,7 @@ const SortableGridItem = SortableElement(GridItem);
 const Grid = ({ items, children, sortable, ...props }) => {
   if (sortable) {
     return (
-      <SortableGridContainer {...props} axis="xy">
+      <SortableGridContainer {...props} axis="xy" distance={15}>
         {items.map((item, index) => (
           <SortableGridItem key={item.id} index={index} tabIndex={0}>
             {children(item)}

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -36,8 +36,8 @@ GridContainer.defaultProps = {
   minWidth: undefined,
 };
 
-const GridItem = ({ children }) => (
-  <li className={styles.item} tabIndex={0}>
+const GridItem = ({ children, ...props }) => (
+  <li className={styles.item} {...props}>
     {children}
   </li>
 );
@@ -54,7 +54,7 @@ const Grid = ({ items, children, sortable, ...props }) => {
     return (
       <SortableGridContainer {...props} axis="xy">
         {items.map((item, index) => (
-          <SortableGridItem key={item.id} index={index}>
+          <SortableGridItem key={item.id} index={index} tabIndex={0}>
             {children(item)}
           </SortableGridItem>
         ))}

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -49,10 +49,11 @@ GridItem.propTypes = {
 const SortableGridContainer = SortableContainer(GridContainer);
 const SortableGridItem = SortableElement(GridItem);
 
-const Grid = ({ items, children, sortable, ...props }) => {
+const Grid = ({ items, children, sortable, onReorder, ...props }) => {
   if (sortable) {
+    const onSortEnd = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
     return (
-      <SortableGridContainer {...props} axis="xy" distance={15}>
+      <SortableGridContainer {...props} axis="xy" distance={15} onSortEnd={onSortEnd}>
         {items.map((item, index) => (
           <SortableGridItem key={item.id} index={index} tabIndex={0}>
             {children(item)}
@@ -72,6 +73,7 @@ Grid.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.node.isRequired })).isRequired,
   children: PropTypes.func.isRequired,
   sortable: PropTypes.bool,
+  onReorder: PropTypes.func,
   className: PropTypes.string,
   style: PropTypes.object,
   gap: PropTypes.oneOfType([
@@ -83,6 +85,7 @@ Grid.propTypes = {
 
 Grid.defaultProps = {
   sortable: false,
+  onReorder: null,
   className: '',
   style: {},
   gap: undefined,

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -51,11 +51,12 @@ const SortableGridItem = SortableElement(GridItem);
 
 const Grid = ({ items, children, sortable, onReorder, ...props }) => {
   if (sortable) {
+    const onDragStart = (event) => event.preventDefault();
     const onSortEnd = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
     return (
       <SortableGridContainer {...props} axis="xy" distance={15} onSortEnd={onSortEnd}>
         {items.map((item, index) => (
-          <SortableGridItem key={item.id} index={index} tabIndex={0} onDragStart={(event) => event.preventDefault()}>
+          <SortableGridItem key={item.id} index={index} tabIndex={0} onDragStart={onDragStart}>
             {children(item)}
           </SortableGridItem>
         ))}

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -18,8 +18,8 @@ const GridContainer = ({ children, gap, minWidth, className, style }) => (
   </ul>
 );
 
-const GridItem = ({ children, ...props }) => (
-  <li className={styles.item} {...props}>
+const GridItem = ({ children, className, ...props }) => (
+  <li className={classnames(styles.item, className)} {...props}>
     {children}
   </li>
 );
@@ -27,14 +27,14 @@ const GridItem = ({ children, ...props }) => (
 const SortableGridContainer = SortableContainer(GridContainer);
 const SortableGridItem = SortableElement(GridItem);
 
-const Grid = ({ items, children, sortable, onReorder, ...props }) => {
+const Grid = ({ items, itemClassName, children, sortable, onReorder, ...props }) => {
   if (sortable) {
     const onDragStart = (event) => event.preventDefault();
     const onSortEnd = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
     return (
       <SortableGridContainer {...props} axis="xy" distance={15} onSortEnd={onSortEnd}>
         {items.map((item, index) => (
-          <SortableGridItem key={item.id} index={index} tabIndex={0} onDragStart={onDragStart}>
+          <SortableGridItem key={item.id} className={itemClassName} index={index} tabIndex={0} onDragStart={onDragStart}>
             {children(item)}
           </SortableGridItem>
         ))}
@@ -43,7 +43,7 @@ const Grid = ({ items, children, sortable, onReorder, ...props }) => {
   }
   return (
     <GridContainer {...props}>
-      {items.map((item) => <GridItem key={item.id}>{children(item)}</GridItem>)}
+      {items.map((item) => <GridItem key={item.id} className={itemClassName}>{children(item)}</GridItem>)}
     </GridContainer>
   );
 };
@@ -54,6 +54,7 @@ Grid.propTypes = {
   sortable: (props) => props.sortable && !props.onReorder && new Error('If a container is sortable, it needs onReorder defined'),
   onReorder: PropTypes.func,
   className: PropTypes.string,
+  itemClassName: PropTypes.string,
   style: PropTypes.object,
   gap: PropTypes.oneOfType([
     PropTypes.shape({ row: PropTypes.node.isRequired, column: PropTypes.node.isRequired }).isRequired,
@@ -66,6 +67,7 @@ Grid.defaultProps = {
   sortable: false,
   onReorder: null,
   className: '',
+  itemClassName: '',
   style: {},
   gap: undefined,
   minWidth: undefined,

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -4,6 +4,37 @@ import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import classnames from 'classnames';
 import styles from './grid.styl';
 
+const GridContainer = ({ children, gap, minWidth, className, style }) => (
+  <ul
+    className={classnames(styles.grid, className)}
+    style={{
+      ...style,
+      '--row-gap': (gap && gap.row) || gap,
+      '--column-gap': (gap && gap.column) || gap,
+      '--min-width': minWidth,
+    }}
+  >
+    {children}
+  </ul>
+);
+
+GridContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  gap: PropTypes.oneOfType([
+    PropTypes.shape({ row: PropTypes.node.isRequired, column: PropTypes.node.isRequired }).isRequired,
+    PropTypes.node.isRequired,
+  ]),
+  minWidth: PropTypes.node,
+};
+
+GridContainer.defaultProps = {
+  className: '',
+  style: {},
+  gap: undefined,
+  minWidth: undefined,
+};
 
 const GridItem = ({ children }) => (
   <li className={styles.item} tabIndex={0}>
@@ -15,29 +46,32 @@ GridItem.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
+const SortableGridContainer = SortableContainer(GridContainer);
 const SortableGridItem = SortableElement(GridItem);
 
-const Grid = ({ items, children, gap, minWidth, className, style }) => (
-  <ul
-    className={classnames(styles.grid, className)}
-    style={{
-      ...style,
-      '--row-gap': (gap && gap.row) || gap,
-      '--column-gap': (gap && gap.column) || gap,
-      '--min-width': minWidth,
-    }}
-  >
-    {items.map((item, index) => (
-      <SortableGridItem key={item.id} index={index}>
-        {children(item)}
-      </SortableGridItem>
-    ))}
-  </ul>
-);
+const Grid = ({ items, children, sortable, ...props }) => {
+  if (sortable) {
+    return (
+      <SortableGridContainer {...props} axis="xy">
+        {items.map((item, index) => (
+          <SortableGridItem key={item.id} index={index}>
+            {children(item)}
+          </SortableGridItem>
+        ))}
+      </SortableGridContainer>
+    );
+  }
+  return (
+    <GridContainer {...props}>
+      {items.map((item) => <GridItem key={item.id}>{children(item)}</GridItem>)}
+    </GridContainer>
+  );
+};
 
 Grid.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.node.isRequired })).isRequired,
   children: PropTypes.func.isRequired,
+  sortable: PropTypes.bool,
   className: PropTypes.string,
   style: PropTypes.object,
   gap: PropTypes.oneOfType([
@@ -48,12 +82,11 @@ Grid.propTypes = {
 };
 
 Grid.defaultProps = {
+  sortable: false,
   className: '',
   style: {},
   gap: undefined,
   minWidth: undefined,
 };
 
-const SortableGrid = SortableContainer(Grid);
-
-export default (props) => <SortableGrid axis="xy" {...props} />;
+export default Grid;

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -1,7 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import classnames from 'classnames';
 import styles from './grid.styl';
+
+
+const GridItem = ({ children }) => (
+  <li className={styles.item} tabIndex={0}>
+    {children}
+  </li>
+);
+
+GridItem.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const SortableGridItem = SortableElement(GridItem);
 
 const Grid = ({ items, children, gap, minWidth, className, style }) => (
   <ul
@@ -13,10 +27,10 @@ const Grid = ({ items, children, gap, minWidth, className, style }) => (
       '--min-width': minWidth,
     }}
   >
-    {items.map((item) => (
-      <li key={item.id} className={styles.item}>
+    {items.map((item, index) => (
+      <SortableGridItem key={item.id} index={index}>
         {children(item)}
-      </li>
+      </SortableGridItem>
     ))}
   </ul>
 );
@@ -40,4 +54,6 @@ Grid.defaultProps = {
   minWidth: undefined,
 };
 
-export default Grid;
+const SortableGrid = SortableContainer(Grid);
+
+export default (props) => <SortableGrid axis="xy" {...props} />;

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -51,7 +51,7 @@ const Grid = ({ items, children, sortable, onReorder, ...props }) => {
 Grid.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.node.isRequired })).isRequired,
   children: PropTypes.func.isRequired,
-  sortable: PropTypes.bool,
+  sortable: (props) => props.sortable && !props.onReorder && new Error('If a container is sortable, it needs onReorder defined'),
   onReorder: PropTypes.func,
   className: PropTypes.string,
   style: PropTypes.object,

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -55,7 +55,7 @@ const Grid = ({ items, children, sortable, onReorder, ...props }) => {
     return (
       <SortableGridContainer {...props} axis="xy" distance={15} onSortEnd={onSortEnd}>
         {items.map((item, index) => (
-          <SortableGridItem key={item.id} index={index} tabIndex={0} draggable="false">
+          <SortableGridItem key={item.id} index={index} tabIndex={0} onDragStart={(event) => event.preventDefault()}>
             {children(item)}
           </SortableGridItem>
         ))}

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -55,7 +55,7 @@ const Grid = ({ items, children, sortable, onReorder, ...props }) => {
     return (
       <SortableGridContainer {...props} axis="xy" distance={15} onSortEnd={onSortEnd}>
         {items.map((item, index) => (
-          <SortableGridItem key={item.id} index={index} tabIndex={0}>
+          <SortableGridItem key={item.id} index={index} tabIndex={0} draggable="false">
             {children(item)}
           </SortableGridItem>
         ))}

--- a/src/components/containers/grid.styl
+++ b/src/components/containers/grid.styl
@@ -6,3 +6,6 @@
   list-style-type: none
   margin: 0
   padding: 0
+
+.item
+  display: block

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -46,10 +46,6 @@ const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, la
   );
 };
 
-ProjectsUL.propTypes = {
-  sortable: (props) => props.sortable && props.layout === 'row' && new Error('Sortable rows are not supported'),
-};
-
 const arrowSrc = 'https://cdn.glitch.com/11efcb07-3386-43b6-bab0-b8dc7372cba8%2Fleft-arrow.svg?1553883919269';
 
 const PaginationController = ({ enabled, projects, projectsPerPage, children }) => {
@@ -193,7 +189,7 @@ ProjectsList.propTypes = {
   placeholder: PropTypes.node,
   enableFiltering: PropTypes.bool,
   enablePagination: PropTypes.bool,
-  enableSorting: PropTypes.bool,
+  enableSorting: (props) => props.enableSorting && props.layout === 'row' && new Error('Sortable rows are not supported'),
   fetchMembers: PropTypes.bool,
   projectsPerPage: PropTypes.number,
   collection: PropTypes.object,

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -22,10 +22,10 @@ const containers = {
   gridCompact: (props) => <Grid className={styles.projectsGridCompact} {...props} />,
 };
 
-const ProjectsUL = ({ collection, projects, sortable, noteOptions, layout, projectOptions, fetchMembers }) => {
+const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, layout, projectOptions, fetchMembers }) => {
   const Container = containers[layout];
   return (
-    <Container items={projects} sortable={sortable}>
+    <Container items={projects} sortable={sortable} onReorder={onReorder}>
       {(project) => (
         <>
           {collection && (
@@ -190,7 +190,6 @@ ProjectsList.propTypes = {
   enableFiltering: PropTypes.bool,
   enablePagination: PropTypes.bool,
   enableSorting: PropTypes.bool,
-  onReorder: PropTypes.func,
   fetchMembers: PropTypes.bool,
   projectsPerPage: PropTypes.number,
   collection: PropTypes.object,

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -27,7 +27,7 @@ const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, la
   return (
     <Container items={projects} sortable={sortable} onReorder={onReorder}>
       {(project) => (
-        <>
+        <div className={styles.projectsItem}>
           {collection && (
             <div className={styles.projectsContainerNote}>
               <Note
@@ -40,7 +40,7 @@ const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, la
             </div>
           )}
           <ProjectItem key={project.id} project={project} projectOptions={projectOptions} fetchMembers={fetchMembers} />
-        </>
+        </div>
       )}
     </Container>
   );

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -46,6 +46,10 @@ const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, la
   );
 };
 
+ProjectsUL.propTypes = {
+  sortable: (props) => props.sortable && props.layout === 'row' && new Error('Sortable rows are not supported'),
+};
+
 const arrowSrc = 'https://cdn.glitch.com/11efcb07-3386-43b6-bab0-b8dc7372cba8%2Fleft-arrow.svg?1553883919269';
 
 const PaginationController = ({ enabled, projects, projectsPerPage, children }) => {

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -22,10 +22,10 @@ const containers = {
   gridCompact: (props) => <Grid className={styles.projectsGridCompact} {...props} />,
 };
 
-const ProjectsUL = ({ collection, projects, noteOptions, layout, projectOptions, fetchMembers }) => {
+const ProjectsUL = ({ collection, projects, sortable, noteOptions, layout, projectOptions, fetchMembers }) => {
   const Container = containers[layout];
   return (
-    <Container items={projects}>
+    <Container items={projects} sortable={sortable}>
       {(project) => (
         <>
           {collection && (
@@ -147,6 +147,7 @@ function ProjectsList({
   fetchMembers,
   projectsPerPage,
   collection,
+  enableSorting,
   noteOptions,
   projectOptions,
 }) {
@@ -166,6 +167,7 @@ function ProjectsList({
                   collection={collection}
                   noteOptions={noteOptions}
                   layout={layout}
+                  sortable={enableSorting && paginatedProjects.length === projects.length}
                   projectOptions={projectOptions}
                   fetchMembers={fetchMembers}
                 />
@@ -185,6 +187,7 @@ ProjectsList.propTypes = {
   placeholder: PropTypes.node,
   enableFiltering: PropTypes.bool,
   enablePagination: PropTypes.bool,
+  enableSorting: PropTypes.bool,
   fetchMembers: PropTypes.bool,
   projectsPerPage: PropTypes.number,
   collection: PropTypes.object,
@@ -197,6 +200,7 @@ ProjectsList.defaultProps = {
   placeholder: null,
   enableFiltering: false,
   enablePagination: false,
+  enableSorting: false,
   fetchMembers: false,
   projectsPerPage: 6,
   collection: null,

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -144,10 +144,11 @@ function ProjectsList({
   placeholder,
   enableFiltering,
   enablePagination,
+  enableSorting,
+  onReorder,
   fetchMembers,
   projectsPerPage,
   collection,
-  enableSorting,
   noteOptions,
   projectOptions,
 }) {
@@ -168,6 +169,7 @@ function ProjectsList({
                   noteOptions={noteOptions}
                   layout={layout}
                   sortable={enableSorting && paginatedProjects.length === projects.length}
+                  onReorder={onReorder}
                   projectOptions={projectOptions}
                   fetchMembers={fetchMembers}
                 />
@@ -188,6 +190,7 @@ ProjectsList.propTypes = {
   enableFiltering: PropTypes.bool,
   enablePagination: PropTypes.bool,
   enableSorting: PropTypes.bool,
+  onReorder: PropTypes.func,
   fetchMembers: PropTypes.bool,
   projectsPerPage: PropTypes.number,
   collection: PropTypes.object,

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -25,9 +25,9 @@ const containers = {
 const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, layout, projectOptions, fetchMembers }) => {
   const Container = containers[layout];
   return (
-    <Container items={projects} sortable={sortable} onReorder={onReorder}>
+    <Container itemClassName={styles.projectsItem} items={projects} sortable={sortable} onReorder={onReorder}>
       {(project) => (
-        <div className={styles.projectsItem}>
+        <>
           {collection && (
             <div className={styles.projectsContainerNote}>
               <Note
@@ -40,7 +40,7 @@ const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, la
             </div>
           )}
           <ProjectItem key={project.id} project={project} projectOptions={projectOptions} fetchMembers={fetchMembers} />
-        </div>
+        </>
       )}
     </Container>
   );

--- a/src/components/containers/projects-list.styl
+++ b/src/components/containers/projects-list.styl
@@ -18,6 +18,7 @@
   display: flex
   flex-direction: column
   justify-content: end
+  height: 100%
   
 .header
   display: flex

--- a/src/components/containers/projects-list.styl
+++ b/src/components/containers/projects-list.styl
@@ -13,6 +13,11 @@
 .projectsRow
   --min-width: 180px
   align-items: flex-end
+
+.projectsItem
+  display: flex
+  flex-direction: column
+  justify-content: end
   
 .header
   display: flex

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -53,9 +53,9 @@ class CollectionEditor extends React.Component {
   }
 
   async updateProjectOrder(project, filteredIndex) {
-    // the filtered index ignores the featured project, bump it up one if moving after it
+    // the shown projects list doesn't include the featured project, bump the index to include it
     const featuredIndex = this.state.projects.findIndex((p) => p.id === this.state.featuredProjectId);
-    const index = (featuredIndex >= 0 && filteredIndex >= featuredIndex) ? filteredIndex + 1 : filteredIndex;
+    const index = (featuredIndex >= 0 && filteredIndex > featuredIndex) ? filteredIndex + 1 : filteredIndex;
     this.setState(({ projects }) => {
       const sortedProjects = projects.filter((p) => p !== project);
       sortedProjects.splice(index, 0, project);

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -51,11 +51,11 @@ class CollectionEditor extends React.Component {
 
   async updateProjectOrder(project, index) {
     this.setState(({ projects }) => {
-      const projectsWithoutItem = projects.filter((p) => p !== project);
-      projectsWithoutItem.splice(index, 0, project);
+      const sortedProjects = projects.filter((p) => p !== project);
+      sortedProjects.splice(index, 0, project);
       return { projects: sortedProjects };
     });
-    console.log(project.id, index);
+    await this.props.api.post(`collections/${this.state.id}/projects/${project.id}/index/${index}`);
   }
 
   async deleteCollection() {

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -49,6 +49,15 @@ class CollectionEditor extends React.Component {
     }));
   }
 
+  async updateProjectOrder(project, index) {
+    this.setState(({ projects }) => {
+      const projectsWithoutItem = projects.filter((p) => p !== project);
+      projectsWithoutItem.splice(index, 0, project);
+      return { projects: sortedProjects };
+    });
+    console.log(project.id, index);
+  }
+
   async deleteCollection() {
     await this.props.api.delete(`/collections/${this.state.id}`);
   }
@@ -98,6 +107,7 @@ class CollectionEditor extends React.Component {
       hideNote: (projectId) => this.hideNote(projectId),
       updateDescription: (description) => this.updateFields({ description }).catch(handleError),
       updateColor: (color) => this.updateFields({ coverColor: color }),
+      updateProjectOrder: (project, index) => this.updateProjectOrder(project, index).catch(handleError),
       featureProject: (id) => this.featureProject(id).catch(handleError),
       unfeatureProject: () => this.updateFields({ featuredProjectId: null }).catch(handleError),
     };

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -55,7 +55,7 @@ class CollectionEditor extends React.Component {
   async updateProjectOrder(project, filteredIndex) {
     // the filtered index ignores the featured project, bump it up one if moving after it
     const featuredIndex = this.state.projects.findIndex((p) => p.id === this.state.featuredProjectId);
-    const index = index >= featuredIndex ? index + 1 : index;
+    const index = (featuredIndex >= 0 && filteredIndex >= featuredIndex) ? filteredIndex + 1 : filteredIndex;
     this.setState(({ projects }) => {
       const sortedProjects = projects.filter((p) => p !== project);
       sortedProjects.splice(index, 0, project);

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -52,7 +52,10 @@ class CollectionEditor extends React.Component {
     }));
   }
 
-  async updateProjectOrder(project, index) {
+  async updateProjectOrder(project, filteredIndex) {
+    // the filtered index ignores the featured project, bump it up one if moving after it
+    const featuredIndex = this.state.projects.findIndex((p) => p.id === this.state.featuredProjectId);
+    const index = index >= featuredIndex ? index + 1 : index;
     this.setState(({ projects }) => {
       const sortedProjects = projects.filter((p) => p !== project);
       sortedProjects.splice(index, 0, project);

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -55,7 +55,12 @@ class CollectionEditor extends React.Component {
       sortedProjects.splice(index, 0, project);
       return { projects: sortedProjects };
     });
-    await this.props.api.post(`collections/${this.state.id}/projects/${project.id}/index/${index}`);
+    try {
+      await this.props.api.post(`collections/${this.state.id}/project/${project.id}/index/${index}`);
+    } catch (error) {
+      
+      throw error;
+    }
   }
 
   async deleteCollection() {

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -40,6 +40,9 @@ class CollectionEditor extends React.Component {
       }));
     }
     await this.props.api.patch(`collections/${collection.id}/add/${project.id}`);
+    if (collection.id === this.state.id) {
+      await this.props.api.post(`collections/${collection.id}/project/${project.id}/index/0`);
+    }
   }
 
   async removeProjectFromCollection(project) {
@@ -55,12 +58,7 @@ class CollectionEditor extends React.Component {
       sortedProjects.splice(index, 0, project);
       return { projects: sortedProjects };
     });
-    try {
-      await this.props.api.post(`collections/${this.state.id}/project/${project.id}/index/${index}`);
-    } catch (error) {
-      
-      throw error;
-    }
+    await this.props.api.post(`collections/${this.state.id}/project/${project.id}/index/${index}`);
   }
 
   async deleteCollection() {

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -70,6 +70,7 @@ const CollectionPageContents = ({
   addProjectToCollection,
   removeProjectFromCollection,
   updateColor,
+  updateProjectOrder,
   displayNewNote,
   updateNote,
   hideNote,
@@ -160,6 +161,7 @@ const CollectionPageContents = ({
                   projects={projects}
                   collection={collection}
                   enableSorting
+                  onReorder={updateProjectOrder}
                   noteOptions={{
                     hideNote,
                     updateNote,

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -160,7 +160,7 @@ const CollectionPageContents = ({
                   {...props}
                   projects={projects}
                   collection={collection}
-                  enableSorting
+                  enableSorting={currentUserIsAuthor}
                   onReorder={updateProjectOrder}
                   noteOptions={{
                     hideNote,

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -159,6 +159,7 @@ const CollectionPageContents = ({
                   {...props}
                   projects={projects}
                   collection={collection}
+                  enableSorting
                   noteOptions={{
                     hideNote,
                     updateNote,

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -215,7 +215,7 @@ async function loadCollection(api, ownerName, collectionName) {
     const collection = await getSingleItem(api, `v1/collections/by/fullUrl?fullUrl=${encodeURIComponent(ownerName)}/${collectionName}`, `${ownerName}/${collectionName}`);
     collection.projects = await getAllPages(
       api,
-      `v1/collections/by/fullUrl/projects?fullUrl=${encodeURIComponent(ownerName)}/${collectionName}&orderKey=updatedAt&orderDirection=ASC&limit=100`,
+      `v1/collections/by/fullUrl/projects?fullUrl=${encodeURIComponent(ownerName)}/${collectionName}&orderKey=projectOrder&orderDirection=ASC&limit=100`,
     );
 
     if (collection.user) {


### PR DESCRIPTION
## Links
https://glitch.manuscript.com/f/cases/3328236/API-Reorder-projects-in-collections
https://superb-guide.glitch.me/

## Changes:
- You can drag around projects in collections you have permissions on
- Tab to focus a whole project item, then space, arrow keys to reorder using keyboard

## How To Test:
- Try reordering projects in a collection, both with and without a featured project
- Make sure other people's collection pages act as expected
- Make sure other grids of stuff still work in general 🤷‍♂ 

## Feedback I'm looking for:
- Projects with notes seem to animate to the wrong position. I can't figure out how to fix it
- I didn't make any changes to project order outside of the collection page. Should previews always show the first three projects, rather than the most recent?
- Draggable project items have their `tabIndex` set to `0`. What should their `role` be set to?