### PR TITLE
Chestnut cappelletti 1: Add OAuth page back

### DIFF
--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -9,6 +9,7 @@ import { useCurrentUser } from '../../state/current-user';
 
 import IndexPage from './index';
 import { FacebookLoginPage, GitHubLoginPage, GoogleLoginPage, SlackLoginPage, EmailTokenLoginPage } from './login';
+import OauthSignIn from './signin';
 import JoinTeamPage from './join-team';
 import QuestionsPage from './questions';
 import ProjectPage from './project';
@@ -96,6 +97,8 @@ const Router = () => (
         exact
         render={({ location }) => <EmailTokenLoginPage key={location.key} token={parse(location.search, 'token')} />}
       />
+
+      <Route path="/signin" exact render={({ location }) => <OauthSignIn key={location.key} />} />
 
       <Route path="/join/@:teamUrl/:joinToken" exact render={({ match }) => <JoinTeamPage key={location.key} {...match.params} />} />
 

--- a/src/presenters/pages/signin.js
+++ b/src/presenters/pages/signin.js
@@ -1,200 +1,27 @@
 /**
  * Login page for Glitch OAuth
  *
+ * This is considered a proof of concept for OAuth.
+ * It currently reuses Components/sign-in-pop to handle sign-in.
+ *
+ * IMPORTANT: This allows Discourse users to sign in to support with their Glitch accounts.
+ *
  * Login via email only
  *
  * TODO: Allow login via username/password when that becomes available
- *
- * IMPORTANT: This is considered a proof of concept for OAuth. It is nearly a direct
- * copy of /pop-overs/sign-in-pop.
  */
 
 /* globals API_URL */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import { captureException } from 'Utils/sentry';
-import { useAPI } from 'State/api';
+
+import PopoverContainer from 'Components/popover/container';
+import { SignInPopBase as SignInPop } from 'Components/sign-in-pop';
 import { useCurrentUser } from 'State/current-user';
-import Notification from 'Components/notification';
-import { PopoverWithButton, MultiPopover, MultiPopoverTitle, PopoverDialog, PopoverActions, PopoverInfo } from 'Components/popover';
 
-class SignIn extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      email: '',
-      done: false,
-      error: false,
-    };
-    this.onChange = this.onChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-  }
+import styles from './signin.styl';
 
