### PR TITLE
Nova-chance: Fix a bug with project restarts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -155,6 +155,7 @@ module.exports = smp.wrap({
     new StatsPlugin('stats.json', {
       all: false,
       assets: true,
+      cachedAssets: true,
       entrypoints: true,
       hash: true,
       publicPath: true,


### PR DESCRIPTION
stats.json only includes the assets from the last build by default, so if you do an incremental build then restart the project it'll lose some of the built js. This tells it to include unchanged output in stats.json

Test by waiting for a build to finish, making a old styles change (so it does a partial rebuild) then refresh in the console and browser. On other remixes it will fail to load if the site isn't cached, here it will load