### PR TITLE
Chip petalite: consolidate links on featured embed

### DIFF
--- a/src/presenters/featured-embed.js
+++ b/src/presenters/featured-embed.js
@@ -8,12 +8,12 @@ import Link, { WrappingLink } from 'Components/link';
 import Button from 'Components/buttons/button';
 
 const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) => (
-    <div className="featured-embed">
-      <div className="mask-container">
-        <WrappingLink href={`culture${blogUrl}`}>
-          <MaskImage maskClass={mask} src={image} />
-        </WrappingLink>
-      </div>
+  <div className="featured-embed">
+    <div className="mask-container">
+      <WrappingLink href={`culture${blogUrl}`}>
+        <MaskImage maskClass={mask} src={image} />
+      </WrappingLink>
+    </div>
 
     <div className="content" style={{ backgroundColor: color }}>
       <Link to={`culture${blogUrl}`}>
@@ -21,8 +21,12 @@ const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) 
           <Heading tagName="h2">{title}</Heading>
           {/* eslint-disable-next-line react/no-danger */}
           <div dangerouslySetInnerHTML={{ __html: body }} />
-          <Button decorative size="small">Learn More <span aria-hidden="true">→</span></Button>
-        </div>      
+          <div className="button-wrap">
+            <Button decorative size="small">
+              Learn More <span aria-hidden="true">→</span>
+            </Button>
+          </div>
+        </div>
       </Link>
       <div className="glitch-embed-wrap">
         <Embed domain={appDomain} />

--- a/src/presenters/featured-embed.js
+++ b/src/presenters/featured-embed.js
@@ -4,27 +4,26 @@ import PropTypes from 'prop-types';
 import Heading from 'Components/text/heading';
 import Embed from 'Components/project/embed';
 import MaskImage from 'Components/images/mask-image';
-import Link from 'Components/link';
+import Link, { WrappingLink } from 'Components/link';
+import Button from 'Components/buttons/button';
 
 const FeaturedEmbed = ({ image, mask, title, appDomain, blogUrl, body, color }) => (
-  <div className="featured-embed">
-    <div className="mask-container">
-      <Link to={`culture${blogUrl}`}>
-        <MaskImage maskClass={mask} src={image} />
-      </Link>
-    </div>
+    <div className="featured-embed">
+      <div className="mask-container">
+        <WrappingLink href={`culture${blogUrl}`}>
+          <MaskImage maskClass={mask} src={image} />
+        </WrappingLink>
+      </div>
 
     <div className="content" style={{ backgroundColor: color }}>
-      <div className="description">
-        <Link to={`culture${blogUrl}`}>
+      <Link to={`culture${blogUrl}`}>
+        <div className="description">
           <Heading tagName="h2">{title}</Heading>
-        </Link>
-        {/* eslint-disable-next-line react/no-danger */}
-        <p dangerouslySetInnerHTML={{ __html: body }} />
-        <Link to={`culture${blogUrl}`} className="learn-more">
-          <button className="button-small">Learn More →</button>
-        </Link>
-      </div>
+          {/* eslint-disable-next-line react/no-danger */}
+          <div dangerouslySetInnerHTML={{ __html: body }} />
+          <Button decorative size="small">Learn More <span aria-hidden="true">→</span></Button>
+        </div>      
+      </Link>
       <div className="glitch-embed-wrap">
         <Embed domain={appDomain} />
       </div>

--- a/styles/includes/featured.styl
+++ b/styles/includes/featured.styl
@@ -81,9 +81,12 @@
         
 // featured embed section 
 .featured-embed
+  .button-wrap > *
+    margin-bottom: 0 !important
   a
     color: black
-    font-weight: bold
+    &:hover
+      text-decoration: none
   .learn-more
     font-size: smaller
   .mask-container


### PR DESCRIPTION
## Links
* Remix link: https://chip-petalite.glitch.me/
* Manuscript link: https://glitch.manuscript.com/f/cases/3328728/

## GIF/Screenshots:
<img width="488" alt="Screen Shot 2019-06-13 at 11 00 38 AM" src="https://user-images.githubusercontent.com/938722/59443759-81141d00-8dca-11e9-9426-f866821d9865.png">

## Changes:
* make (purely decorative) linked image clickable but non-tabbable
* make the whole embed text a single link