### PR TITLE
Superb guide: collection reorder prompt + minor css cleanup + empty collection fixes

### DIFF
--- a/src/components/collections-list/more-collections.js
+++ b/src/components/collections-list/more-collections.js
@@ -31,7 +31,7 @@ const loadMoreCollectionsFromAuthor = async ({ api, collection }) => {
   // get project details for each collection
   let moreCollectionsWithProjects = await Promise.all(
     moreCollectionsFromAuthor.map(async (c) => {
-      c.projects = await getSingleItem(api, `/v1/collections/by/id/projects?id=${c.id}orderKey=projectOrder&orderDirection=ASC`, 'items');
+      c.projects = await getSingleItem(api, `/v1/collections/by/id/projects?id=${c.id}`, 'items');
       return c;
     }),
   );

--- a/src/components/collections-list/more-collections.js
+++ b/src/components/collections-list/more-collections.js
@@ -31,7 +31,7 @@ const loadMoreCollectionsFromAuthor = async ({ api, collection }) => {
   // get project details for each collection
   let moreCollectionsWithProjects = await Promise.all(
     moreCollectionsFromAuthor.map(async (c) => {
-      c.projects = await getSingleItem(api, `/v1/collections/by/id/projects?id=${c.id}`, 'items');
+      c.projects = await getSingleItem(api, `/v1/collections/by/id/projects?id=${c.id}orderKey=projectOrder&orderDirection=ASC`, 'items');
       return c;
     }),
   );

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -28,13 +28,18 @@ const SortableGridContainer = SortableContainer(GridContainer);
 const SortableGridItem = SortableElement(GridItem);
 
 const Grid = ({ items, itemClassName, children, sortable, onReorder, ...props }) => {
+  const [sortingItems, setSortingItems] = React.useState(null);
   if (sortable) {
     const onDragStart = (event) => event.preventDefault();
-    const onSortOver = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
-    const onSortEnd = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
+    const onSortStart = () => setSortingItems(items);
+    const onSortOver = ({ oldIndex, newIndex }) => onReorder(sortingItems[oldIndex], newIndex);
+    const onSortEnd = ({ oldIndex, newIndex }) => {
+      onReorder(sortingItems[oldIndex], newIndex);
+      setSortingItems(null);
+    };
     return (
-      <SortableGridContainer {...props} axis="xy" distance={15} onSortOver={onSortOver} onSortEnd={onSortEnd}>
-        {items.map((item, index) => (
+      <SortableGridContainer {...props} axis="xy" distance={15} onSortStart={onSortStart} onSortOver={onSortOver} onSortEnd={onSortEnd}>
+        {(sortingItems || items).map((item, index) => (
           <SortableGridItem key={item.id} className={itemClassName} index={index} tabIndex={0} onDragStart={onDragStart}>
             {children(item)}
           </SortableGridItem>

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -32,7 +32,9 @@ const Grid = ({ items, itemClassName, children, sortable, onReorder, ...props })
   if (sortable) {
     const onDragStart = (event) => event.preventDefault();
     const onSortStart = () => setSortingItems(items);
-    const onSortOver = ({ oldIndex, newIndex }) => onReorder(sortingItems[oldIndex], newIndex);
+    const onSortOver = ({ oldIndex, newIndex, isKeySorting }) => {
+      if (isKeySorting) onReorder(items[oldIndex], newIndex);
+    };
     const onSortEnd = ({ oldIndex, newIndex }) => {
       onReorder(sortingItems[oldIndex], newIndex);
       setSortingItems(null);

--- a/src/components/containers/grid.js
+++ b/src/components/containers/grid.js
@@ -30,9 +30,10 @@ const SortableGridItem = SortableElement(GridItem);
 const Grid = ({ items, itemClassName, children, sortable, onReorder, ...props }) => {
   if (sortable) {
     const onDragStart = (event) => event.preventDefault();
+    const onSortOver = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
     const onSortEnd = ({ oldIndex, newIndex }) => onReorder(items[oldIndex], newIndex);
     return (
-      <SortableGridContainer {...props} axis="xy" distance={15} onSortEnd={onSortEnd}>
+      <SortableGridContainer {...props} axis="xy" distance={15} onSortOver={onSortOver} onSortEnd={onSortEnd}>
         {items.map((item, index) => (
           <SortableGridItem key={item.id} className={itemClassName} index={index} tabIndex={0} onDragStart={onDragStart}>
             {children(item)}

--- a/src/components/containers/grid.styl
+++ b/src/components/containers/grid.styl
@@ -8,4 +8,4 @@
   padding: 0
 
 .item
-  display: block
+  list-style: none

--- a/src/components/containers/projects-list.styl
+++ b/src/components/containers/projects-list.styl
@@ -17,7 +17,7 @@
 .projectsItem
   display: flex
   flex-direction: column
-  justify-content: end
+  justify-content: flex-end
   height: 100%
   
 .header

--- a/src/components/containers/projects-list.styl
+++ b/src/components/containers/projects-list.styl
@@ -15,7 +15,7 @@
   align-items: flex-end
 
 .projectsItem
-  display: flex !important
+  display: flex
   flex-direction: column
   justify-content: end
   height: 100%

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -57,7 +57,7 @@ class CollectionEditor extends React.Component {
     const featuredIndex = this.state.projects.findIndex((p) => p.id === this.state.featuredProjectId);
     const index = (featuredIndex >= 0 && filteredIndex > featuredIndex) ? filteredIndex + 1 : filteredIndex;
     this.setState(({ projects }) => {
-      const sortedProjects = projects.filter((p) => p !== project);
+      const sortedProjects = projects.filter((p) => p.id !== project.id);
       sortedProjects.splice(index, 0, project);
       return { projects: sortedProjects };
     });

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -40,7 +40,7 @@ class CollectionEditor extends React.Component {
       }));
     }
     await this.props.api.patch(`collections/${collection.id}/add/${project.id}`);
-    if (collection.id === this.state.id) {
+    if (collection.id === this.state.id && this.state.projects.length > 1) {
       await this.props.api.post(`collections/${collection.id}/project/${project.id}/index/0`);
     }
   }

--- a/src/presenters/collection-editor.js
+++ b/src/presenters/collection-editor.js
@@ -40,7 +40,7 @@ class CollectionEditor extends React.Component {
       }));
     }
     await this.props.api.patch(`collections/${collection.id}/add/${project.id}`);
-    if (collection.id === this.state.id && this.state.projects.length > 1) {
+    if (collection.id === this.state.id) {
       await this.props.api.post(`collections/${collection.id}/project/${project.id}/index/0`);
     }
   }

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -78,7 +78,7 @@ const CollectionPageContents = ({
   unfeatureProject,
   ...props
 }) => {
-  const collectionHasProjects = !!collection && !!collection.projects && !!collection.projects.length;
+  const collectionHasProjects = !!collection && !!collection.projects;
   let featuredProject = null;
   let { projects } = collection;
   if (collection.featuredProjectId) {

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -176,7 +176,7 @@ const CollectionPageContents = ({
                 fetchMembers
               />
             )}
-            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or tab to focus a project then press space and use the arrow keys</div>}
+            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or move focus</div>}
           </div>
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -127,57 +127,57 @@ const CollectionPageContents = ({
 
             {currentUserIsAuthor && <EditCollectionColor update={updateColor} initialColor={collection.coverColor} />}
           </header>
-          {!collectionHasProjects && currentUserIsAuthor && (
-            <div className="empty-collection-hint" style={{ backgroundColor: collection.coverColor }}>
-              <Image src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" />
-              <Text>You can add any project, created by any user</Text>
+          <div className="collection-contents">
+            <div className="collection-project-container-header">
+              {currentUserIsAuthor && <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />}
             </div>
-          )}
-          {!collectionHasProjects && !currentUserIsAuthor && (
-            <div className="empty-collection-hint" style={{ backgroundColor: collection.coverColor }}>No projects to see in this collection just yet.</div>
-          )}
-              <div className="collection-contents">
-                <div className="collection-project-container-header">
-                  {currentUserIsAuthor && <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />}
-                </div>
-                {featuredProject && (
-                  <FeaturedProject
-                    isAuthorized={currentUserIsAuthor}
-                    currentUser={currentUser}
-                    featuredProject={featuredProject}
-                    unfeatureProject={unfeatureProject}
-                    addProjectToCollection={addProjectToCollection}
-                    collection={collection}
-                    displayNewNote={displayNewNote}
-                    updateNote={updateNote}
-                    hideNote={hideNote}
-                  />
-                )}
-          {collectionHasProjects && (
-                <ProjectsList
-                  layout="gridCompact"
-                  {...props}
-                  projects={projects}
-                  collection={collection}
-                  enableSorting={currentUserIsAuthor}
-                  onReorder={updateProjectOrder}
-                  noteOptions={{
-                    hideNote,
-                    updateNote,
-                    isAuthorized: currentUserIsAuthor,
-                  }}
-                  projectOptions={{
-                    removeProjectFromCollection,
-                    addProjectToCollection,
-                    displayNewNote,
-                    featureProject,
-                    isAuthorized: currentUserIsAuthor,
-                  }}
-                  fetchMembers
-                />
-          )}
-                {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or press space and use the arrow keys</div>}
+            {!collectionHasProjects && currentUserIsAuthor && (
+              <div className="empty-collection-hint">
+                <Image src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" width="" height="" />
+                <Text>You can add any project, created by any user</Text>
               </div>
+            )}
+            {!collectionHasProjects && !currentUserIsAuthor && (
+              <div className="empty-collection-hint">No projects to see in this collection just yet.</div>
+            )}
+            {featuredProject && (
+              <FeaturedProject
+                isAuthorized={currentUserIsAuthor}
+                currentUser={currentUser}
+                featuredProject={featuredProject}
+                unfeatureProject={unfeatureProject}
+                addProjectToCollection={addProjectToCollection}
+                collection={collection}
+                displayNewNote={displayNewNote}
+                updateNote={updateNote}
+                hideNote={hideNote}
+              />
+            )}
+            {collectionHasProjects && (
+              <ProjectsList
+                layout="gridCompact"
+                {...props}
+                projects={projects}
+                collection={collection}
+                enableSorting={currentUserIsAuthor}
+                onReorder={updateProjectOrder}
+                noteOptions={{
+                  hideNote,
+                  updateNote,
+                  isAuthorized: currentUserIsAuthor,
+                }}
+                projectOptions={{
+                  removeProjectFromCollection,
+                  addProjectToCollection,
+                  displayNewNote,
+                  featureProject,
+                  isAuthorized: currentUserIsAuthor,
+                }}
+                fetchMembers
+              />
+            )}
+            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or focus a project and press space</div>}
+          </div>
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}
       </main>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -139,9 +139,12 @@ const CollectionPageContents = ({
           {collectionHasProjects && (
             <>
               <div className="collection-contents">
-                <div className="collection-project-container-header">
-                  {currentUserIsAuthor && <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />}
-                </div>
+                {currentUserIsAuthor && (
+                  <div className="collection-project-container-header">
+                    <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />
+                    asdf
+                  </div>
+                )}
                 {featuredProject && (
                   <FeaturedProject
                     isAuthorized={currentUserIsAuthor}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -139,12 +139,9 @@ const CollectionPageContents = ({
           {collectionHasProjects && (
             <>
               <div className="collection-contents">
-                {currentUserIsAuthor && (
-                  <div className="collection-project-container-header">
-                    <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />
-                    asdf
-                  </div>
-                )}
+                <div className="collection-project-container-header">
+                  {currentUserIsAuthor && <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />}
+                </div>
                 {featuredProject && (
                   <FeaturedProject
                     isAuthorized={currentUserIsAuthor}
@@ -179,6 +176,7 @@ const CollectionPageContents = ({
                   }}
                   fetchMembers
                 />
+                {currentUserIsAuthor && <div>asdfadfs</div>}
               </div>
             </>
           )}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -176,7 +176,7 @@ const CollectionPageContents = ({
                 fetchMembers
               />
             )}
-            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or focus a project and press space</div>}
+            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or press space with a project focused</div>}
           </div>
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -78,7 +78,7 @@ const CollectionPageContents = ({
   unfeatureProject,
   ...props
 }) => {
-  const collectionHasProjects = !!collection && !!collection.projects;
+  const collectionHasProjects = !!collection && !!collection.projects && collection.projects.length > 0;
   let featuredProject = null;
   let { projects } = collection;
   if (collection.featuredProjectId) {
@@ -128,16 +128,14 @@ const CollectionPageContents = ({
             {currentUserIsAuthor && <EditCollectionColor update={updateColor} initialColor={collection.coverColor} />}
           </header>
           {!collectionHasProjects && currentUserIsAuthor && (
-            <div className="empty-collection-hint">
+            <div className="empty-collection-hint" style={{ backgroundColor: collection.coverColor }}>
               <Image src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" />
               <Text>You can add any project, created by any user</Text>
             </div>
           )}
           {!collectionHasProjects && !currentUserIsAuthor && (
-            <div className="empty-collection-hint">No projects to see in this collection just yet.</div>
+            <div className="empty-collection-hint" style={{ backgroundColor: collection.coverColor }}>No projects to see in this collection just yet.</div>
           )}
-          {collectionHasProjects && (
-            <>
               <div className="collection-contents">
                 <div className="collection-project-container-header">
                   {currentUserIsAuthor && <AddCollectionProject addProjectToCollection={addProjectToCollection} collection={collection} />}
@@ -155,6 +153,7 @@ const CollectionPageContents = ({
                     hideNote={hideNote}
                   />
                 )}
+          {collectionHasProjects && (
                 <ProjectsList
                   layout="gridCompact"
                   {...props}
@@ -176,10 +175,9 @@ const CollectionPageContents = ({
                   }}
                   fetchMembers
                 />
+          )}
                 {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or press space and use the arrow keys</div>}
               </div>
-            </>
-          )}
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}
       </main>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -176,7 +176,7 @@ const CollectionPageContents = ({
                 fetchMembers
               />
             )}
-            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or press space with a project focused</div>}
+            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or tab to focus a project then press space and use the arrow keys</div>}
           </div>
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -133,7 +133,7 @@ const CollectionPageContents = ({
             </div>
             {!collectionHasProjects && currentUserIsAuthor && (
               <div className="empty-collection-hint">
-                <Image src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" width="" height="" />
+                <Image src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="psst" width="" height="" />
                 <Text>You can add any project, created by any user</Text>
               </div>
             )}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -176,7 +176,12 @@ const CollectionPageContents = ({
                 fetchMembers
               />
             )}
-            {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or move focus</div>}
+            {currentUserIsAuthor && projects.length > 1 && (
+              <div>
+                Drag to reorder, or move focus to a project and press space.
+                Move it with the arrow keys and press space again to save.
+              </div>
+            )}
           </div>
         </article>
         {!currentUserIsAuthor && <ReportButton reportedType="collection" reportedModel={collection} />}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -159,7 +159,7 @@ const CollectionPageContents = ({
                 {...props}
                 projects={projects}
                 collection={collection}
-                enableSorting={currentUserIsAuthor}
+                enableSorting={currentUserIsAuthor && projects.length > 1}
                 onReorder={updateProjectOrder}
                 noteOptions={{
                   hideNote,

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -176,7 +176,7 @@ const CollectionPageContents = ({
                   }}
                   fetchMembers
                 />
-                {currentUserIsAuthor && <div>Click and drag to reorder projects, or press space while a project is focused</div>}
+                {currentUserIsAuthor && projects.length > 1 && <div>Drag to reorder, or press space and use the arrow keys</div>}
               </div>
             </>
           )}

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -78,7 +78,7 @@ const CollectionPageContents = ({
   unfeatureProject,
   ...props
 }) => {
-  const collectionHasProjects = !!collection && !!collection.projects;
+  const collectionHasProjects = !!collection && !!collection.projects && !!collection.projects.length;
   let featuredProject = null;
   let { projects } = collection;
   if (collection.featuredProjectId) {
@@ -176,7 +176,7 @@ const CollectionPageContents = ({
                   }}
                   fetchMembers
                 />
-                {currentUserIsAuthor && <div>asdfadfs</div>}
+                {currentUserIsAuthor && <div>Click and drag to reorder projects, or press space while a project is focused</div>}
               </div>
             </>
           )}

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -42,7 +42,7 @@ const getIncludedCollections = async (api, projectId) => {
   const populatedCollections = await Promise.all(
     selectedCollections.map(async (collection) => {
       const { projects, user, team } = await allByKeys({
-        projects: getAllPages(api, `/v1/collections/by/id/projects?id=${collection.id}&limit=100&orderKey=createdAt&orderDirection=DESC`),
+        projects: getAllPages(api, `/v1/collections/by/id/projects?id=${collection.id}&limit=100&orderKey=projectOrder&orderDirection=ASC`),
         user: collection.user && getSingleItem(api, `v1/users/by/id?id=${collection.user.id}`, collection.user.id),
         team: collection.team && getSingleItem(api, `v1/teams/by/id?id=${collection.team.id}`, collection.team.id),
       });


### PR DESCRIPTION
## Links
* https://superb-guide.glitch.me/

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/58658417-721f6c00-82ee-11e9-8595-d8455decf53d.png)
![image](https://user-images.githubusercontent.com/8932174/58658435-7e0b2e00-82ee-11e9-9532-0b1b9c9cc34c.png)
![image](https://user-images.githubusercontent.com/8932174/58658470-8bc0b380-82ee-11e9-9571-70453ff015a1.png)

## Changes:
- Added a prompt to the bottom of collections with more than one project explaining how to reorder, not happy with the wording
- Reworked some css to get rid of an `!important` I added during a deploy yesterday
- The empty collection check was broken, so the prompts weren't visible, this brings them back
- Project page 'in collections' area shows the first three projects in the collection. user/team pages still don't because they use the old api to load collections

## How To Test:
- Can you figure out how to reorder a collection without a mouse based on that prompt?
- Do the empty collection messages show up in the right situations?

## Feedback I'm looking for:
- The reorder prompt is there to indicate how to do so to people not using a mouse, since there's no real way to discover it on your own. Any ideas on a better way to do it than this?
- Do we still want those empty collection messages?