### PR TITLE
Remove code that renames a project on undelete 

### DIFF
--- a/src/presenters/user-editor.js
+++ b/src/presenters/user-editor.js
@@ -97,17 +97,6 @@ class UserEditor extends React.Component {
   async undeleteProject(id) {
     await this.props.api.post(`/projects/${id}/undelete`);
     const { data } = await this.props.api.get(`projects/${id}`);
-    if (data.domain.endsWith('-deleted')) {
-      try {
-        const newDomain = data.domain.replace(/-deleted$/, '');
-        await this.props.api.patch(`/projects/${id}`, {
-          domain: newDomain,
-        });
-        data.domain = newDomain;
-      } catch (e) {
-        console.warn('failed to rename project on undelete', e);
-      }
-    }
     // temp set undeleted project updatedAt to now, while it's actually updating behind the scenes
     data.updatedAt = Date.now();
     this.setState(({ projects, _deletedProjects }) => ({


### PR DESCRIPTION
This is handled at the API now, so it's not necessary to do in the client.

## Links
* foregoing-spell.glitch.me
* https://glitch.manuscript.com/f/cases/3328503/

## Changes:
* Removes code that's unnecessary now

## How To Test:
* Delete a project, then undelete it and see that it gets renamed to not include the -deleted suffix.
