### PR TITLE
Long museum: collection avatar a11y improvement

### DIFF
--- a/src/components/collection/defaultAvatar.js
+++ b/src/components/collection/defaultAvatar.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const DefaultAvatar = ({ backgroundFillColor }) => (
-  <svg width={159} height={147} viewBox="0 0 159 147" alt="collection">
+const DefaultAvatar = ({ backgroundFillColor, alt="collection" }) => (
+  <svg width={159} height={147} viewBox="0 0 159 147" alt={alt}>
     <g data-svg="collection-avatar">
       <polygon data-svg="frame" fill="#FFFB98" points="0 147 159 147 159 16 0 16" />
       <polygon data-svg="sky" fill={backgroundFillColor} points="17 132 141 132 141 30 17 30" />

--- a/src/components/collection/defaultAvatar.js
+++ b/src/components/collection/defaultAvatar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const DefaultAvatar = ({ backgroundFillColor }) => (
-  <svg width={159} height={147} viewBox="0 0 159 147">
+  <svg width={159} height={147} viewBox="0 0 159 147" alt="collection">
     <g data-svg="collection-avatar">
       <polygon data-svg="frame" fill="#FFFB98" points="0 147 159 147 159 16 0 16" />
       <polygon data-svg="sky" fill={backgroundFillColor} points="17 132 141 132 141 30 17 30" />

--- a/src/components/collection/defaultAvatar.js
+++ b/src/components/collection/defaultAvatar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const DefaultAvatar = ({ backgroundFillColor, alt="collection" }) => (
+const DefaultAvatar = ({ backgroundFillColor, alt }) => (
   <svg width={159} height={147} viewBox="0 0 159 147" alt={alt}>
     <g data-svg="collection-avatar">
       <polygon data-svg="frame" fill="#FFFB98" points="0 147 159 147 159 16 0 16" />
@@ -54,6 +54,7 @@ DefaultAvatar.propTypes = {
 };
 DefaultAvatar.defaultProps = {
   backgroundFillColor: '#45C1F7',
+  alt: ""
 };
 
 export default DefaultAvatar;

--- a/src/components/collection/defaultAvatar.js
+++ b/src/components/collection/defaultAvatar.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const DefaultAvatar = ({ backgroundFillColor, alt }) => (
-  <svg width={159} height={147} viewBox="0 0 159 147" alt={alt}>
+const DefaultAvatar = ({ backgroundFillColor }) => (
+  <svg width={159} height={147} viewBox="0 0 159 147" alt="">
     <g data-svg="collection-avatar">
       <polygon data-svg="frame" fill="#FFFB98" points="0 147 159 147 159 16 0 16" />
       <polygon data-svg="sky" fill={backgroundFillColor} points="17 132 141 132 141 30 17 30" />
@@ -54,7 +54,6 @@ DefaultAvatar.propTypes = {
 };
 DefaultAvatar.defaultProps = {
   backgroundFillColor: '#45C1F7',
-  alt: ""
 };
 
 export default DefaultAvatar;

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -46,7 +46,7 @@ Link.propTypes = {
 };
 
 export const CollectionLink = ({ collection, children, ...props }) => (
-  <Link to={getCollectionLink(collection)} {...props}>
+  <Link to={getCollectionLink(collection)} {...props} aria-label={collection.name}>
     {children}
   </Link>
 );

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -25,6 +25,7 @@ const CollectionWide = ({ collection }) => {
       <header className={`collection ${dark}`}>
         <CollectionLink className="collection-image-container" collection={collection}>
           <CollectionAvatar color={collection.coverColor} />
+          <span className="screen-reader-text">{collection.name}</span>
         </CollectionLink>
         <CollectionLink className="collection-name" collection={collection}>
           <Heading tagName="h2">{collection.name}</Heading>

--- a/src/presenters/featured-collections.js
+++ b/src/presenters/featured-collections.js
@@ -25,7 +25,6 @@ const CollectionWide = ({ collection }) => {
       <header className={`collection ${dark}`}>
         <CollectionLink className="collection-image-container" collection={collection}>
           <CollectionAvatar color={collection.coverColor} />
-          <span className="screen-reader-text">{collection.name}</span>
         </CollectionLink>
         <CollectionLink className="collection-name" collection={collection}>
           <Heading tagName="h2">{collection.name}</Heading>

--- a/src/presenters/includes/collection-avatar.js
+++ b/src/presenters/includes/collection-avatar.js
@@ -18,9 +18,10 @@ const hexToRgbA = (hex) => {
 };
 /* eslint-enable no-bitwise */
 
-const CollectionAvatar = (props) => <DefaultAvatar backgroundFillColor={hexToRgbA(props.color)} alt={props.alt} />;
+const CollectionAvatar = (props) => <DefaultAvatar backgroundFillColor={hexToRgbA(props.color)} />;
 
 CollectionAvatar.propTypes = {
   color: PropTypes.string.isRequired,
 };
+
 export default CollectionAvatar;

--- a/src/presenters/includes/collection-avatar.js
+++ b/src/presenters/includes/collection-avatar.js
@@ -18,7 +18,7 @@ const hexToRgbA = (hex) => {
 };
 /* eslint-enable no-bitwise */
 
-const CollectionAvatar = (props) => <DefaultAvatar backgroundFillColor={hexToRgbA(props.color)} />;
+const CollectionAvatar = (props) => <DefaultAvatar backgroundFillColor={hexToRgbA(props.color)} alt={props.alt} />;
 
 CollectionAvatar.propTypes = {
   color: PropTypes.string.isRequired,


### PR DESCRIPTION
## Links
* https://long-museum.glitch.me
* https://glitch.manuscript.com/f/cases/3328691/Link-text-for-collection-avatar-should-be-collection-name-not-url-slug

## Changes:
* Before when you navigated to the homepage and used a screenreader on featured collections it would read out the collection avatar as the href to the collection, which is hard to hear. I've added some text that is only accessible with a screenreader so that when you tab through it reads out the name of the collection

## How To Test:
* I used chrome and voiceover and it seemed to work ok! Feel free to do your own better testing tho!

## Feedback I'm looking for:
- anything I might be missing?
