### PR TITLE
Lumpy wedge: improve image upload error handling

### DIFF
--- a/src/components/animation-container/index.js
+++ b/src/components/animation-container/index.js
@@ -30,6 +30,7 @@ const AnimationContainer = ({ type, children, className, onAnimationEnd }) => {
     </div>
   );
 };
+
 AnimationContainer.propTypes = {
   type: PropTypes.oneOf(types).isRequired,
   children: PropTypes.func.isRequired,

--- a/src/presenters/includes/auth-description.js
+++ b/src/presenters/includes/auth-description.js
@@ -30,6 +30,8 @@ AuthDescription.propTypes = {
   update: PropTypes.func,
 };
 
+
+
 AuthDescription.defaultProps = {
   allowImages: true,
   placeholder: '',

--- a/src/presenters/includes/auth-description.js
+++ b/src/presenters/includes/auth-description.js
@@ -30,8 +30,6 @@ AuthDescription.propTypes = {
   update: PropTypes.func,
 };
 
-
-
 AuthDescription.defaultProps = {
   allowImages: true,
   placeholder: '',

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { uploadAsset, uploadAssetSizes } from '../../utils/assets';
 import { useNotifications } from '../notifications';
+import { captureException } from './utils/sentry';
 
 const NotifyUploading = ({ progress }) => (
   <>
@@ -31,11 +32,9 @@ async function uploadWrapper(notifications, upload) {
       notifications.createNotification('Image uploaded!');
     });
   } catch (e) {
+    captureException(e);
     notifications.createErrorNotification(<NotifyError />);
     removeNotification();
-    // throw e;
-    
-    
   }
   return result;
 }

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -11,7 +11,7 @@ const NotifyUploading = ({ progress }) => (
   </>
 );
 const NotifyError = ({ e }) => {
-  if (e && Object.hasOwnProperty.call(e, "status_code") && e.status_code === 0) {
+  if (e && Object.hasOwnProperty.call(e, 'status_code') && e.status_code === 0) {
     return 'File upload failed. Check your firewall settings and try again?';
   }
   return 'File upload failed. Try again in a few minutes?';
@@ -39,7 +39,7 @@ async function uploadWrapper(notifications, upload) {
     removeNotification();
     return result;
   }
-  
+
   removeNotification();
   notifications.createNotification('Image uploaded!');
   return result;

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { uploadAsset, uploadAssetSizes } from '../../utils/assets';
+import { captureException } from '../../utils/sentry';
 import { useNotifications } from '../notifications';
-import { captureException } from './utils/sentry';
 
 const NotifyUploading = ({ progress }) => (
   <>
@@ -20,7 +20,7 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
-    throw new Error("this is a fake error")
+    throw new Error("FAKE")
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;
@@ -28,13 +28,15 @@ async function uploadWrapper(notifications, upload) {
         progress = (progress + 1) / 2;
       }
       updateNotification(<NotifyUploading progress={progress} />);
-      removeNotification();
-      notifications.createNotification('Image uploaded!');
     });
   } catch (e) {
     captureException(e);
     notifications.createErrorNotification(<NotifyError />);
     removeNotification();
+    return result;
+  } finally {
+    removeNotification();
+    notifications.createNotification('Image uploaded!');
   }
   return result;
 }

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -12,9 +12,9 @@ const NotifyUploading = ({ progress }) => (
 );
 const NotifyError = ({ e }) => {
   if (e && Object.hasOwnProperty.call(e, "status_code") && e.status_code === 0) {
-    return 'File upload failed. Check your firewall settings and try again?'
+    return 'File upload failed. Check your firewall settings and try again?';
   }
-  return 'File upload failed. Try again in a few minutes?'
+  return 'File upload failed. Try again in a few minutes?';
 };
 
 async function uploadWrapper(notifications, upload) {

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -34,6 +34,8 @@ async function uploadWrapper(notifications, upload) {
     notifications.createErrorNotification(<NotifyError />);
     removeNotification();
     // throw e;
+    
+    
   }
   return result;
 }

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -10,7 +10,13 @@ const NotifyUploading = ({ progress }) => (
     <progress className="notify-progress" value={progress} />
   </>
 );
-const NotifyError = () => 'File upload failed. Try again in a few minutes?';
+const NotifyError = ({ e }) => {
+  console.log(e)
+  if (e && Object.hasOwnProperty.call(e, "status_code") && e.status_code === 0) {
+    return 'File upload failed. Check your firewall settings and try again?'
+  }
+  return 'File upload failed. Try again in a few minutes?'
+};
 
 async function uploadWrapper(notifications, upload) {
   let result = null;
@@ -20,7 +26,9 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
-    // throw new Error("FAKE")
+    let errir = new Error("FAKE")
+    errir.status_code = 0;
+    throw errir
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;
@@ -31,7 +39,7 @@ async function uploadWrapper(notifications, upload) {
     });
   } catch (e) {
     captureException(e);
-    notifications.createErrorNotification(<NotifyError />);
+    notifications.createErrorNotification(<NotifyError e={e} />);
     removeNotification();
     return result;
   }

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -25,6 +25,9 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
+    let fake = new Error("i'm bad")
+    fake.status_code = 0
+    throw fake
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -10,8 +10,8 @@ const NotifyUploading = ({ progress }) => (
     <progress className="notify-progress" value={progress} />
   </>
 );
