### PR TITLE
thundering-verse: only show email login validation error if input is blurred

### DIFF
--- a/src/components/inputs/text-input.js
+++ b/src/components/inputs/text-input.js
@@ -24,6 +24,7 @@ const TextInput = ({
   name,
   onChange,
   onBlur,
+  onFocus,
   opaque,
   placeholder,
   postfix,
@@ -57,6 +58,7 @@ const TextInput = ({
           name={name}
           onChange={(evt) => onChange(evt.target.value)}
           onBlur={onBlur}
+          onFocus={onFocus}
           placeholder={placeholder}
           type={type}
           value={value}
@@ -84,6 +86,7 @@ TextInput.propTypes = {
   name: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
   opaque: PropTypes.bool,
   placeholder: PropTypes.string,
   postfix: PropTypes.node,
@@ -100,6 +103,7 @@ TextInput.defaultProps = {
   maxLength: undefined,
   name: undefined,
   onBlur: undefined,
+  onFocus: undefined,
   opaque: false,
   placeholder: undefined,
   postfix: null,

--- a/src/components/inputs/text-input.js
+++ b/src/components/inputs/text-input.js
@@ -12,9 +12,7 @@ import { visuallyHidden } from '../global.styl';
 
 const TYPES = ['email', 'password', 'search', 'text'];
 
-const InputPart = ({ children, className }) => (
-  <span className={classNames(styles.inputPart, className)}>{children}</span>
-);
+const InputPart = ({ children, className }) => <span className={classNames(styles.inputPart, className)}>{children}</span>;
 
 const TextInput = ({
   autoFocus,
@@ -25,6 +23,7 @@ const TextInput = ({
   maxLength,
   name,
   onChange,
+  onBlur,
   opaque,
   placeholder,
   postfix,
@@ -57,6 +56,7 @@ const TextInput = ({
           maxLength={maxLength}
           name={name}
           onChange={(evt) => onChange(evt.target.value)}
+          onBlur={onBlur}
           placeholder={placeholder}
           type={type}
           value={value}
@@ -83,6 +83,7 @@ TextInput.propTypes = {
   maxLength: PropTypes.number,
   name: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
   opaque: PropTypes.bool,
   placeholder: PropTypes.string,
   postfix: PropTypes.node,
@@ -98,6 +99,7 @@ TextInput.defaultProps = {
   error: null,
   maxLength: undefined,
   name: undefined,
+  onBlur: undefined,
   opaque: false,
   placeholder: undefined,
   postfix: null,

--- a/src/components/sign-in-pop/index.js
+++ b/src/components/sign-in-pop/index.js
@@ -128,8 +128,9 @@ const EmailHandler = ({ showView }) => {
               value={email}
               onChange={setEmail}
               onBlur={() => setIsFocused(false)}
+              onFocus={() => setIsFocused(true)}
               placeholder="new@user.com"
-              error={isEnabled && hasBlurred && validationError}
+              error={isEnabled && !isFocused && validationError}
               autoFocus
             />
             <div className={styles.submitWrap}>

--- a/src/components/sign-in-pop/index.js
+++ b/src/components/sign-in-pop/index.js
@@ -64,14 +64,14 @@ const SignInCodeSection = ({ onClick }) => (
   </PopoverActions>
 );
 
-function useEmail() {
+function useEmail(hasBlurred) {
   const [email, setEmailValue] = useState('');
-  const [hasBlurred, setHasBlurred] = useState(false);
   const [validationError, setValidationError] = useState(null);
   const validate = useMemo(
     () =>
       debounce((value) => {
         const isValidEmail = parseOneAddress(value) !== null;
+        console.log('hasBlurred in useEmail', hasBlurred);
         setValidationError(isValidEmail || !hasBlurred ? null : 'Enter a valid email address');
       }),
     [],
@@ -86,7 +86,8 @@ function useEmail() {
 
 const EmailHandler = ({ showView }) => {
   const api = useAPI();
-  const [email, setEmail, validationError] = useEmail();
+  const [hasBlurred, setHasBlurred] = useState(false);
+  const [email, setEmail, validationError] = useEmail(hasBlurred);
   const [{ status, submitError }, setStatus] = useState({ status: 'ready' });
   const isEnabled = email.length > 0;
 
@@ -122,7 +123,16 @@ const EmailHandler = ({ showView }) => {
       <PopoverActions>
         {status === 'ready' && (
           <form onSubmit={onSubmit} style={{ marginBottom: 0 }}>
-            <TextInput type="email" labelText="Email address" value={email} onChange={setEmail} placeholder="new@user.com" error={validationError} autoFocus />
+            <TextInput
+              type="email"
+              labelText="Email address"
+              value={email}
+              onChange={setEmail}
+              onBlur={() => console.log('blur')}
+              placeholder="new@user.com"
+              error={validationError}
+              autoFocus
+            />
             <div className={styles.submitWrap}>
               <Button size="small" disabled={!isEnabled} onClick={onSubmit}>
                 Send Link

--- a/src/components/sign-in-pop/index.js
+++ b/src/components/sign-in-pop/index.js
@@ -64,15 +64,14 @@ const SignInCodeSection = ({ onClick }) => (
   </PopoverActions>
 );
 
-function useEmail(hasBlurred) {
+function useEmail() {
   const [email, setEmailValue] = useState('');
   const [validationError, setValidationError] = useState(null);
   const validate = useMemo(
     () =>
       debounce((value) => {
         const isValidEmail = parseOneAddress(value) !== null;
-        console.log('hasBlurred in useEmail', hasBlurred);
-        setValidationError(isValidEmail || !hasBlurred ? null : 'Enter a valid email address');
+        setValidationError(isValidEmail ? null : 'Enter a valid email address');
       }),
     [],
   );
@@ -86,8 +85,8 @@ function useEmail(hasBlurred) {
 
 const EmailHandler = ({ showView }) => {
   const api = useAPI();
-  const [hasBlurred, setHasBlurred] = useState(false);
-  const [email, setEmail, validationError] = useEmail(hasBlurred);
+  const [email, setEmail, validationError] = useEmail();
+  const [isFocused, setIsFocused] = useState(true);
   const [{ status, submitError }, setStatus] = useState({ status: 'ready' });
   const isEnabled = email.length > 0;
 
@@ -128,9 +127,9 @@ const EmailHandler = ({ showView }) => {
               labelText="Email address"
               value={email}
               onChange={setEmail}
-              onBlur={() => console.log('blur')}
+              onBlur={() => setIsFocused(false)}
               placeholder="new@user.com"
-              error={validationError}
+              error={isEnabled && hasBlurred && validationError}
               autoFocus
             />
             <div className={styles.submitWrap}>

--- a/src/components/sign-in-pop/index.js
+++ b/src/components/sign-in-pop/index.js
@@ -66,12 +66,13 @@ const SignInCodeSection = ({ onClick }) => (
 
 function useEmail() {
   const [email, setEmailValue] = useState('');
+  const [hasBlurred, setHasBlurred] = useState(false);
   const [validationError, setValidationError] = useState(null);
   const validate = useMemo(
     () =>
       debounce((value) => {
         const isValidEmail = parseOneAddress(value) !== null;
-        setValidationError(isValidEmail ? null : 'Enter a valid email address');
+        setValidationError(isValidEmail || !hasBlurred ? null : 'Enter a valid email address');
       }),
     [],
   );

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -3,9 +3,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'glitch-this-week-may-22-2019' },
-  { owner: 'glitch', name: 'digital-deliciousness' },
-  { owner: 'glitch', name: 'so-useful' }
+  { owner: 'glitch', name: 'glitch-this-week-may-29-2019' },
+  { owner: 'glitch', name: 'draw-with-music' },
+  { owner: 'glitch', name: 'colorful-creations' }
 ];
 
 // More ideas is populated from this team


### PR DESCRIPTION
## Links
* [thundering-verse.glitch.me/](https://thundering-verse.glitch.me/)

## GIF/Screenshots:
![email-validation](https://user-images.githubusercontent.com/7584833/58599447-56648900-824e-11e9-9c5d-c15f7a6cc4d8.gif)

## Changes:
The email login input used to show the validation error after the first `onChange`, which was a bit jarring. This updates that input to only show the validation error if the input is _not focused_ and the input is _not empty_.

## How To Test:
Type in the email login input, you should only see the validation error if the input is blurred and the email is invalid.

## Feedback I'm looking for:
Is this the right place to implement this? Or should this ultimately live in the `<TextInput>` component?