### PR TITLE
automatic-hacksaw: fix team-user-info avatar link and hover state

### DIFF
--- a/src/components/team-users/team-user-info.js
+++ b/src/components/team-users/team-user-info.js
@@ -10,7 +10,6 @@ import Thanks from 'Components/thanks';
 import {
   PopoverContainer,
   PopoverDialog,
-  PopoverWithButton,
   PopoverActions,
   PopoverInfo,
   MultiPopover,
@@ -216,7 +215,7 @@ const TeamUserPop = ({ team, user, removeUserFromTeam, updateUserPermissions }) 
     <PopoverContainer>
       {({ visible, togglePopover, toggleAndCall }) => (
         <div style={{ position: 'relative' }}>
-          <TransparentButton onClick={togglePopover}>        
+          <TransparentButton onClick={togglePopover}>
             <UserAvatar user={user} suffix={adminStatusDisplay(team.adminIds, user)} withinButton />
           </TransparentButton>
 

--- a/src/components/team-users/team-user-info.js
+++ b/src/components/team-users/team-user-info.js
@@ -8,6 +8,7 @@ import { UserAvatar, ProjectAvatar } from 'Components/images/avatar';
 import { UserLink } from 'Components/link';
 import Thanks from 'Components/thanks';
 import {
+  PopoverContainer,
   PopoverDialog,
   PopoverWithButton,
   PopoverActions,
@@ -17,6 +18,7 @@ import {
   ActionDescription,
 } from 'Components/popover';
 import Button from 'Components/buttons/button';
+import TransparentButton from 'Components/buttons/transparent-button';
 import Emoji from 'Components/images/emoji';
 import Loader from 'Components/loader';
 
@@ -132,7 +134,9 @@ const TeamUserInfo = ({ user, team, onMakeAdmin, onRemoveAdmin, onRemoveUser }) 
     <PopoverDialog align="left">
       <PopoverInfo>
         <div className={styles.userProfile}>
-          <UserLink user={user}><UserAvatar user={user} /></UserLink>
+          <UserLink user={user}>
+            <UserAvatar user={user} />
+          </UserLink>
           <div className={styles.userInfo}>
             <div className={styles.userName}>{user.name || 'Anonymous'}</div>
             {user.login && <div className={styles.userLogin}>@{user.login}</div>}
@@ -209,28 +213,33 @@ const TeamUserPop = ({ team, user, removeUserFromTeam, updateUserPermissions }) 
   const onMakeAdmin = useTrackedFunc(() => updateUserPermissions(user.id, ADMIN_ACCESS_LEVEL), 'Make an Admin clicked');
 
   return (
-    <PopoverWithButton
-      buttonProps={{ type: 'transparent' }}
-      buttonText={<UserAvatar user={user} suffix={adminStatusDisplay(team.adminIds, user)} withinButton />}
-    >
-      {({ togglePopover, toggleAndCall }) => (
-        <MultiPopover
-          views={{
-            remove: () => <TeamUserRemovePop user={user} userTeamProjects={userTeamProjects} onRemoveUser={toggleAndCall(removeUser)} />,
-          }}
-        >
-          {(showViews) => (
-            <TeamUserInfo
-              user={user}
-              team={team}
-              onRemoveAdmin={toggleAndCall(onRemoveAdmin)}
-              onMakeAdmin={toggleAndCall(onMakeAdmin)}
-              onRemoveUser={() => onOrShowRemoveUser(showViews.remove, togglePopover)}
-            />
+    <PopoverContainer>
+      {({ visible, togglePopover, toggleAndCall }) => (
+        <div style={{ position: 'relative' }}>
+          <TransparentButton onClick={togglePopover}>        
+            <UserAvatar user={user} suffix={adminStatusDisplay(team.adminIds, user)} withinButton />
+          </TransparentButton>
+
+          {visible && (
+            <MultiPopover
+              views={{
+                remove: () => <TeamUserRemovePop user={user} userTeamProjects={userTeamProjects} onRemoveUser={toggleAndCall(removeUser)} />,
+              }}
+            >
+              {(showViews) => (
+                <TeamUserInfo
+                  user={user}
+                  team={team}
+                  onRemoveAdmin={toggleAndCall(onRemoveAdmin)}
+                  onMakeAdmin={toggleAndCall(onMakeAdmin)}
+                  onRemoveUser={() => onOrShowRemoveUser(showViews.remove, togglePopover)}
+                />
+              )}
+            </MultiPopover>
           )}
-        </MultiPopover>
+        </div>
       )}
-    </PopoverWithButton>
+    </PopoverContainer>
   );
 };
 

--- a/src/components/team-users/team-user-info.js
+++ b/src/components/team-users/team-user-info.js
@@ -5,6 +5,7 @@ import { getDisplayName } from 'Models/user';
 import { userIsTeamAdmin, userIsOnlyTeamAdmin } from 'Models/team';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
 import { UserAvatar, ProjectAvatar } from 'Components/images/avatar';
+import { UserLink } from 'Components/link';
 import Thanks from 'Components/thanks';
 import {
   PopoverDialog,
@@ -131,7 +132,7 @@ const TeamUserInfo = ({ user, team, onMakeAdmin, onRemoveAdmin, onRemoveUser }) 
     <PopoverDialog align="left">
       <PopoverInfo>
         <div className={styles.userProfile}>
-          <UserAvatar user={user} />
+          <UserLink user={user}><UserAvatar user={user} /></UserLink>
           <div className={styles.userInfo}>
             <div className={styles.userName}>{user.name || 'Anonymous'}</div>
             {user.login && <div className={styles.userLogin}>@{user.login}</div>}
@@ -209,7 +210,7 @@ const TeamUserPop = ({ team, user, removeUserFromTeam, updateUserPermissions }) 
 
   return (
     <PopoverWithButton
-      buttonProps={{ type: 'dropDown' }}
+      buttonProps={{ type: 'transparent' }}
       buttonText={<UserAvatar user={user} suffix={adminStatusDisplay(team.adminIds, user)} withinButton />}
     >
       {({ togglePopover, toggleAndCall }) => (


### PR DESCRIPTION
## Links
* [automatic-hacksaw.glitch.me](https://automatic-hacksaw.glitch.me)
* [Manuscript: Out-of-place gray background when hovering team member avatars](https://glitch.fogbugz.com/f/cases/3328732/)
* [Meg's report that user avatars in team-user-info-pop no longer link to user pages](https://fogcreek.slack.com/archives/CB4EHAJ2J/p1560457647138800)

## GIF/Screenshots:
**Before**
![team-avatar-hover](https://user-images.githubusercontent.com/7584833/59468228-7de75400-8dff-11e9-9910-075cf22c8538.gif)

## Changes:
* Uses a `<TransparentButton>` to get rid of hover background on avatar button
* Wrap `<UserAvatar>` in a `<UserLink>` 

## How To Test:
* Hover a user avatar on a team listing. There should not be a background.
* Click the avatar to open the pop. Click the avatar inside the pop. It should take you to their user page.