### PR TITLE
Quixotic-rocket: Replace _cacheCover with updatedAt

### DIFF
--- a/src/components/containers/cover-container.js
+++ b/src/components/containers/cover-container.js
@@ -12,7 +12,7 @@ const getProfileStyles = {
 };
 
 const CoverContainer = ({ coverActions, children, type, item }) => {
-  const cache = item._cacheCover; // eslint-disable-line no-underscore-dangle
+  const cache = item.updatedAt;
   return (
     <div className={styles.coverContainer} style={getProfileStyles[type]({ ...item, cache })}>
       {children}

--- a/src/components/containers/profile/team.js
+++ b/src/components/containers/profile/team.js
@@ -12,7 +12,7 @@ const TeamProfileContainer = ({ item, children, avatarActions, coverActions }) =
     <div className={classnames(styles.profileWrap)}>
       <div className={styles.avatarContainer}>
         {/* eslint-disable-next-line no-underscore-dangle */}
-        <div className={classnames(styles.avatar, styles.team)} style={getTeamAvatarStyle({ ...item, cache: item._cacheAvatar })} />
+        <div className={classnames(styles.avatar, styles.team)} style={getTeamAvatarStyle({ ...item, cache: item.updatedAt })} />
         <div className={styles.avatarButtons}>{avatarActions && <TrackedButtonGroup actions={avatarActions} />}</div>
       </div>
       <div className={styles.profileInfo}>{children}</div>

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -163,7 +163,7 @@ export function useTeamEditor(initialTeam) {
             hasAvatarImage: true,
             backgroundColor: color,
           });
-          setTeam((prev) => ({ ...prev, _cacheAvatar: Date.now() }));
+          setTeam((prev) => ({ ...prev, updatedAt: Date.now() }));
         }, handleError),
       ),
     uploadCover: () =>

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -63,11 +63,7 @@ export function useTeamEditor(initialTeam) {
   const { createNotification } = useNotifications();
   const { handleError, handleErrorForInput, handleCustomError } = useErrorHandlers();
   const reloadProjectMembers = useProjectReload();
-  const [team, setTeam] = useState({
-    ...initialTeam,
-    _cacheAvatar: Date.now(),
-    _cacheCover: Date.now(),
-  });
+  const [team, setTeam] = useState({ ...initialTeam });
 
   async function updateFields(changes) {
     const { data } = await updateTeam(api, team, changes);
@@ -182,7 +178,7 @@ export function useTeamEditor(initialTeam) {
             hasCoverImage: true,
             coverColor: color,
           });
-          setTeam((prev) => ({ ...prev, _cacheCover: Date.now() }));
+          setTeam((prev) => ({ ...prev, updatedAt: Date.now() }));
         }, handleError),
       ),
     clearCover: () => updateFields({ hasCoverImage: false }).catch(handleError),

--- a/src/state/user.js
+++ b/src/state/user.js
@@ -26,7 +26,6 @@ export const addProjectToCollection = (api, project, collection) => api.patch(`c
 export function useUserEditor(initialUser) {
   const [user, setUser] = useState({
     ...initialUser,
-    _cacheCover: Date.now(),
     _deletedProjects: [],
   });
   const api = useAPI();
@@ -85,7 +84,7 @@ export function useUserEditor(initialUser) {
             hasCoverImage: true,
             coverColor: color,
           });
-          setUser((prev) => ({ ...prev, _cacheCover: Date.now() }));
+          setUser((prev) => ({ ...prev, updatedAt: Date.now() }));
         }, handleError),
       ),
     clearCover: () => updateFields({ hasCoverImage: false }).catch(handleError),


### PR DESCRIPTION
## Links
- https://quixotic-rocket.glitch.me/
- https://glitch.manuscript.com/f/cases/3328758/On-anonymous-user-s-page-user-_cacheCover-is-not-provided-though-marked-as-required

## Changes:
Removes all references to _cacheCover and _cacheAvatar, which were used to cache bust images on profile pages. They were set to the current datetime on page load and updated whenever the image updated. Now it uses updatedAt, which means images can be cached across page loads.

## How To Test:
- Try updating avatars and cover images for users and teams
