### PR TITLE
sedate-pancreas-1: add polyfill for intersection observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "webpack-cli": "^3.3.0",
     "webpack-dev-middleware": "^3.6.2",
     "winston": "^3.2.1",
-    "wcag-contrast": "^2.1.1"
+    "wcag-contrast": "^2.1.1",
+    "intersection-observer": "^0.7.0"
   },
   "engines": {
     "node": "10.x"

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -49,6 +49,7 @@ dependencies:
   group-by-time: 1.0.0
   helmet: 3.16.0
   html-truncate: 1.2.2
+  intersection-observer: 0.7.0
   lodash: 4.17.11
   lodash-webpack-plugin: 0.11.5
   markdown-it: 8.4.2
@@ -8092,6 +8093,10 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+  /intersection-observer/0.7.0:
+    dev: false
+    resolution:
+      integrity: sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
   /invariant/2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -13881,6 +13886,7 @@ specifiers:
   group-by-time: ^1.0.0
   helmet: ^3.16.0
   html-truncate: ^1.2.2
+  intersection-observer: ^0.7.0
   lodash: ^4.17.11
   lodash-webpack-plugin: ^0.11.5
   markdown-it: ^8.4.2

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -5,6 +5,7 @@
 import 'details-element-polyfill';
 import 'url-search-params-polyfill';
 import 'intersection-observer';
+
 if (!String.prototype.trimStart) {
   String.prototype.trimStart = String.prototype.trimLeft;
 }

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-extend-native */
 import 'details-element-polyfill';
 import 'url-search-params-polyfill';
-
+import 'intersection-observer';
 if (!String.prototype.trimStart) {
   String.prototype.trimStart = String.prototype.trimLeft;
 }


### PR DESCRIPTION
## Links
* https://sedate-pancreas-1.glitch.me/
* https://glitch.manuscript.com/f/cases/3328763/Teams-pages-won-t-load-in-Safari-desktop-or-mobile-Intersection-Observer-API-not-supported-in-safari-before-March-2019

## Changes:
* adds a polyfill for intersection observer, should resolve this issue from sentry: https://sentry.io/organizations/fog-creek-software/issues/1076155283/?project=1246508&referrer=slack

## How To Test:
* use browserstack to open a version of safari that is older than 12.1 (which was released back in march)
* notice on glitch.com we show an error but on https://sedate-pancreas-1.glitch.me/ the site loads

