### PR TITLE
sweet-ethernet: don't pass props to DOM elements

### DIFF
--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -158,7 +158,7 @@ function ProjectsList({
   return (
     <FilterController enabled={enableFiltering} placeholder={placeholder} projects={projects}>
       {({ filterInput, renderProjects }) => (
-        <article {...props} className={classNames(styles.projectsContainer)}>
+        <article className={classNames(styles.projectsContainer)}>
           <div className={styles.header}>
             {title && <Heading tagName="h2">{title}</Heading>}
             {filterInput}

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -153,11 +153,12 @@ function ProjectsList({
   collection,
   noteOptions,
   projectOptions,
+  dataCy,
 }) {
   return (
     <FilterController enabled={enableFiltering} placeholder={placeholder} projects={projects}>
       {({ filterInput, renderProjects }) => (
-        <article className={classNames(styles.projectsContainer)}>
+        <article className={classNames(styles.projectsContainer)} data-cy={dataCy}>
           <div className={styles.header}>
             {title && <Heading tagName="h2">{title}</Heading>}
             {filterInput}
@@ -197,6 +198,7 @@ ProjectsList.propTypes = {
   collection: PropTypes.object,
   noteOptions: PropTypes.object,
   projectOptions: PropTypes.object,
+  dataCy: PropTypes.string,
 };
 
 ProjectsList.defaultProps = {
@@ -210,6 +212,7 @@ ProjectsList.defaultProps = {
   collection: null,
   noteOptions: {},
   projectOptions: {},
+  dataCy: null,
 };
 
 export default ProjectsList;

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -153,7 +153,6 @@ function ProjectsList({
   collection,
   noteOptions,
   projectOptions,
-  ...props
 }) {
   return (
     <FilterController enabled={enableFiltering} placeholder={placeholder} projects={projects}>

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -4,7 +4,7 @@
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
   { owner: 'glitch', name: 'glitch-this-week-june-5-2019' },
-  { owner: 'glitch', name: 'draw-with-music' },
+  { owner: 'glitch', name: 'discover-modern-art' },
   { owner: 'glitch', name: 'relish-the-randomosity' }
 ];
 

--- a/src/curated/collections.js
+++ b/src/curated/collections.js
@@ -3,9 +3,9 @@
 
 // What collections to show in the expanded area on the homepage
 export const featuredCollections = [
-  { owner: 'glitch', name: 'glitch-this-week-may-29-2019' },
+  { owner: 'glitch', name: 'glitch-this-week-june-5-2019' },
   { owner: 'glitch', name: 'draw-with-music' },
-  { owner: 'glitch', name: 'colorful-creations' }
+  { owner: 'glitch', name: 'relish-the-randomosity' }
 ];
 
 // More ideas is populated from this team

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -143,7 +143,7 @@ const UserPage = ({
       {/* Pinned Projects */}
       {pinnedProjects.length > 0 && (
         <ProjectsList
-          data-cy="pinned-projects"
+          dataCy="pinned-projects"
           layout="grid"
           title={
             <>
@@ -177,7 +177,7 @@ const UserPage = ({
       {/* Recent Projects */}
       {recentProjects.length > 0 && (
         <ProjectsList
-          data-cy="recent-projects"
+          dataCy="recent-projects"
           layout="grid"
           title="Recent Projects"
           projects={recentProjects}


### PR DESCRIPTION
## Links
* [sweet-ethernet.glitch.me](https://sweet-ethernet.glitch.me)

## Changes:
This removes `{...props}` from an `<article>` DOM element. I think this is leftover from refactoring, we shouldn't need to pass props to a native DOM element, and it was throwing a console error that you can see at [lavish-laborer.glitch.me/@glitch](https://lavish-laborer.glitch.me/@glitch)

## How To Test:
Open [sweet-ethernet.glitch.me/@glitch](https://sweet-ethernet.glitch.me/@glitch), you shouldn't see any errors in the console

## Feedback I'm looking for:
Does this unexpectedly break anything? Is there actually a good reason to pass `props` to DOM elements?