### PR TITLE
Useful bangle: fix small collection item styles

### DIFF
--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -96,12 +96,11 @@
     margin-bottom: 10px
     
 .smallCollectionLink
-  display: block
   color: inherit
   text-decoration: none
   display: flex
   flex-direction: column
-  height: 100%
+  flex: 1 1 100%
   &:hover
     text-decoration: none
     


### PR DESCRIPTION
## Links
* Remix link: https://useful-bangle.glitch.me

## GIF/Screenshots:
![Screen Shot 2019-06-25 at 10 07 14 AM](https://user-images.githubusercontent.com/938722/60105384-3c28a880-9731-11e9-863e-73fff4f7593b.png)
![Screen Shot 2019-06-25 at 10 07 25 AM](https://user-images.githubusercontent.com/938722/60105385-3c28a880-9731-11e9-80c0-e02a0b6705ae.png)
![Screen Shot 2019-06-25 at 10 07 36 AM](https://user-images.githubusercontent.com/938722/60105386-3c28a880-9731-11e9-9468-422dea3d2494.png)

## Changes:
* fix small collection item styes

## How To Test:
* verify small collection items don't overlap on https://useful-bangle.glitch.me/search?q=react&activeFilter=collection (compare with production)
* verify that collection items in "more from glitch" fill the whole container on https://useful-bangle.glitch.me/@glitch/glitch-this-week-june-19-2019
