### PR TITLE
Halved belief: don't see undelete button if you can't undelete

### DIFF
--- a/src/components/buttons/button.js
+++ b/src/components/buttons/button.js
@@ -46,7 +46,11 @@ const Button = ({ onClick, href, disabled, type, size, matchBackground, hover, c
   }
 
   if (decorative) {
-    return <span className={className}>{children}</span>;
+    return (
+      <span className={className} disabled={disabled}>
+        {children}
+      </span>
+    );
   }
 
   return (

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -40,7 +40,7 @@ DeletedProject.propTypes = {
 
 const DeletedProjectViewOnly = ({ id, domain }) => {
   return (
-    <div>
+    <div className={styles.deletedProject}>
       <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
       <div className={styles.projectName}>{domain}</div>
     </div>
@@ -49,11 +49,10 @@ const DeletedProjectViewOnly = ({ id, domain }) => {
 
 export const DeletedProjectsList = ({ deletedProjects, undelete }) => {
   const undeleteTracked = useTrackedFunc(undelete, 'Undelete clicked');
-
   return (
     <Grid items={deletedProjects} className={styles.deletedProjectsContainer}>
       {({ id, domain, permission }) => {
-        if (permission) {
+        if (permission.accessLevel === 30 && undelete) {
           return <DeletedProject id={id} domain={domain} onClick={() => undeleteTracked(id)} />;
         } else {
           return <DeletedProjectViewOnly id={id} domain={domain} />;
@@ -65,22 +64,9 @@ export const DeletedProjectsList = ({ deletedProjects, undelete }) => {
 
 DeletedProjectsList.propTypes = {
   deletedProjects: PropTypes.array.isRequired,
-  undelete: PropTypes.func.isRequired,
+  undelete: PropTypes.func,
 };
 
-const ViewOnlyDeletedProjectsList = ({ deletedProjects }) => (
-  <Grid items={deletedProjects} className={styles.deletedProjectsContainer}>
-    {({ id, domain }) => (
-      <div>
-        <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
-        <div className={styles.projectName}>{domain}</div>
-      </div>
-    )}
-  </Grid>
-);
-ViewOnlyDeletedProjectsList.propTypes = {
-  deletedProjects: PropTypes.array.isRequired,
-};
 
 function DeletedProjects({ deletedProjects, setDeletedProjects, undelete, user }) {
   const api = useAPI();
@@ -115,11 +101,9 @@ function DeletedProjects({ deletedProjects, setDeletedProjects, undelete, user }
   }
   return (
     <>
-      {undelete ? (
+
         <DeletedProjectsList deletedProjects={deletedProjects} undelete={undelete} />
-      ) : (
-        <ViewOnlyDeletedProjectsList deletedProjects={deletedProjects} />
-      )}
+
       <Button type="tertiary" onClick={clickHide}>
         Hide Deleted Projects
       </Button>

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -32,20 +32,33 @@ const DeletedProject = ({ id, domain, onClick }) => (
     )}
   </AnimationContainer>
 );
-
-
 DeletedProject.propTypes = {
   id: PropTypes.string.isRequired,
   domain: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
 };
 
+const DeletedProjectViewOnly = ({ id, domain}) => {
+  return (
+        <div>
+        <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
+        <div className={styles.projectName}>{domain}</div>
+      </div>
+  )
+}
+   
 export const DeletedProjectsList = ({ deletedProjects, undelete }) => {
   const undeleteTracked = useTrackedFunc(undelete, 'Undelete clicked');
-
+  console.log(deletedProjects[0])
   return (
     <Grid items={deletedProjects} className={styles.deletedProjectsContainer}>
-      {({ id, domain }) => <DeletedProject id={id} domain={domain} onClick={() => undeleteTracked(id)} />}
+      {({ id, domain, permission }) => {
+        if (permission) {
+          return <DeletedProject id={id} domain={domain} onClick={() => undeleteTracked(id)} />          
+        } else {
+          return <DeletedProjectViewOnly id={id} domain={domain}/>
+        }
+      }}
     </Grid>
   );
 };

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -11,6 +11,7 @@ import Button from 'Components/buttons/button';
 import TransparentButton from 'Components/buttons/transparent-button';
 import AnimationContainer from 'Components/animation-container';
 import Grid from 'Components/containers/grid';
+import TooltipContainer from 'Components/tooltips/tooltip-container';
 import { getAvatarUrl } from 'Models/project';
 import { useAPI } from 'State/api';
 import { useTrackedFunc } from 'State/segment-analytics';
@@ -24,6 +25,18 @@ const DeletedProject = ({ id, domain, onClick }) => {
       <div className={styles.deletedProject}>
         <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
         <div className={styles.projectName}>{domain}</div>
+        <div style={{ margin: '70px' }}>
+          <TooltipContainer
+            type="action"
+            id="a-unique-id"
+            target={
+              <Button size="small" decorative disabled>
+                Undelete
+              </Button>
+            }
+            tooltip="I'm an action tooltip"
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -38,25 +38,25 @@ DeletedProject.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-const DeletedProjectViewOnly = ({ id, domain}) => {
+const DeletedProjectViewOnly = ({ id, domain }) => {
   return (
-        <div>
-        <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
-        <div className={styles.projectName}>{domain}</div>
-      </div>
-  )
-}
-   
+    <div>
+      <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
+      <div className={styles.projectName}>{domain}</div>
+    </div>
+  );
+};
+
 export const DeletedProjectsList = ({ deletedProjects, undelete }) => {
   const undeleteTracked = useTrackedFunc(undelete, 'Undelete clicked');
-  console.log(deletedProjects[0])
+
   return (
     <Grid items={deletedProjects} className={styles.deletedProjectsContainer}>
       {({ id, domain, permission }) => {
         if (permission) {
-          return <DeletedProject id={id} domain={domain} onClick={() => undeleteTracked(id)} />          
+          return <DeletedProject id={id} domain={domain} onClick={() => undeleteTracked(id)} />;
         } else {
-          return <DeletedProjectViewOnly id={id} domain={domain}/>
+          return <DeletedProjectViewOnly id={id} domain={domain} />;
         }
       }}
     </Grid>
@@ -115,11 +115,11 @@ function DeletedProjects({ deletedProjects, setDeletedProjects, undelete, user }
   }
   return (
     <>
-      {
-        undelete
-          ? <DeletedProjectsList deletedProjects={deletedProjects} undelete={undelete} />
-          : <ViewOnlyDeletedProjectsList deletedProjects={deletedProjects} />
-      }
+      {undelete ? (
+        <DeletedProjectsList deletedProjects={deletedProjects} undelete={undelete} />
+      ) : (
+        <ViewOnlyDeletedProjectsList deletedProjects={deletedProjects} />
+      )}
       <Button type="tertiary" onClick={clickHide}>
         Hide Deleted Projects
       </Button>

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -27,7 +27,7 @@ const DeletedProject = ({ id, domain, onClick }) => {
         <div className={styles.projectName}>{domain}</div>
         <TooltipContainer
           type="action"
-          id="a-unique-id"
+          id="deleted-project-tooltip-container"
           target={
             <div className={styles.buttonWrap}>
               <Button size="small" disabled decorative>

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -38,13 +38,16 @@ DeletedProject.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-const DeletedProjectViewOnly = ({ id, domain }) => {
-  return (
-    <div className={styles.deletedProject}>
-      <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
-      <div className={styles.projectName}>{domain}</div>
-    </div>
-  );
+const DeletedProjectViewOnly = ({ id, domain }) => (
+  <div className={styles.deletedProject}>
+    <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
+    <div className={styles.projectName}>{domain}</div>
+  </div>
+);
+
+DeletedProject.propTypes = {
+  id: PropTypes.string.isRequired,
+  domain: PropTypes.string.isRequired,
 };
 
 export const DeletedProjectsList = ({ deletedProjects, undelete }) => {
@@ -52,7 +55,7 @@ export const DeletedProjectsList = ({ deletedProjects, undelete }) => {
   return (
     <Grid items={deletedProjects} className={styles.deletedProjectsContainer}>
       {({ id, domain, permission }) => {
-        if (permission.accessLevel === 30 && undelete) {
+        if (permission && permission.accessLevel === 30 && undelete) {
           return <DeletedProject id={id} domain={domain} onClick={() => undeleteTracked(id)} />;
         } else {
           return <DeletedProjectViewOnly id={id} domain={domain} />;
@@ -66,7 +69,9 @@ DeletedProjectsList.propTypes = {
   deletedProjects: PropTypes.array.isRequired,
   undelete: PropTypes.func,
 };
-
+DeletedProjectsList.defaultProps = {
+  undelete: null, // super users can't delete project from within the ui
+};
 
 function DeletedProjects({ deletedProjects, setDeletedProjects, undelete, user }) {
   const api = useAPI();
@@ -101,9 +106,7 @@ function DeletedProjects({ deletedProjects, setDeletedProjects, undelete, user }
   }
   return (
     <>
-
-        <DeletedProjectsList deletedProjects={deletedProjects} undelete={undelete} />
-
+      <DeletedProjectsList deletedProjects={deletedProjects} undelete={undelete} />
       <Button type="tertiary" onClick={clickHide}>
         Hide Deleted Projects
       </Button>

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -25,18 +25,18 @@ const DeletedProject = ({ id, domain, onClick }) => {
       <div className={styles.deletedProject}>
         <img className={styles.avatar} src={getAvatarUrl(id)} alt="" />
         <div className={styles.projectName}>{domain}</div>
-        <div style={{ margin: '70px' }}>
-          <TooltipContainer
-            type="action"
-            id="a-unique-id"
-            target={
-              <Button size="small" decorative disabled>
+        <TooltipContainer
+          type="action"
+          id="a-unique-id"
+          target={
+            <div className={styles.buttonWrap}>
+              <Button size="small" disabled decorative>
                 Undelete
               </Button>
-            }
-            tooltip="I'm an action tooltip"
-          />
-        </div>
+            </div>
+          }
+          tooltip="Only admins can undelete a project"
+        />
       </div>
     );
   }

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -27,7 +27,7 @@ const DeletedProject = ({ id, domain, onClick }) => {
         <div className={styles.projectName}>{domain}</div>
         <TooltipContainer
           type="action"
-          id="deleted-project-tooltip-container"
+          id="undelete-project"
           target={
             <div className={styles.buttonWrap}>
               <Button size="small" disabled decorative>


### PR DESCRIPTION
## Links
* https://halved-belief.glitch.me/
* https://glitch.manuscript.com/f/cases/3328582/

## GIF/Screenshots:
![Screen Shot 2019-06-06 at 3 08 37 PM](https://user-images.githubusercontent.com/6620164/59060172-83c4be80-886e-11e9-8646-6ae663705502.png)

## Changes:
* currently when you look at your deleted projects it's fairly likely you'll see projects there you can't actually undelete despite seeing the button. As an example if I am invited to join a project I can't delete it because I'm not an admin. Similarly I can't undelete it, if I try I get a 401 error. This removes the button from rendering on those projects. 

## How To Test:
* join a project as a non admin, have the admin delete it, notice you can see it under deleted projects on your user page but you can't undelete. (if you want me to invite you to a project and delete it for testing purposes slack me :)) 

## Feedback I'm looking for:
- seem good?
