### PR TITLE
Coordinated cauliflower: collection item button

### DIFF
--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -92,17 +92,13 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
 
         <ProjectsPreview collection={collection} isAuthorized={isAuthorized} />
 
-        <CollectionLink collection={collection} className={styles.footerLink}>
-          <>
-            {collection.projects && collection.projects.length > 0 && (
-              <>
-                {`View ${collection.projects.length >= 3 ? 'all' : ''} `}
-                <Pluralize count={collection.projects.length} singular="project" />
-                <span aria-hidden="true"> →</span>
-              </>
-            )}
-          </>
-        </CollectionLink>
+        {collection.projects && collection.projects.length > 0 && (
+          <CollectionLink collection={collection} className={styles.footerLink}>
+            {`View ${collection.projects.length >= 3 ? 'all' : ''} `}
+            <Pluralize count={collection.projects.length} singular="project" />
+            <span aria-hidden="true"> →</span>
+          </CollectionLink>
+        )}
       </div>
     )}
   </AnimationContainer>

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -68,14 +68,14 @@
   padding: 10px
   background-color: secondary-background
   &.empty
-    padding: 18px 18px 0
+    padding: 18px 18px 12px
     border-bottom-right-radius: 5px
     border-bottom-left-radius: 5px
     p
       margin: 0
 .projectsList
   --min-width: 180px    
-
+  
 .footerLink
   flex: 0 0 auto
   display: block


### PR DESCRIPTION
## Links
* Remix link: https://coordinated-cauliflower.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328713/

## GIF/Screenshots:
![Screen Shot 2019-06-12 at 5 44 57 PM](https://user-images.githubusercontent.com/938722/59388535-00a5db80-8d3a-11e9-944e-27d74ce17127.png)

## Changes:
* if no projects in collection, don't render "view all projects" button at all
* update css accordingly

## How To Test:
* visit https://coordinated-cauliflower.glitch.me/~modernserf
* the collection linen-collection should only have one focusable element (the header)
* the collection flannel-collection should have a focusable header, project names, and view all projects link