### PR TITLE
Frosted hammer: remove legacy search

### DIFF
--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -105,7 +105,7 @@ const { actions, reducer } = createSlice({
   }),
 });
 
-function AlgoliaSearchController({ visible, setVisible, children, defaultValue, useSearchProvider }) {
+function AlgoliaSearchController({ visible, setVisible, children, defaultValue }) {
   const initialState = {
     selectedResult: null,
     query: defaultValue,
@@ -113,7 +113,7 @@ function AlgoliaSearchController({ visible, setVisible, children, defaultValue, 
     results: [],
   };
   const [{ query, results, selectedResult, redirect }, dispatch] = useReducer(reducer, initialState);
-  const algoliaResults = useSearchProvider(query);
+  const algoliaResults = useAlgoliaSearch(query);
 
   useEffect(() => {
     // use last complete results
@@ -162,40 +162,20 @@ function AlgoliaSearchController({ visible, setVisible, children, defaultValue, 
   });
 }
 
-function LegacySearchController({ children, defaultValue }) {
-  const [query, onChange] = useState(defaultValue);
-  const onSubmit = (event) => {
-    event.preventDefault();
-    if (!query) return;
-    window.location = `/search?q=${query}`;
-  };
-
-  return children({
-    query,
-    onChange,
-    onSubmit,
-    autoComplete: 'on',
-    autoCompleteResults: null,
-  });
+function SearchController({ children, defaultValue }) {
+  return (
+    <PopoverContainer>
+      {(popoverProps) => (
+        <AlgoliaSearchController {...popoverProps} defaultValue={defaultValue}>
+          {children}
+        </AlgoliaSearchController>
+      )}
+    </PopoverContainer>
+  );
 }
 
-function SearchController({ children, defaultValue, showAutocomplete, useSearchProvider }) {
-  if (showAutocomplete) {
-    return (
-      <PopoverContainer>
-        {(popoverProps) => (
-          <AlgoliaSearchController {...popoverProps} defaultValue={defaultValue} useSearchProvider={useSearchProvider}>
-            {children}
-          </AlgoliaSearchController>
-        )}
-      </PopoverContainer>
-    );
-  }
-  return <LegacySearchController defaultValue={defaultValue}>{children}</LegacySearchController>;
-}
-
-export const BaseSearchForm = (props) => (
-  <SearchController {...props}>
+const SearchForm = ({ defaultValue }) => (
+  <SearchController defaultValue={defaultValue}>
     {({ query, onChange, onFocus, onSubmit, onKeyDown, autoComplete, autoCompleteResults }) => (
       <form
         className={styles.container}
@@ -222,11 +202,6 @@ export const BaseSearchForm = (props) => (
     )}
   </SearchController>
 );
-
-const SearchForm = ({ defaultValue }) => {
-  const algoliaFlag = useDevToggle('Algolia Search');
-  return <BaseSearchForm defaultValue={defaultValue} showAutocomplete={algoliaFlag} useSearchProvider={useAlgoliaSearch} />;
-};
 
 SearchForm.propTypes = {
   defaultValue: PropTypes.string,

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -1,11 +1,10 @@
-import React, { useState, useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { mapValues, flatMap } from 'lodash';
 import { getLink as getProjectLink } from 'Models/project';
 import { getLink as getUserLink } from 'Models/user';
 import { getLink as getTeamLink } from 'Models/team';
 import { useAlgoliaSearch } from 'State/search';
-import useDevToggle from 'State/dev-toggles';
 import TextInput from '../inputs/text-input';
 import PopoverContainer from '../../presenters/pop-overs/popover-container';
 import AutocompleteSearch from './autocomplete';

--- a/src/components/search-form/story.js
+++ b/src/components/search-form/story.js
@@ -1,34 +1,8 @@
 import React, { useState } from 'react';
-import { mapValues, sumBy, memoize } from 'lodash';
 import { storiesOf } from '@storybook/react';
-import { users, teams, projects, collections } from '../../../stories/data';
+import { users } from '../../../stories/data';
 import { provideContext } from '../../../stories/util';
-import { BaseSearchForm } from './index';
-
-const mockSearchDB = {
-  user: Object.values(users).map((user) => ({ ...user, __searchKeys: [user.name, user.login], type: 'user' })),
-  team: Object.values(teams).map((team) => ({ ...team, __searchKeys: [team.name, team.url], type: 'team' })),
-  project: Object.values(projects).map((project) => ({ ...project, __searchKeys: [project.domain, project.description], type: 'project' })),
-  collection: Object.values(collections).map((collection) => ({
-    ...collection,
-    __searchKeys: [collection.name, collection.description],
-    type: 'collection',
-  })),
-  starterKit: [],
-};
-
-const useMockSearchProvider = memoize((query) => {
-  const queryRE = new RegExp(query.replace(/[^A-Za-z]/g, ''), 'i');
-  const resultsByType = mapValues(mockSearchDB, (items) => items.filter((item) => item.__searchKeys.some((key) => queryRE.test(key))));
-  const topResultsByType = mapValues(mockSearchDB, (items) => items.filter((item) => item.__searchKeys.some((key) => query === key)));
-  const topResults = [].concat(...Object.values(topResultsByType).map((sublist) => sublist.slice(0, 1)));
-  return {
-    status: 'ready',
-    totalHits: sumBy(Object.values(resultsByType), (items) => items.length),
-    topResults,
-    ...resultsByType,
-  };
-});
+import SearchForm from './index';
 
 const mockAPI = {
   async get(url) {
@@ -43,7 +17,7 @@ storiesOf('SearchForm', module).add(
   'results',
   provideContext({ currentUser: {}, api: mockAPI }, () => (
     <div style={{ width: 300, position: 'relative' }}>
-      <BaseSearchForm defaultValue="" showAutocomplete useSearchProvider={useMockSearchProvider} />
+      <SearchForm defaultValue="" />
     </div>
   )),
 );

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -6,25 +6,12 @@ import { withRouter } from 'react-router-dom';
 import SearchResults from 'Components/search-results';
 import NotFound from 'Components/errors/not-found';
 import MoreIdeas from 'Components/more-ideas';
-import { useAlgoliaSearch, useLegacySearch } from 'State/search';
-import useDevToggle from 'State/dev-toggles';
+import { useAlgoliaSearch } from 'State/search';
 
 import Layout from '../layout';
 
-// Hooks can't be _used_ conditionally, but components can be _rendered_ conditionally
-const AlgoliaSearchWrapper = (props) => {
-  const searchResults = useAlgoliaSearch(props.query);
-  return <SearchResults {...props} searchResults={searchResults} />;
-};
-
-const LegacySearchWrapper = (props) => {
-  const searchResults = useLegacySearch(props.query);
-  return <SearchResults {...props} searchResults={searchResults} />;
-};
-
 const SearchPage = withRouter(({ query, activeFilter, history }) => {
-  const algoliaFlag = useDevToggle('Algolia Search');
-  const SearchWrapper = algoliaFlag ? AlgoliaSearchWrapper : LegacySearchWrapper;
+  const searchResults = useAlgoliaSearch(query);
   const setActiveFilter = (filter) => {
     history.push(`/search?q=${query}&activeFilter=${filter}`);
   };
@@ -32,7 +19,11 @@ const SearchPage = withRouter(({ query, activeFilter, history }) => {
   return (
     <Layout searchQuery={query}>
       {!!query && <Helmet title={`Search for ${query}`} />}
-      {query ? <SearchWrapper query={query} activeFilter={activeFilter || 'all'} setActiveFilter={setActiveFilter} /> : <NotFound name="anything" />}
+      {query ? (
+        <SearchResults query={query} searchResults={searchResults} activeFilter={activeFilter || 'all'} setActiveFilter={setActiveFilter} />
+      ) : (
+        <NotFound name="anything" />
+      )}
       <MoreIdeas />
     </Layout>
   );

--- a/src/state/dev-toggles.js
+++ b/src/state/dev-toggles.js
@@ -24,9 +24,8 @@ const toggleData = [
     description: 'Sign in with your Slack account!',
   },
   {
-    name: 'Algolia Search',
-    description: 'Use the new Algolia-powered search API.',
-    enabledByDefault: true,
+    name: '(Free Slot)',
+    description: '',
   },
 ].slice(0, 3); // <-- Yeah really, only 3.  If you need more, clean up one first.
 

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -174,20 +174,4 @@ export function useAlgoliaSearch(query, params = defaultParams, deps = []) {
   return useSearchProvider(algoliaProvider, query, params, deps);
 }
 
-// legacy search
-
-const formatLegacyResult = (type) => ({ data }) => data.map((value) => ({ type, ...value }));
-
-const getLegacyProvider = (api) => ({
-  team: (query) => api.get(`teams/search?q=${query}`).then(formatLegacyResult('team')),
-  user: (query) => api.get(`users/search?q=${query}`).then(formatLegacyResult('user')),
-  project: (query) => api.get(`projects/search?q=${query}`).then(formatLegacyResult('project')),
-  collection: () => Promise.resolve([]),
-  starterKit: (query) => Promise.resolve(findStarterKits(query)),
-});
-
-export function useLegacySearch(query) {
-  const api = useAPI();
-  const legacyProvider = getLegacyProvider(api);
-  return useSearchProvider(legacyProvider, query);
-}
+export default useAlgoliaSearch;


### PR DESCRIPTION
## Links
* Remix link: https://frosted-hammer.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3328648/

## Changes:
* remove algolia feature flag
* remove legacy search

## How To Test:
* visit https://frosted-hammer.glitch.me/
* search autocomplete should work
* the search page should include collections

## Things left to do before deploying:
- is there any reason we need to keep legacy search around? eg. as part of our case study with Algolia?
