### PR TITLE
Peach countess: fix collapsing markdown inputs

### DIFF
--- a/src/components/inputs/markdown-input.js
+++ b/src/components/inputs/markdown-input.js
@@ -13,7 +13,7 @@ const MarkdownInput = ({ allowImages, error, onBlur: outerOnBlur, onChange, plac
     setFocused(false);
     outerOnBlur(event);
   };
-  if (error || focused || !value) {
+  if (error || focused || !value.trim()) {
     return (
       <TextArea
         autoFocus={focused}

--- a/src/components/inputs/markdown-input.js
+++ b/src/components/inputs/markdown-input.js
@@ -13,6 +13,7 @@ const MarkdownInput = ({ allowImages, error, onBlur: outerOnBlur, onChange, plac
     setFocused(false);
     outerOnBlur(event);
   };
+  console.log(value, !value)
   if (error || focused || !value) {
     return (
       <TextArea

--- a/src/components/inputs/markdown-input.js
+++ b/src/components/inputs/markdown-input.js
@@ -13,7 +13,6 @@ const MarkdownInput = ({ allowImages, error, onBlur: outerOnBlur, onChange, plac
     setFocused(false);
     outerOnBlur(event);
   };
-  console.log(value, !value)
   if (error || focused || !value) {
     return (
       <TextArea

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -126,6 +126,7 @@ const UserPage = ({
             description={user.description}
             update={updateDescription}
             placeholder="Tell us about yourself"
+            onBlur={}
           />
         </UserProfileContainer>
       </section>

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -126,7 +126,6 @@ const UserPage = ({
             description={user.description}
             update={updateDescription}
             placeholder="Tell us about yourself"
-            onBlur={}
           />
         </UserProfileContainer>
       </section>


### PR DESCRIPTION
## Links
* https://peach-countess.glitch.me
* https://glitch.manuscript.com/f/cases/3328640/

## GIF/Screenshots:
![](http://g.recordit.co/mjizjXfMUg.gif)

## Changes:
* show markdown fields as editable if when their value trimmed has a length of 0. 

## How To Test:
* you can see the bug fixed in storybook ^
* you can also see this on the user profile for descriptions and for collection descriptions

## Feedback I'm looking for:
- debating if we should trim on blur so it shows the placeholder text instead. what do y'all think? looks like we trim values when we display them, so it's not like we're letting users have weird spacing as descriptions? Then again it might be kind of annoying to have trims happen when you blur if you're not expecting it? Like if I type "blah blah " and then navigating away to copy some text to then paste in and the last space after the blah is removed it'll be "blah blahpastedText" instead of "blah blah pastedText" but maybe that's fine?

