### PR TITLE
Full larch: Do not alert sentry of UC Browser bugs

### DIFF
--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -24,6 +24,10 @@ try {
     ignoreErrors: SentryHelpers.ignoreErrors,
     whitelistUrls: ['/glitch.com/'],
     beforeSend(event) {
+      const ucBrowser = window.navigator.userAgent.match(/^Mozilla\/5\.0 .+ Gecko\/$/)
+      if (ucBrowser) {
+        
+      }
       try {
         return SentryHelpers.beforeSend(PROJECT_DOMAIN, _env, event);
       } catch (error) {

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -24,9 +24,10 @@ try {
     ignoreErrors: SentryHelpers.ignoreErrors,
     whitelistUrls: ['/glitch.com/'],
     beforeSend(event) {
-      const ucBrowser = window.navigator.userAgent.match(/^Mozilla\/5\.0 .+ Gecko\/$/)
+      // do not send errors to sentry when user uses UC Browser
+      const ucBrowser = window.navigator.userAgent.match(/^Mozilla\/5\.0 .+ Gecko\/$/);
       if (ucBrowser) {
-        
+        return null;
       }
       try {
         return SentryHelpers.beforeSend(PROJECT_DOMAIN, _env, event);


### PR DESCRIPTION
## Links
* https://full-larch.glitch.me/
* https://glitch.manuscript.com/f/cases/3327840/

## Changes:
* [UC Browser](https://en.wikipedia.org/wiki/UC_Browser) is a very popular browser, which unfortunately behaves very differently from our supported browsers (and has some security issues apparently), until we're ready to support it, it doesn't make much sense to log out the errors to sentry. This pr will [hopefully detect](https://stackoverflow.com/questions/38089868/javascript-how-to-detect-if-the-user-is-using-uc-browser-mini) when a user is using this browser and [not send the bug to sentry by returning null](https://docs.sentry.io/error-reporting/configuration/filtering/?platform=browser). 

## How To Test:
* Unfortunately I'm not able to download UC Browser as I've got a mac, I tried a bit with browserstack as it looks like their Androids have UC Browser available (though not their desktops?) But couldn't open the dev tools console with it unfortunately. But if you have a machine you can download uc browser on and want to try that would be cool! Otherwise I think we can probs trust the internet and try it out.

## Feedback I'm looking for:
- thoughts on why this might be a bad idea for reasons I'm not thinking about?
