### PR TITLE
aromatic-mushroom: add size prop to TeamAvatar

### DIFF
--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -48,10 +48,10 @@ Avatar.defaultProps = {
   hideTooltip: false,
 };
 
-export const TeamAvatar = ({ team, hideTooltip }) => (
+export const TeamAvatar = ({ team, size, hideTooltip }) => (
   <Avatar
     name={team.name}
-    src={getTeamAvatarUrl({ ...team, size: 'small' })}
+    src={getTeamAvatarUrl({ ...team, size })}
     srcFallback={DEFAULT_TEAM_AVATAR}
     type="team"
     hideTooltip={hideTooltip}
@@ -64,9 +64,11 @@ TeamAvatar.propTypes = {
     hasAvatarImage: PropTypes.bool.isRequired,
   }).isRequired,
   hideTooltip: PropTypes.bool,
+  size: PropTypes.oneOf(['small', 'large']),
 };
 TeamAvatar.defaultProps = {
   hideTooltip: false,
+  size: 'small',
 };
 
 export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton }) => (


### PR DESCRIPTION
## Links
* [aromatic-mushroom.glitch.me](https://aromatic-mushroom.glitch.me)

## Changes:
Adds a size prop to the TeamAvatar component so we can also fetch higher-res avatars

## How To Test:
Do we still have team avatars across the site?