### PR TITLE
Lunar front 1: add accessible label to user profile link in recent projects

### DIFF
--- a/src/components/recent-projects/index.js
+++ b/src/components/recent-projects/index.js
@@ -4,12 +4,11 @@ import Heading from 'Components/text/heading';
 import ProjectsList from 'Components/containers/projects-list';
 import Loader from 'Components/loader';
 import CoverContainer from 'Components/containers/cover-container';
-import { UserLink } from 'Components/link';
+import { UserLink, WrappingLink } from 'Components/link';
 import Button from 'Components/buttons/button';
 import Emoji from 'Components/images/emoji';
 import SignInPop from 'Components/sign-in-pop';
-import VisuallyHidden from 'Components/containers/visually-hidden';
-import { getAvatarStyle } from 'Models/user';
+import { getAvatarStyle, getLink } from 'Models/user';
 import { useCurrentUser } from 'State/current-user';
 
 import ProjectsLoader from '../../presenters/projects-loader';
@@ -56,10 +55,9 @@ const RecentProjects = () => {
       <CoverContainer type="user" item={currentUser}>
         <div className={styles.coverWrap}>
           <div className={styles.avatarWrap}>
-            <UserLink user={currentUser}>
+            <WrappingLink user={currentUser} href={getLink(currentUser)}>
               <div className={styles.userAvatar} style={getAvatarStyle(currentUser)} />
-              <VisuallyHidden>Your profile page</VisuallyHidden>
-            </UserLink>
+            </WrappingLink>
           </div>
           <div className={styles.projectsWrap}>
             {fetched ? (

--- a/src/components/recent-projects/index.js
+++ b/src/components/recent-projects/index.js
@@ -8,6 +8,7 @@ import { UserLink } from 'Components/link';
 import Button from 'Components/buttons/button';
 import Emoji from 'Components/images/emoji';
 import SignInPop from 'Components/sign-in-pop';
+import VisuallyHidden from 'Components/containers/visually-hidden';
 import { getAvatarStyle } from 'Models/user';
 import { useCurrentUser } from 'State/current-user';
 
@@ -49,7 +50,7 @@ const RecentProjects = () => {
   return (
     <section>
       <Heading tagName="h2">
-        <UserLink user={currentUser}>Your Projects →</UserLink>
+        <UserLink user={currentUser}>Your Projects <span aria-hidden="true">→</span></UserLink>
       </Heading>
       {isAnonymousUser && <SignInNotice />}
       <CoverContainer type="user" item={currentUser}>
@@ -57,6 +58,7 @@ const RecentProjects = () => {
           <div className={styles.avatarWrap}>
             <UserLink user={currentUser}>
               <div className={styles.userAvatar} style={getAvatarStyle(currentUser)} />
+              <VisuallyHidden>Your profile page</VisuallyHidden>
             </UserLink>
           </div>
           <div className={styles.projectsWrap}>


### PR DESCRIPTION
## Links
* Remix link: https://lunar-front-1.glitch.me
* Manuscript link: https://glitch.manuscript.com/f/cases/3328727/

## GIF/Screenshots:
<img width="255" alt="Screen Shot 2019-06-13 at 10 32 11 AM" src="https://user-images.githubusercontent.com/938722/59441411-8a9b8600-8dc6-11e9-9fa2-51266024d8f8.png">

## Changes:
* add visually hidden "Your profile page" text to user avatar link
* make arrow in "Your projects" hidden to screen readers

## How To Test:
* log into https://lunar-front-1.glitch.me
* check the link around the user avatar

## Feedback I'm looking for:
Is this the text I should use for this link?