-const NotifyError = ({ e }) => {
-  if (e && Object.hasOwnProperty.call(e, 'status_code') && e.status_code === 0) {
+const NotifyError = ({ error }) => {
+  if (error && Object.hasOwnProperty.call(error, 'status_code') && error.status_code === 0) {
     return 'File upload failed. Check your firewall settings and try again?';
   }
   return 'File upload failed. Try again in a few minutes?';
@@ -33,9 +33,9 @@ async function uploadWrapper(notifications, upload) {
       }
       updateNotification(<NotifyUploading progress={progress} />);
     });
-  } catch (e) {
-    captureException(e);
-    notifications.createErrorNotification(<NotifyError e={e} />);
+  } catch (error) {
+    captureException(error);
+    notifications.createErrorNotification(<NotifyError error={error} />);
     removeNotification();
     return result;
   }

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -11,7 +11,7 @@ const NotifyUploading = ({ progress }) => (
   </>
 );
 const NotifyError = ({ error }) => {
-  if (error && Object.hasOwnProperty.call(error, 'status_code') && error.status_code === 0) {
+  if (error && error.status_code === 0) {
     return 'File upload failed. Check your firewall settings and try again?';
   }
   return 'File upload failed. Try again in a few minutes?';

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -25,9 +25,6 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
-    let fake = new Error("i'm bad")
-    fake.status_code = 0
-    throw fake
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -19,6 +19,7 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
+    throw new Error("this is a fake error")
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;
@@ -26,13 +27,13 @@ async function uploadWrapper(notifications, upload) {
         progress = (progress + 1) / 2;
       }
       updateNotification(<NotifyUploading progress={progress} />);
+      removeNotification();
+      notifications.createNotification('Image uploaded!');
     });
   } catch (e) {
     notifications.createErrorNotification(<NotifyError />);
-    throw e;
-  } finally {
     removeNotification();
-    notifications.createNotification('Image uploaded!');
+    // throw e;
   }
   return result;
 }

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -11,7 +11,6 @@ const NotifyUploading = ({ progress }) => (
   </>
 );
 const NotifyError = ({ e }) => {
-  console.log(e)
   if (e && Object.hasOwnProperty.call(e, "status_code") && e.status_code === 0) {
     return 'File upload failed. Check your firewall settings and try again?'
   }
@@ -26,9 +25,6 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
-    let errir = new Error("FAKE")
-    errir.status_code = 0;
-    throw errir
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;

--- a/src/presenters/includes/uploader.js
+++ b/src/presenters/includes/uploader.js
@@ -20,7 +20,7 @@ async function uploadWrapper(notifications, upload) {
     'notifyUploading',
   );
   try {
-    throw new Error("FAKE")
+    // throw new Error("FAKE")
     result = await upload(({ lengthComputable, loaded, total }) => {
       if (lengthComputable) {
         progress = loaded / total;
@@ -34,10 +34,10 @@ async function uploadWrapper(notifications, upload) {
     notifications.createErrorNotification(<NotifyError />);
     removeNotification();
     return result;
-  } finally {
-    removeNotification();
-    notifications.createNotification('Image uploaded!');
   }
+  
+  removeNotification();
+  notifications.createNotification('Image uploaded!');
   return result;
 }
 


### PR DESCRIPTION
## Links
* https://lumpy-wedge.glitch.me/
* https://glitch.manuscript.com/f/cases/3328077/

## GIF/Screenshots:
![Screen Shot 2019-05-28 at 11 00 15 AM](https://user-images.githubusercontent.com/6620164/58488705-d0eeb500-8137-11e9-8e99-5cdb8dd6c0a1.png)

## Changes:
* added a new error message for when folks hit a firewall
* fixed bug where sometimes users would hit an error and yet still get a notification that their image uploaded, I think because even if you a throw an error in a catch it still proceeds to the finally case (interestingly though I can't figure out how to recreate this without hardcoding in an error so maybe this isn't actually happening in real life).
* capture file upload exceptions with sentry directly, rather than rely on a global catch.

## How To Test:
* I added this code in the `try {}` not sure if we have a great way of forcing this particular error we're trying to protect around:
```
    let fake = new Error("i'm bad")
    fake.status_code = 0
    throw fake
```
for general error testing you can go offline which seems to work.

## Feedback I'm looking for:
- Do you generally agree with my check for a status_code? I'm basing this assumption on the details described in the manuscript case
- Do you agree with my thoughts on moving this out of a `finally` am I missing stuff here?


