### PR TITLE
Quixotic-rocket: Fix create collection on team pages with a space in their name

### DIFF
--- a/src/components/collection/create-collection-pop.js
+++ b/src/components/collection/create-collection-pop.js
@@ -87,7 +87,7 @@ function CreateCollectionPopBase({ align, title, onSubmit, options }) {
     setLoading(true);
     const collection = await createCollection(api, collectionName, selection.value, createNotification);
     const team = currentUser.teams.find((t) => t.id === selection.value);
-    collection.fullUrl = `${team ? team.name : currentUser.login}/${collection.url}`;
+    collection.fullUrl = `${team ? team.url : currentUser.login}/${collection.url}`;
     onSubmit(collection);
   }
 


### PR DESCRIPTION
## Links
* https://quixotic-rocket.glitch.me/
* https://glitch.manuscript.com/f/cases/3328794/Creating-a-new-collection-on-a-team-page-redirects-to-a-broken-url

## Changes:
* Use `team.url` instead of `team.name`

## How To Test:
* Go to a team page with a space in their name, and create a collection