### PR TITLE
Regular muscle: show user avatars on collection notes

### DIFF
--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -82,7 +82,7 @@ const CollectionCurator = ({ collection }) => {
   return <ProfileItem {...curator} />;
 };
 
-const CollectionCuratorLoader = ({ collection }) => (
+export const CollectionCuratorLoader = ({ collection }) => (
   <VisibilityContainer>
     {({ wasEverVisible }) => (wasEverVisible ? <CollectionCurator collection={collection} /> : <ProfileItem />)}
   </VisibilityContainer>

--- a/src/components/collection/note.js
+++ b/src/components/collection/note.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { isDarkColor } from 'Models/collection';
 import { ProfileItem } from 'Components/profile-list';
 import AuthDescription from 'Components/fields/auth-description';
+import { CollectionCuratorLoader } from 'Components/collection/collection-item';
 
 import styles from './note.styl';
 

--- a/src/components/collection/note.js
+++ b/src/components/collection/note.js
@@ -4,7 +4,6 @@ import classNames from 'classnames/bind';
 import _ from 'lodash';
 
 import { isDarkColor } from 'Models/collection';
-import { ProfileItem } from 'Components/profile-list';
 import AuthDescription from 'Components/fields/auth-description';
 import { CollectionCuratorLoader } from 'Components/collection/collection-item';
 
@@ -46,7 +45,7 @@ const Note = ({ collection, project, updateNote, hideNote, isAuthorized }) => {
         />
       </div>
       <div className={styles.user}>
-        <ProfileItem user={collection.user} team={collection.team} />
+        <CollectionCuratorLoader collection={collection} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Links
* https://regular-muscle.glitch.me
* https://glitch.manuscript.com/f/cases/3328797/user-avatars-not-rendering-on-notes

## GIF/Screenshots:
before and after
![Screen Shot 2019-06-26 at 2 21 02 PM](https://user-images.githubusercontent.com/6620164/60204803-a9196c80-981d-11e9-9068-6d16d0a41008.png)

## Changes:
* make sure we load full users for collections and pass that to notes

## How To Test:
* go to any notes with collections and ensure the user avatars load properly

## Feedback I'm looking for:
- I see we have 2 CollectionCuratorLoaders and wasn't sure which to use, but this one seems to do the trick? Should I just pass CollectionCurator instead of the loader? 