### PR TITLE
Nova chance: Fix the project is still building page

### DIFF
--- a/server/webpack.js
+++ b/server/webpack.js
@@ -1,7 +1,7 @@
 function webpackBackgroundProcess() {
   // Launch webpack in a separate process because it blocks a bit
   const { spawn } = require('child_process');
-  const env = { ...process.env, NODE_OPTIONS: '--max-old-space-size=384' };
+  const env = { ...process.env, NODE_OPTIONS: '--max-old-space-size=512' };
   spawn('webpack', ['--watch', '--info-verbosity', 'verbose'], { env, stdio: 'inherit' });
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,7 @@ import { LiveAnnouncer } from 'react-aria-live';
 import ErrorBoundary from './presenters/includes/error-boundary';
 import { Notifications } from './presenters/notifications';
 import Router from './presenters/pages/router';
-console.log('asdf');
+
 const App = () => (
   <ErrorBoundary fallback="Something went very wrong, try refreshing?">
     <BrowserRouter>

--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,7 @@ import { LiveAnnouncer } from 'react-aria-live';
 import ErrorBoundary from './presenters/includes/error-boundary';
 import { Notifications } from './presenters/notifications';
 import Router from './presenters/pages/router';
-
+console.log('asdf');
 const App = () => (
   <ErrorBoundary fallback="Something went very wrong, try refreshing?">
     <BrowserRouter>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,7 @@ console.log(`Starting Webpack in ${mode} mode.`);
 let prevBuildAssets = [];
 try {
   const prevBuildStats = JSON.parse(fs.readFileSync(path.resolve(BUILD, 'stats.json')));
-  const prevBuildAssetLists = Object.values(prevBuildStats.entrypoints).map((entrypoint) => entrypoint.assets);
-  prevBuildAssets = ['stats.json'].concat(...prevBuildAssetLists).map((file) => `!${file}`);
+  prevBuildAssets = ['!stats.json'].concat(...prevBuildStats.assets.map((asset) => `!${asset.name}`));
 } catch (error) {
   // Don't worry about it, there's probably just no stats.json
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,7 @@ module.exports = smp.wrap({
       hash: true,
       publicPath: true,
     }),
-    new CleanWebpackPlugin({ dry: false, cleanStaleWebpackAssets: true, verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*', '!stats.json']}),
+    new CleanWebpackPlugin({ dry: true, verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*']}),
   ],
   watchOptions: {
     ignored: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
@@ -23,6 +24,8 @@ if (process.env.NODE_ENV === 'production') {
 const smp = new SpeedMeasurePlugin({ outputFormat: 'humanVerbose' });
 
 console.log(`Starting Webpack in ${mode} mode.`);
+
+const lastBuildAssets = fs.readFileSync()
 
 module.exports = smp.wrap({
   mode,
@@ -145,7 +148,6 @@ module.exports = smp.wrap({
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' }),
     new StatsPlugin('stats.json', {
       all: false,
-      assets: true,
       entrypoints: true,
       hash: true,
       publicPath: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,7 @@ module.exports = smp.wrap({
       hash: true,
       publicPath: true,
     }),
-    new CleanWebpackPlugin({ dry: true, verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/*']}),
+    new CleanWebpackPlugin({ dry: false, verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/**']}),
   ],
   watchOptions: {
     ignored: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,6 +145,7 @@ module.exports = smp.wrap({
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' }),
     new StatsPlugin('stats.json', {
       all: false,
+      assets: true,
       entrypoints: true,
       hash: true,
       publicPath: true,


### PR DESCRIPTION
## Links
- https://nova-chance.glitch.me/
- https://glitch.manuscript.com/f/cases/3328664/The-the-site-is-not-ready-yet-page-doesn-t-work

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/59375737-cb3ec500-8d1c-11e9-8e54-203b5c4878e0.png)

## Changes:
- Delete the stats.json file on webpack startup so the site knows that there isn't any build output ready
- Don't wipe the storybook build when webpack/the server gets restarted
- Bumped prod webpack memory from 384mb to 512mb, because it was crashing sometimes when I made a local change. This means that non perf-boosted projects are more likely to get limited, but only if they're running in dev mode.

## How To Test:
Join the project via perf boost and run `refresh` in the console. It should show the not ready page, and storybook should stay built. Changing a js file should also keep storybook around.

## Feedback I'm looking for:
Why was stats.json excluded from cleanup?