### PR TITLE
lavish-laborer: make sure all Image components use alt prop

### DIFF
--- a/src/components/project/embed.js
+++ b/src/components/project/embed.js
@@ -44,7 +44,7 @@ const Embed = ({ domain }) => (
       // Error message if JS not supported
       // TODO(sheridan): Refactor this once we have a true error component
       <div>
-        <Image src={telescopeImageUrl} width="35%" />
+        <Image src={telescopeImageUrl} width="35%" alt="" />
         <div>
           <h2>The web browser you're using is missing some important Javascript features</h2>
           <p>To use this app, please try applying your latest system updates, or try again with a different web browser.</p>

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -4,7 +4,7 @@
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
   { owner: 'glitch', name: 'glitch-this-week-june-5-2019' },
-  { owner: 'glitch', name: 'draw-with-music' },
+  { owner: 'glitch', name: 'discover-modern-art' },
   { owner: 'glitch', name: 'relish-the-randomosity' }
 ];
 

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -3,9 +3,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'glitch-this-week-may-29-2019' },
+  { owner: 'glitch', name: 'glitch-this-week-june-5-2019' },
   { owner: 'glitch', name: 'draw-with-music' },
-  { owner: 'glitch', name: 'colorful-creations' }
+  { owner: 'glitch', name: 'relish-the-randomosity' }
 ];
 
 // More ideas is populated from this team

--- a/src/presenters/pages/category.js
+++ b/src/presenters/pages/category.js
@@ -22,7 +22,7 @@ const CategoryPageWrap = ({ addProjectToCollection, category, currentUser }) => 
         <header className="collection">
           <Heading tagName="h1">{category.name}</Heading>
           <div className="collection-image-container">
-            <Image src={category.avatarUrl} />
+            <Image src={category.avatarUrl} alt="" />
           </div>
 
           <p className="description">{category.description}</p>


### PR DESCRIPTION
## Links
* [lavish-laborer.glitch.me](https://lavish-laborer.glitch.me)
* [Manuscript](https://glitch.fogbugz.com/f/cases/3328679/Missing-prop-type-on-Category-pages-like-games)

## Changes:
Make sure all `<Image>` components use an `alt` prop

## How To Test:
Go to [/games](https://lavish-laborer.glitch.me/games). You should not see any errors in the console