### PR TITLE
chalk-laugh: refactor Text component

### DIFF
--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -71,8 +71,6 @@
     padding: 18px 18px 12px
     border-bottom-right-radius: 5px
     border-bottom-left-radius: 5px
-    p
-      margin: 0
 .projectsList
   --min-width: 180px    
   

--- a/src/components/collection/collection.styl
+++ b/src/components/collection/collection.styl
@@ -1,4 +1,4 @@
 .collectionProjectCount
-  margin: 1em 0
+  margin: 25px 0 1em 0
   font-size: 14px
   font-weight: 600

--- a/src/components/collection/collection.styl
+++ b/src/components/collection/collection.styl
@@ -1,0 +1,4 @@
+.collectionProjectCount
+  margin: 1em 0
+  font-size: 14px
+  font-weight: 600

--- a/src/components/collection/collection.styl
+++ b/src/components/collection/collection.styl
@@ -1,4 +1,2 @@
 .collectionProjectCount
   margin: 25px 0 1em 0
-  font-size: 14px
-  font-weight: 600

--- a/src/components/errors/not-found.js
+++ b/src/components/errors/not-found.js
@@ -9,7 +9,7 @@ const needle = 'https://cdn.glitch.com/bc50f686-4c0a-4e20-852f-3999b29e8092%2Fne
 
 const NotFound = ({ name }) => (
   <section>
-    <Text>We didn't find {name}</Text>
+    <Text defaultMargin>We didn't find {name}</Text>
     <div className={styles.errorImage}>
       <img className={styles.compass} src={compass} alt="" />
       <img className={styles.needle} src={needle} alt="" />

--- a/src/components/new-stuff/new-stuff-article.js
+++ b/src/components/new-stuff/new-stuff-article.js
@@ -13,7 +13,7 @@ const NewStuffArticle = ({ title, body, link }) => (
     <div className={styles.body}>
       <Markdown>{body}</Markdown>
     </div>
-    {!link && (
+    {!!link && (
       <Text defaultMargin>
         <Link to={link}>
           Read the blog post →

--- a/src/components/new-stuff/new-stuff-article.js
+++ b/src/components/new-stuff/new-stuff-article.js
@@ -13,7 +13,7 @@ const NewStuffArticle = ({ title, body, link }) => (
     <div className={styles.body}>
       <Markdown>{body}</Markdown>
     </div>
-    {!!link && (
+    {!link && (
       <Text defaultMargin>
         <Link to={link}>
           Read the blog post →

--- a/src/components/new-stuff/new-stuff-article.js
+++ b/src/components/new-stuff/new-stuff-article.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Link from '../link';
-import Markdown from '../text/markdown';
-import Text from '../text/text';
+import Link from 'Components/link';
+import Markdown from 'Components/text/markdown';
+import Text from 'Components/text/text';
 
 import styles from './new-stuff-article.styl';
 
@@ -14,7 +14,7 @@ const NewStuffArticle = ({ title, body, link }) => (
       <Markdown>{body}</Markdown>
     </div>
     {!!link && (
-      <Text>
+      <Text defaultMargin>
         <Link to={link}>
           Read the blog post →
         </Link>

--- a/src/components/notification/index.js
+++ b/src/components/notification/index.js
@@ -38,7 +38,7 @@ Notification.defaultProps = {
 
 export const AddProjectToCollectionMsg = ({ projectDomain, collectionName, url }) => (
   <>
-    <Text>
+    <Text fontSize='12px'>
       {`Added ${projectDomain} `}
       {collectionName && `to collection ${collectionName}`}
     </Text>

--- a/src/components/notification/index.js
+++ b/src/components/notification/index.js
@@ -38,7 +38,7 @@ Notification.defaultProps = {
 
 export const AddProjectToCollectionMsg = ({ projectDomain, collectionName, url }) => (
   <>
-    <Text fontSize='12px'>
+    <Text fontSize="12px">
       {`Added ${projectDomain} `}
       {collectionName && `to collection ${collectionName}`}
     </Text>

--- a/src/components/notification/styles.styl
+++ b/src/components/notification/styles.styl
@@ -17,8 +17,6 @@
   animation-timing-function: ease-out
   margin-bottom: 5px
   line-height: 16px
-  p
-    margin: 0
   hr
     opacity: 0.5
     height: 1px

--- a/src/components/project/project-item-small.js
+++ b/src/components/project/project-item-small.js
@@ -22,8 +22,8 @@ const ProjectItemSmall = ({ project }) => (
         <span className={styles.avatarWrap}>
           <ProfileAvatar project={project} />
         </span>
-        <Text>
-          <span className={styles.projectName}>{project.domain}</span>{' '}
+        <Text className={styles.projectName}>
+          {project.domain}
         </Text>
         {project.private && (
           <Badge type="private" aria-label="private">

--- a/src/components/project/project-item-small.js
+++ b/src/components/project/project-item-small.js
@@ -22,9 +22,7 @@ const ProjectItemSmall = ({ project }) => (
         <span className={styles.avatarWrap}>
           <ProfileAvatar project={project} />
         </span>
-        <Text className={styles.projectName}>
-          {project.domain}
-        </Text>
+        <Text className={styles.projectName}>{project.domain}</Text>
         {project.private && (
           <Badge type="private" aria-label="private">
             {' '}

--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -29,7 +29,6 @@
     overflow: hidden
   p
     margin-top: 2px
-    margin-bottom: 0
     text-overflow: ellipsis
     overflow: hidden
     white-space: nowrap

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -8,10 +8,11 @@ const cx = classNames.bind(styles);
 /**
  * Text Component
  */
-const Text = ({ children, defaultMargin }) => {
-  const className = cx({
+const Text = ({ children, className, defaultMargin }) => {
+  className = cx({
     p: true,
     defaultMargin,
+    {className,
   });
   
   return <p className={className}>{children}</p>;

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -8,13 +8,14 @@ const cx = classNames.bind(styles);
 /**
  * Text Component
  */
-const Text = ({ children, className, defaultMargin }) => {
+const Text = ({ children, className, fontSize, defaultMargin }) => {
   const textClassName = cx({
     p: true,
     defaultMargin,
   });
   
-  return <p className={`${className || ''} ${textClassName}`}>{children}</p>;
+  // classNames(styles.projectsContainer, styles.empty)
+  return <p style={{ '--fontSize': fontSize }} className={`${className || ''} ${textClassName}`}>{children}</p>;
 };
 
 Text.propTypes = {
@@ -25,6 +26,7 @@ Text.propTypes = {
 };
 
 Text.defaultProps = {
+  fontSize: 'inherit',
   defaultMargin: false,
 }
 

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -5,7 +5,7 @@ import styles from './text.styl';
 /**
  * Text Component
  */
-const Text = ({ children }) => <p className={styles.p}>{children}</p>;
+const Text = ({ children, defaultMargin }) => <p className={styles.p}>{children}</p>;
 
 Text.propTypes = {
   /** element(s) to display in the tag */

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -9,13 +9,12 @@ const cx = classNames.bind(styles);
  * Text Component
  */
 const Text = ({ children, className, defaultMargin }) => {
-  className = cx({
+  const textClassName = cx({
     p: true,
     defaultMargin,
-    {className,
   });
   
-  return <p className={className}>{children}</p>;
+  return <p className={`${className || ''} ${textClassName}`}>{children}</p>;
 };
 
 Text.propTypes = {

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -15,7 +15,8 @@ const Text = ({ children, className, size, weight, defaultMargin }) => {
   });
   
   // classNames(styles.projectsContainer, styles.empty)
-  return <p style={{ '--size': size, '--weight': weight }} className={`${className || ''} ${textClassName}`}>{children}</p>;
+  // `${className || ''} ${textClassName}`
+  return <p style={{ '--size': size, '--weight': weight }} className={classNames(textClassName, className)}>{children}</p>;
 };
 
 Text.propTypes = {

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -1,15 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 import styles from './text.styl';
+
+const cx = classNames.bind(styles);
 
 /**
  * Text Component
  */
-const Text = ({ children, defaultMargin }) => <p className={styles.p}>{children}</p>;
+const Text = ({ children, defaultMargin }) => {
+  const className = cx({
+    p: true,
+    defaultMargin,
+  });
+  
+  return <p className={className}>{children}</p>;
+};
 
 Text.propTypes = {
   /** element(s) to display in the tag */
   children: PropTypes.node.isRequired,
+  /** use the browser-defined paragraph margins? */
+  defaultMargin: PropTypes.bool,
 };
+
+Text.defaultProps = {
+  defaultMargin: false,
+}
 
 export default Text;

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -13,15 +13,21 @@ const Text = ({ children, className, size, weight, defaultMargin }) => {
     p: true,
     defaultMargin,
   });
-  
-  // classNames(styles.projectsContainer, styles.empty)
-  // `${className || ''} ${textClassName}`
-  return <p style={{ '--size': size, '--weight': weight }} className={classNames(textClassName, className)}>{children}</p>;
+
+  return (
+    <p style={{ '--size': size, '--weight': weight }} className={classNames(textClassName, className)}>
+      {children}
+    </p>
+  );
 };
 
 Text.propTypes = {
   /** element(s) to display in the tag */
   children: PropTypes.node.isRequired,
+  /** font-size */
+  size: PropTypes.string,
+  /** font-weight */
+  weight: PropTypes.string,
   /** use the browser-defined paragraph margins? */
   defaultMargin: PropTypes.bool,
 };
@@ -30,6 +36,6 @@ Text.defaultProps = {
   size: 'inherit',
   weight: '400',
   defaultMargin: false,
-}
+};
 
 export default Text;

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -8,14 +8,14 @@ const cx = classNames.bind(styles);
 /**
  * Text Component
  */
-const Text = ({ children, className, fontSize, defaultMargin }) => {
+const Text = ({ children, className, size, weight, defaultMargin }) => {
   const textClassName = cx({
     p: true,
     defaultMargin,
   });
   
   // classNames(styles.projectsContainer, styles.empty)
-  return <p style={{ '--fontSize': fontSize }} className={`${className || ''} ${textClassName}`}>{children}</p>;
+  return <p style={{ '--size': size, '--weight': weight }} className={`${className || ''} ${textClassName}`}>{children}</p>;
 };
 
 Text.propTypes = {
@@ -26,7 +26,8 @@ Text.propTypes = {
 };
 
 Text.defaultProps = {
-  fontSize: 'inherit',
+  size: 'inherit',
+  weight: '400',
   defaultMargin: false,
 }
 

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -5,7 +5,6 @@
   font-size: var(--size);
   font-weight: var(--weight);
   line-height: 1.35
-  line-height: 20px
   margin: 0
   + .p
     margin-top: 1em

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -3,3 +3,7 @@
 .p
   font-family: sansserif
   line-height: 20px
+  margin: 0
+
+.defaultMargin
+  margin: initial

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -4,6 +4,7 @@
   font-family: sansserif
   font-size: var(--size);
   font-weight: var(--weight);
+  line-height: 1.35
   line-height: 20px
   margin: 0
   + .p

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -6,3 +6,5 @@
   margin: 0
   + .p
     margin-bottom: 1em
+.defaultMargin
+  margin: 1em 0

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -2,7 +2,8 @@
 
 .p
   font-family: sansserif
-  font-size: var(--fontSize);
+  font-size: var(--size);
+  font-weight: var(--weight);
   line-height: 20px
   margin: 0
   + .p

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -2,6 +2,7 @@
 
 .p
   font-family: sansserif
+  font-size: var(--fontSize);
   line-height: 20px
   margin: 0
   + .p

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -4,6 +4,5 @@
   font-family: sansserif
   line-height: 20px
   margin: 0
-
-.defaultMargin
-  margin: initial
+  + .p
+    margin-bottom: 1em

--- a/src/components/text/text.styl
+++ b/src/components/text/text.styl
@@ -7,6 +7,6 @@
   line-height: 20px
   margin: 0
   + .p
-    margin-bottom: 1em
+    margin-top: 1em
 .defaultMargin
   margin: 1em 0

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -27,6 +27,8 @@ import { useCurrentUser } from 'State/current-user';
 import { useCollectionEditor, userOrTeamIsAuthor } from 'State/collection';
 import { getSingleItem, getAllPages } from 'Shared/api';
 
+import styles from 'Components/collection/collection.styl';
+
 function DeleteCollectionBtn({ collection, deleteCollection }) {
   const [done, setDone] = useState(false);
   if (done) {
@@ -105,11 +107,9 @@ const CollectionPageContents = ({ collection: initialCollection }) => {
               />
             </div>
 
-            <div className="collection-project-count">
-              <Text>
-                <Pluralize count={collection.projects.length} singular="Project" />
-              </Text>
-            </div>
+            <Text className={styles.collectionProjectCount}>
+              <Pluralize count={collection.projects.length} singular="Project" />
+            </Text>
 
             {currentUserIsAuthor && <EditCollectionColor update={funcs.updateColor} initialColor={collection.coverColor} />}
           </header>

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -107,7 +107,7 @@ const CollectionPageContents = ({ collection: initialCollection }) => {
               />
             </div>
 
-            <Text className={styles.collectionProjectCount}>
+            <Text size="14px" weight="600" className={styles.collectionProjectCount}>
               <Pluralize count={collection.projects.length} singular="Project" />
             </Text>
 

--- a/src/presenters/pages/index.js
+++ b/src/presenters/pages/index.js
@@ -81,7 +81,7 @@ const WhatIsGlitch = () => {
 
 const MadeInGlitch = () => (
   <section className="made-in-glitch">
-    <Text>Of course, this site was made on Glitch too</Text>
+    <Text defaultMargin>Of course, this site was made on Glitch too</Text>
     <Button href={getEditorUrl('community')} emoji="carpStreamer">
       View Source
     </Button>

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -65,7 +65,7 @@ const ProjectPals = () => (
 
 const TeamMarketing = () => (
   <section className={styles.teamMarketing}>
-    <Text>
+    <Text defaultMargin>
       <img
         className={styles.forPlatformsIcon}
         src="https://cdn.glitch.com/be1ad2d2-68ab-404a-82f4-6d8e98d28d93%2Ffor-platforms-icon.svg?1506442305188"
@@ -99,7 +99,7 @@ const useTeamNameConflictWarning = (team) => {
   const { currentUser } = useCurrentUser();
   const { createNotification } = useNotifications();
   useEffect(() => {
-    if (teamConflictsWithUser(team, currentUser)) {
+    if (!teamConflictsWithUser(team, currentUser)) {
       const notification = createNotification(<NameConflictWarning id={currentUser.id} />, { persistent: true });
       return () => {
         notification.removeNotification();

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -99,7 +99,7 @@ const useTeamNameConflictWarning = (team) => {
   const { currentUser } = useCurrentUser();
   const { createNotification } = useNotifications();
   useEffect(() => {
-    if (!teamConflictsWithUser(team, currentUser)) {
+    if (teamConflictsWithUser(team, currentUser)) {
       const notification = createNotification(<NameConflictWarning id={currentUser.id} />, { persistent: true });
       return () => {
         notification.removeNotification();

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -49,7 +49,7 @@ const Beta = () => (
     <img src="https://cdn.glitch.com/0c3ba0da-dac8-4904-bb5e-e1c7acc378a2%2Fbeta-flag.svg?1541448893958" alt="" />
     <div>
       <Heading tagName="h4">Teams are in beta</Heading>
-      <Text>Learn More</Text>
+      <Text fontSize="smaller">Learn More</Text>
     </div>
   </a>
 );

--- a/src/presenters/pages/team.styl
+++ b/src/presenters/pages/team.styl
@@ -36,7 +36,6 @@
     margin: 2px 0
   p
     margin-top: -5px
-    margin-bottom: 0px 
     font-size: smaller
   &:hover
     text-decoration: underline

--- a/src/presenters/pages/team.styl
+++ b/src/presenters/pages/team.styl
@@ -36,7 +36,6 @@
     margin: 2px 0
   p
     margin-top: -5px
-    font-size: smaller
   &:hover
     text-decoration: underline
     

--- a/src/presenters/pages/vscode-auth.js
+++ b/src/presenters/pages/vscode-auth.js
@@ -28,7 +28,7 @@ const VSCodeAuth = ({ insiders, openProject }) => {
 
   return (
     <div className={styles.content}>
-      <Text>{isSignedIn ? redirectMessage : signInMessage}</Text>
+      <Text defaultMargin>{isSignedIn ? redirectMessage : signInMessage}</Text>
       {!isSignedIn &&
         <PopoverContainer>
           {() => <SignInPop align="none" />}

--- a/src/state/offline-notice.js
+++ b/src/state/offline-notice.js
@@ -29,7 +29,7 @@ const OfflineNotice = () => {
     };
   }, []);
 
-  if (!online) {
+  if (online) {
     return <PersistentNotification>It looks like you're offline</PersistentNotification>;
   }
   return null;

--- a/src/state/offline-notice.js
+++ b/src/state/offline-notice.js
@@ -29,7 +29,7 @@ const OfflineNotice = () => {
     };
   }, []);
 
-  if (online) {
+  if (!online) {
     return <PersistentNotification>It looks like you're offline</PersistentNotification>;
   }
   return null;

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -64,7 +64,7 @@
     > * p
       margin: 0 !important
   .collection-project-count
-    margin: 25px 0px 0px
+    margin: 25px 0px 25px
     font-size: 14px
     font-weight: 600
   .edit-collection-color-btn
@@ -95,6 +95,8 @@
   .project-options-pop
     width: 200px
   .empty-collection-hint
+    display: flex
+    align-items: center
     border-radius: 4px
     margin: 25px 16px
     img

--- a/styles/pages/collection.styl
+++ b/styles/pages/collection.styl
@@ -63,10 +63,6 @@
       margin: 0
     > * p
       margin: 0 !important
-  .collection-project-count
-    margin: 25px 0px 25px
-    font-size: 14px
-    font-weight: 600
   .edit-collection-color-btn
     margin-top: 25px
   .collection-url


### PR DESCRIPTION
## Links
* [chalk-laugh.glitch.me](https://chalk-laugh.glitch.me)
* [Manuscript](https://glitch.fogbugz.com/f/cases/3328263/Text-component-margins-and-font-size-adjustments)

<div style="display: flex">
  <img src="https://user-images.githubusercontent.com/7584833/59718590-78678080-91e8-11e9-9e41-84bcdbe4b8f9.png"/>
  <img src="https://user-images.githubusercontent.com/7584833/59718591-79001700-91e8-11e9-86b0-178f40925034.png"/>
<img src="https://user-images.githubusercontent.com/7584833/59718593-79001700-91e8-11e9-8767-92e2664de63e.png" />
<img src="https://user-images.githubusercontent.com/7584833/59718595-79001700-91e8-11e9-88e2-809b192bb3a3.png "/>
</div>

## Changes:
* Add `size`, `weight`, `defaultMargin` props to Text component
* Allow Text component to accept `className`
* Update all instances of Text component to take advantage of these updates

## How To Test:
Try out a bunch of places where the Text component is used:
- Project count on [collection page](https://chalk-laugh.glitch.me/@taravancil/glitch)
- [Error page](https://chalk-laugh.glitch.me/404)
- [Home page "of course this site was made on glitch too"](https://chalk-laugh.glitch.me)

## Feedback I'm looking for:
- Instead of the `defaultMargin` prop, would we prefer `marginTop` and `marginBottom` props? This would eliminate some cases where we're using a `className` just to specify a margin
- As far as I can tell, there's nowhere the `.p + .p` selector is applied. Do we want to eliminate that and just use margin props? ^