### PR TITLE
Chain cut: handle teams without urls

### DIFF
--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -47,8 +47,8 @@ const useTeamUsers = createAPIHook(async (api, teamID) => {
     const res = await api.get(`/v1/teams/by/id/users?id=${teamID}`);
     return res.data.items;
   } catch (e) {
-    console.log("error", e)
-    return []
+    captureException(e);
+    return [];
   }
 });
 

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -58,7 +58,11 @@ function TeamWithDataLoading({ team }) {
 }
 
 const TeamResult = ({ result }) => {
-  console.log({result})
+  // filter our team that don't have urls (
+  // sometimes search results are out of sync with db, ensures we don't show teams that don't exist)
+  if (!result.url) {
+    return null;
+  }
   if (!result.users) {
     return <TeamWithDataLoading team={result} />;
   }
@@ -145,7 +149,6 @@ const resultComponents = {
 };
 
 const ResultComponent = ({ result }) => {
-  console.log("resultcomponent", result)
   const Component = resultComponents[result.type];
   return <Component result={result} />;
 };

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -43,8 +43,13 @@ const FilterContainer = ({ filters, activeFilter, setFilter, query }) => {
 // Search results from algolia do not contain their associated users or teams,
 // so those need to be fetched after the search results have loaded.
 const useTeamUsers = createAPIHook(async (api, teamID) => {
-  const res = await api.get(`/v1/teams/by/id/users?id=${teamID}`);
-  return res.data.items;
+  try {
+    const res = await api.get(`/v1/teams/by/id/users?id=${teamID}`);
+    return res.data.items;
+  } catch (e) {
+    console.log("error", e)
+    return []
+  }
 });
 
 function TeamWithDataLoading({ team }) {

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -58,6 +58,7 @@ function TeamWithDataLoading({ team }) {
 }
 
 const TeamResult = ({ result }) => {
+  console.log({result})
   if (!result.users) {
     return <TeamWithDataLoading team={result} />;
   }
@@ -144,6 +145,7 @@ const resultComponents = {
 };
 
 const ResultComponent = ({ result }) => {
+  console.log("resultcomponent", result)
   const Component = resultComponents[result.type];
   return <Component result={result} />;
 };

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -58,11 +58,6 @@ function TeamWithDataLoading({ team }) {
 }
 
 const TeamResult = ({ result }) => {
-  // filter our team that don't have urls (
-  // sometimes search results are out of sync with db, ensures we don't show teams that don't exist)
-  if (!result.url) {
-    return null;
-  }
   if (!result.users) {
     return <TeamWithDataLoading team={result} />;
   }

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -18,9 +18,7 @@ const ProfileAvatar = ({ team }) => <Image className={styles.avatar} src={getAva
 
 const getTeamThanksCount = (team) => sumBy(team.users, (user) => user.thanksCount);
 
-const TeamItem = ({ team }) => {
-  console.log(team.url, team)
-  return (
+const TeamItem = ({ team }) => (
   <WrappingLink className={styles.container} href={getLink(team)}>
     <Cover type="team" item={team} size="medium" />
     <div className={styles.mainContent}>
@@ -40,7 +38,7 @@ const TeamItem = ({ team }) => {
       </div>
     </div>
   </WrappingLink>
-)};
+);
 
 TeamItem.propTypes = {
   team: PropTypes.shape({

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -19,7 +19,7 @@ const ProfileAvatar = ({ team }) => <Image className={styles.avatar} src={getAva
 const getTeamThanksCount = (team) => sumBy(team.users, (user) => user.thanksCount);
 
 const TeamItem = ({ team }) => {
-  console.log(team)
+  console.log(team.url, team)
   return (
   <WrappingLink className={styles.container} href={getLink(team)}>
     <Cover type="team" item={team} size="medium" />

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -18,7 +18,9 @@ const ProfileAvatar = ({ team }) => <Image className={styles.avatar} src={getAva
 
 const getTeamThanksCount = (team) => sumBy(team.users, (user) => user.thanksCount);
 
-const TeamItem = ({ team }) => (
+const TeamItem = ({ team }) => {
+  console.log(team)
+  return (
   <WrappingLink className={styles.container} href={getLink(team)}>
     <Cover type="team" item={team} size="medium" />
     <div className={styles.mainContent}>
@@ -38,7 +40,7 @@ const TeamItem = ({ team }) => (
       </div>
     </div>
   </WrappingLink>
-);
+)};
 
 TeamItem.propTypes = {
   team: PropTypes.shape({

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -41,9 +41,10 @@ const getTopResults = (resultsByType, query) =>
   [findTop.project(resultsByType.project, query), findTop.team(resultsByType.team, query), findTop.user(resultsByType.user, query)].filter(Boolean);
 
 const filterOutBadData = (payload) => {
-  let fileredData = { ...payload };
-  filteredData.team
-  return payload
+  let filteredData = { ...payload };
+  // sometimes search results are out of sync with db, ensures we don't show teams that don't exist)
+  filteredData.team = filteredData.team.filter(t => !!t.url);
+  return filteredData;
 }
 
 // search provider logic -- shared between algolia & legacy API

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -41,7 +41,7 @@ const getTopResults = (resultsByType, query) =>
   [findTop.project(resultsByType.project, query), findTop.team(resultsByType.team, query), findTop.user(resultsByType.user, query)].filter(Boolean);
 
 const filterOutBadData = (payload) => {
-  let filteredData = { ...payload };
+  const filteredData = { ...payload };
   // sometimes search results are out of sync with db, ensures we don't show teams that don't exist)
   filteredData.team = filteredData.team.filter((t) => !!t.url);
   return filteredData;

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -43,9 +43,9 @@ const getTopResults = (resultsByType, query) =>
 const filterOutBadData = (payload) => {
   let filteredData = { ...payload };
   // sometimes search results are out of sync with db, ensures we don't show teams that don't exist)
-  filteredData.team = filteredData.team.filter(t => !!t.url);
+  filteredData.team = filteredData.team.filter((t) => !!t.url);
   return filteredData;
-}
+};
 
 // search provider logic -- shared between algolia & legacy API
 function useSearchProvider(provider, query, params, deps) {
@@ -57,7 +57,6 @@ function useSearchProvider(provider, query, params, deps) {
     topResults: [],
     ...emptyResults,
   };
-
   const reducer = (state, action) => {
     switch (action.type) {
       case 'clearQuery':
@@ -65,7 +64,6 @@ function useSearchProvider(provider, query, params, deps) {
       case 'loading':
         return { ...state, status: 'loading' };
       case 'ready': {
-        
         const resultsWithEmpties = { ...emptyResults, ...filterOutBadData(action.payload) };
         return {
           status: 'ready',

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -40,6 +40,12 @@ const findTop = {
 const getTopResults = (resultsByType, query) =>
   [findTop.project(resultsByType.project, query), findTop.team(resultsByType.team, query), findTop.user(resultsByType.user, query)].filter(Boolean);
 
+const filterOutBadData = (payload) => {
+  let fileredData = { ...payload };
+  filteredData.team
+  return payload
+}
+
 // search provider logic -- shared between algolia & legacy API
 function useSearchProvider(provider, query, params, deps) {
   const { handleError } = useErrorHandlers();
@@ -50,6 +56,7 @@ function useSearchProvider(provider, query, params, deps) {
     topResults: [],
     ...emptyResults,
   };
+
   const reducer = (state, action) => {
     switch (action.type) {
       case 'clearQuery':
@@ -57,7 +64,8 @@ function useSearchProvider(provider, query, params, deps) {
       case 'loading':
         return { ...state, status: 'loading' };
       case 'ready': {
-        const resultsWithEmpties = { ...emptyResults, ...action.payload };
+        
+        const resultsWithEmpties = { ...emptyResults, ...filterOutBadData(action.payload) };
         return {
           status: 'ready',
           totalHits: sumBy(Object.values(action.payload), (items) => items.length),


### PR DESCRIPTION
## Links
* https://chain-cut.glitch.me/search?q=Computing%20Corner&activeFilter=all
* https://glitch.manuscript.com/f/cases/3328671/

## Changes:
* Previously when you went to https://glitch.com/search?q=computing-corner and clicked on the team with the pink default avatar it'd error out (it also through an error in the console about proptypes in remixes. This was because our search results are out of date with our database for some reason. We have a ticket to deal with the underlying issue: https://glitch.fogbugz.com/f/cases/3328672/Collection-project-count-is-wrong-in-search-results#BugEvent.21314743 but I figured it'd also be nice to ensure we don't display dead links. 
* I also put some error handling in our user fetching as I noticed we were setting .users to an error rather than an empty array. 

## How To Test:
* look up computing corner on both the remix and glitch.com notice that we remove deadlinks from the search results in the remix

## Feedback I'm looking for:
- any reason not to do this?