-  onChange(e) {
-    this.setState({ email: e.target.value });
-  }
-
-  async onSubmit(e) {
-    e.preventDefault();
-    this.setState({ done: true });
-    try {
-      await this.props.api.post('/email/sendLoginEmail', {
-        emailAddress: this.state.email,
-      });
-      this.setState({ error: false });
-    } catch (error) {
-      captureException(error);
-      this.setState({ error: true });
-    }
-  }
-
-  render() {
-    const isEnabled = this.state.email.length > 0;
-    return (
-      <NestedPopover alternateContent={() => <SignInWithConsumer {...this.props} />} startAlternateVisible={false}>
-        {(showCodeLogin) => (
-          <dialog className="pop-over sign-in-pop">
-            <NestedPopoverTitle>
-              Email Sign In <span className="emoji email" />
-            </NestedPopoverTitle>
-            <section className="pop-over-actions first-section">
-              {!this.state.done && (
-                <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
-                  <input value={this.state.email} onChange={this.onChange} className="pop-over-input" type="email" placeholder="new@user.com" />
-                  <button style={{ marginTop: 10 }} className="button-small button-link" disabled={!isEnabled}>
-                    Send Link
-                  </button>
-                </form>
-              )}
-              {this.state.done && !this.state.error && (
-                <>
-                  <Notification persistent inline type="success">
-                    Almost Done
-                  </Notification>
-                  <div>Finish signing in from the email sent to {this.state.email}.</div>
-                </>
-              )}
-              {this.state.done && this.state.error && (
-                <>
-                  <Notification persistent inline type="error">
-                    Error
-                  </Notification>
-                  <div>Something went wrong, email not sent.</div>
-                </>
-              )}
-            </section>
-            {this.state.done && !this.state.error && (
-              <SignInCodeSection
-                onClick={() => {
-                  showCodeLogin(this.props.api);
-                }}
-              />
-            )}
-          </dialog>
-        )}
-      </NestedPopover>
-    );
-  }
-}
-
-class SignInCodeHandler extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      code: '',
-      done: false,
-      error: false,
-    };
-    this.onChange = this.onChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-  }
-
-  onChange(e) {
-    this.setState({ code: e.target.value });
-  }
-
-  async onSubmit(e) {
-    e.preventDefault();
-    this.setState({ done: true });
-    try {
-      const { data } = await this.props.api.post(`/auth/email/${this.state.code}`);
-      this.props.setUser(data);
-      this.setState({ error: false });
-    } catch (error) {
-      captureException(error);
-      this.setState({ error: true });
-    }
-  }
-
-  render() {
-    const isEnabled = this.state.code.length > 0;
-    return (
-      <dialog className="pop-over sign-in-pop middle">
-        <NestedPopoverTitle>Use a sign in code</NestedPopoverTitle>
-        <section className="pop-over-actions first-section">
-          {!this.state.done && (
-            <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
-              Paste your temporary sign in code below
-              <input value={this.state.code} onChange={this.onChange} className="pop-over-input" type="text" placeholder="cute-unique-cosmos" />
-              <button style={{ marginTop: 10 }} className="button-small button-link" disabled={!isEnabled}>
-                Sign In
-              </button>
-            </form>
-          )}
-          {this.state.done && !this.state.error && (
-            <>
-              <Notification persistent type="success">
-                Success!
-              </Notification>
-            </>
-          )}
-          {this.state.done && this.state.error && (
-            <>
-              <Notification persistent type="error">
-                Error
-              </Notification>
-              <div>Code not found or already used. Try signing in with email.</div>
-            </>
-          )}
-        </section>
-      </dialog>
-    );
-  }
-}
-
-const SignInWithConsumer = (props) => {
-  const { login } = useCurrentUser();
-  return <SignInCodeHandler setUser={login} {...props} />;
-};
-
-const EmailSignInButton = ({ onClick }) => (
-  <button
-    className="button button-small button-link has-emoji"
-    onClick={() => {
-      onClick();
-    }}
-  >
-    Sign in with Email <span className="emoji email" />
-  </button>
-);
-EmailSignInButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
-};
-
-const SignInCodeSection = ({ onClick }) => (
-  <section className="pop-over-actions last-section pop-over-info">
-    <button className="button-small button-tertiary button-on-secondary-background" onClick={onClick}>
-      <span>Use a sign in code</span>
-    </button>
-  </section>
-);
-SignInCodeSection.propTypes = {
-  onClick: PropTypes.func.isRequired,
-};
-
-const SignInPop = () => {
-  const api = useAPI();
+const SignInPage = () => {
   const { currentUser } = useCurrentUser();
   const { persistentToken, login } = currentUser;
   const isSignedIn = persistentToken && login;
@@ -212,36 +39,12 @@ const SignInPop = () => {
   }
 
   return (
-    <NestedPopover alternateContent={() => <SignIn api={api} />} startAlternateVisible={false}>
-      {(showEmailLogin) => (
-        <NestedPopover alternateContent={() => <SignInWithConsumer api={api} />} startAlternateVisible={false}>
-          {(showCodeLogin) => (
-            <div
-              className="pop-over sign-in-pop middle"
-              style={{
-                position: 'relative',
-                margin: '0 auto',
-                width: '25%',
-              }}
-            >
-              <section className="pop-over-actions first-section">
-                <EmailSignInButton
-                  onClick={() => {
-                    showEmailLogin(api);
-                  }}
-                />
-              </section>
-              <SignInCodeSection
-                onClick={() => {
-                  showCodeLogin(api);
-                }}
-              />
-            </div>
-          )}
-        </NestedPopover>
-      )}
-    </NestedPopover>
+    <div className={styles.content}>
+      <PopoverContainer>
+        {() => <SignInPop align="none" />}
+      </PopoverContainer>
+    </div>
   );
 };
 
-export default SignInPop;
+export default SignInPage;

--- a/src/presenters/pages/signin.js
+++ b/src/presenters/pages/signin.js
@@ -1,0 +1,247 @@
+/**
+ * Login page for Glitch OAuth
+ *
+ * Login via email only
+ *
+ * TODO: Allow login via username/password when that becomes available
+ *
+ * IMPORTANT: This is considered a proof of concept for OAuth. It is nearly a direct
+ * copy of /pop-overs/sign-in-pop.
+ */
+
+/* globals API_URL */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { captureException } from 'Utils/sentry';
+import { useAPI } from 'State/api';
+import { useCurrentUser } from 'State/current-user';
+import Notification from 'Components/notification';
+import { PopoverWithButton, MultiPopover, MultiPopoverTitle, PopoverDialog, PopoverActions, PopoverInfo } from 'Components/popover';
+
+class SignIn extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      email: '',
+      done: false,
+      error: false,
+    };
+    this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  onChange(e) {
+    this.setState({ email: e.target.value });
+  }
+
+  async onSubmit(e) {
+    e.preventDefault();
+    this.setState({ done: true });
+    try {
+      await this.props.api.post('/email/sendLoginEmail', {
+        emailAddress: this.state.email,
+      });
+      this.setState({ error: false });
+    } catch (error) {
+      captureException(error);
+      this.setState({ error: true });
+    }
+  }
+
+  render() {
+    const isEnabled = this.state.email.length > 0;
+    return (
+      <NestedPopover alternateContent={() => <SignInWithConsumer {...this.props} />} startAlternateVisible={false}>
+        {(showCodeLogin) => (
+          <dialog className="pop-over sign-in-pop">
+            <NestedPopoverTitle>
+              Email Sign In <span className="emoji email" />
+            </NestedPopoverTitle>
+            <section className="pop-over-actions first-section">
+              {!this.state.done && (
+                <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
+                  <input value={this.state.email} onChange={this.onChange} className="pop-over-input" type="email" placeholder="new@user.com" />
+                  <button style={{ marginTop: 10 }} className="button-small button-link" disabled={!isEnabled}>
+                    Send Link
+                  </button>
+                </form>
+              )}
+              {this.state.done && !this.state.error && (
+                <>
+                  <Notification persistent inline type="success">
+                    Almost Done
+                  </Notification>
+                  <div>Finish signing in from the email sent to {this.state.email}.</div>
+                </>
+              )}
+              {this.state.done && this.state.error && (
+                <>
+                  <Notification persistent inline type="error">
+                    Error
+                  </Notification>
+                  <div>Something went wrong, email not sent.</div>
+                </>
+              )}
+            </section>
+            {this.state.done && !this.state.error && (
+              <SignInCodeSection
+                onClick={() => {
+                  showCodeLogin(this.props.api);
+                }}
+              />
+            )}
+          </dialog>
+        )}
+      </NestedPopover>
+    );
+  }
+}
+
+class SignInCodeHandler extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      code: '',
+      done: false,
+      error: false,
+    };
+    this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  onChange(e) {
+    this.setState({ code: e.target.value });
+  }
+
+  async onSubmit(e) {
+    e.preventDefault();
+    this.setState({ done: true });
+    try {
+      const { data } = await this.props.api.post(`/auth/email/${this.state.code}`);
+      this.props.setUser(data);
+      this.setState({ error: false });
+    } catch (error) {
+      captureException(error);
+      this.setState({ error: true });
+    }
+  }
+
+  render() {
+    const isEnabled = this.state.code.length > 0;
+    return (
+      <dialog className="pop-over sign-in-pop middle">
+        <NestedPopoverTitle>Use a sign in code</NestedPopoverTitle>
+        <section className="pop-over-actions first-section">
+          {!this.state.done && (
+            <form onSubmit={this.onSubmit} style={{ marginBottom: 0 }}>
+              Paste your temporary sign in code below
+              <input value={this.state.code} onChange={this.onChange} className="pop-over-input" type="text" placeholder="cute-unique-cosmos" />
+              <button style={{ marginTop: 10 }} className="button-small button-link" disabled={!isEnabled}>
+                Sign In
+              </button>
+            </form>
+          )}
+          {this.state.done && !this.state.error && (
+            <>
+              <Notification persistent type="success">
+                Success!
+              </Notification>
+            </>
+          )}
+          {this.state.done && this.state.error && (
+            <>
+              <Notification persistent type="error">
+                Error
+              </Notification>
+              <div>Code not found or already used. Try signing in with email.</div>
+            </>
+          )}
+        </section>
+      </dialog>
+    );
+  }
+}
+
+const SignInWithConsumer = (props) => {
+  const { login } = useCurrentUser();
+  return <SignInCodeHandler setUser={login} {...props} />;
+};
+
+const EmailSignInButton = ({ onClick }) => (
+  <button
+    className="button button-small button-link has-emoji"
+    onClick={() => {
+      onClick();
+    }}
+  >
+    Sign in with Email <span className="emoji email" />
+  </button>
+);
+EmailSignInButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+const SignInCodeSection = ({ onClick }) => (
+  <section className="pop-over-actions last-section pop-over-info">
+    <button className="button-small button-tertiary button-on-secondary-background" onClick={onClick}>
+      <span>Use a sign in code</span>
+    </button>
+  </section>
+);
+SignInCodeSection.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+const SignInPop = () => {
+  const api = useAPI();
+  const { currentUser } = useCurrentUser();
+  const { persistentToken, login } = currentUser;
+  const isSignedIn = persistentToken && login;
+
+  React.useEffect(() => {
+    if (isSignedIn) {
+      const params = new URLSearchParams(window.location.search);
+      params.append('authorization', persistentToken);
+      window.location.assign(`${API_URL}/oauth/dialog/authorize?${params}`);
+    }
+  }, [isSignedIn]);
+
+  if (isSignedIn) {
+    return null;
+  }
+
+  return (
+    <NestedPopover alternateContent={() => <SignIn api={api} />} startAlternateVisible={false}>
+      {(showEmailLogin) => (
+        <NestedPopover alternateContent={() => <SignInWithConsumer api={api} />} startAlternateVisible={false}>
+          {(showCodeLogin) => (
+            <div
+              className="pop-over sign-in-pop middle"
+              style={{
+                position: 'relative',
+                margin: '0 auto',
+                width: '25%',
+              }}
+            >
+              <section className="pop-over-actions first-section">
+                <EmailSignInButton
+                  onClick={() => {
+                    showEmailLogin(api);
+                  }}
+                />
+              </section>
+              <SignInCodeSection
+                onClick={() => {
+                  showCodeLogin(api);
+                }}
+              />
+            </div>
+          )}
+        </NestedPopover>
+      )}
+    </NestedPopover>
+  );
+};
+
+export default SignInPop;

--- a/src/presenters/pages/signin.styl
+++ b/src/presenters/pages/signin.styl
@@ -1,0 +1,9 @@
+@import  "../../components/constants"
+
+.content {
+  padding: 1rem 2rem;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 800px;
+}


### PR DESCRIPTION
## Links
* Remix link: https://chestnut-cappelletti-1.glitch.me/

## Changes:
* Adds OAuth sign in page back to routes

## How To Test:
* https://chestnut-cappelletti-1.glitch.me/signin should show the sign in popup.

## Feedback I'm looking for:

This kind of reuses the VSCode auth page and the `sign-in-pop` to get it put back quickly and also to minimize conflicts with upcoming changes Greg and I made to sign in.

There was a note about previously supporting email sign in only, which is mainly because it feels weird to sign in with another OAuth provider from our OAuth screen? I think some of the work in our other PR will make it easier to have things that are modular like this if we want them to be.

Once that PR is merged I will probably revisit this to use some of the work we've done there.

## Things left to do before deploying:
- [x] Review and 👀 
