### PR TITLE
Profuse tea: Don't show 'edit project' on featured projects you are not a member of

### DIFF
--- a/src/components/buttons/button.styl
+++ b/src/components/buttons/button.styl
@@ -17,6 +17,7 @@
   position: relative
   text-align: left
   text-decoration: none
+  vertical-align: middle
   &.matchBackground
     background-color: inherit
   &.hasImage

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -56,7 +56,6 @@ const FeaturedProject = ({
             />
           }
           project={featuredProject}
-          isAuthorized={isAuthorized}
           addProjectToCollection={addProjectToCollection}
         />
       )}

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -19,9 +19,9 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
     baseProjectId: project.id,
     baseDomain: project.domain,
   });
-  const isMember = project.permissions.some(({ userId }) => userId === currentUser.id);
 
-  const bottomLeft = isAuthorized || isMember ? (
+  const isMember = currentUser.projects.some(({ id }) => id === project.id);
+  const bottomLeft = isMember ? (
     <EditButton name={project.id} isMember={isMember} size="small" />
   ) : (
     <ReportButton reportedType="project" reportedModel={project} />

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -21,7 +21,7 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
   });
 
   const isMember = currentUser.projects.some(({ id }) => id === project.id);
-  const bottomLeft = isAuthorized || isMember ? (
+  const bottomLeft = isMember ? (
     <EditButton name={project.id} isMember={isMember} size="small" />
   ) : (
     <ReportButton reportedType="project" reportedModel={project} />

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -19,15 +19,15 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
     baseProjectId: project.id,
     baseDomain: project.domain,
   });
+  const isMember = project.permissions.some(({ userId }) => userId === currentUser.id);
 
-  const BottomLeft = () => {
-    if (isAuthorized) {
-      return <EditButton name={project.id} isMember={isAuthorized} size="small" />;
-    }
-    return <ReportButton reportedType="project" reportedModel={project} />;
-  };
+  const bottomLeft = isAuthorized || isMember ? (
+    <EditButton name={project.id} isMember={isMember} size="small" />
+  ) : (
+    <ReportButton reportedType="project" reportedModel={project} />
+  );
 
-  const BottomRight = () => (
+  const bottomRight = (
     <>
       {currentUser.login && (
         <div className={styles.addToCollectionWrap}>
@@ -46,10 +46,10 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
       </div>
       <div className={styles.buttonContainer}>
         <div className={styles.left}>
-          <BottomLeft />
+          {bottomLeft}
         </div>
         <div className={cx({ right: true, buttonWrap: true })}>
-          <BottomRight />
+          {bottomRight}
         </div>
       </div>
     </section>

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -21,7 +21,7 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
   });
 
   const isMember = currentUser.projects.some(({ id }) => id === project.id);
-  const bottomLeft = isMember ? (
+  const bottomLeft = isAuthorized || isMember ? (
     <EditButton name={project.id} isMember={isMember} size="small" />
   ) : (
     <ReportButton reportedType="project" reportedModel={project} />

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -20,7 +20,7 @@ const ProjectEmbed = ({ project, top, addProjectToCollection }) => {
     baseProjectId: project.id,
     baseDomain: project.domain,
   });
-  
+
   const bottomLeft = isMember ? (
     <EditButton name={project.id} isMember={isMember} size="small" />
   ) : (

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -13,14 +13,14 @@ import styles from './project-embed.styl';
 
 const cx = classNames.bind(styles);
 
-const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) => {
+const ProjectEmbed = ({ project, top, addProjectToCollection }) => {
   const { currentUser } = useCurrentUser();
+  const isMember = currentUser.projects.some(({ id }) => id === project.id);
   const trackRemix = useTracker('Click Remix', {
     baseProjectId: project.id,
     baseDomain: project.domain,
   });
-
-  const isMember = currentUser.projects.some(({ id }) => id === project.id);
+  
   const bottomLeft = isMember ? (
     <EditButton name={project.id} isMember={isMember} size="small" />
   ) : (
@@ -34,7 +34,7 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
           <AddProjectToCollection project={project} currentUser={currentUser} addProjectToCollection={addProjectToCollection} fromProject />
         </div>
       )}
-      <RemixButton name={project.domain} isMember={isAuthorized} onClick={trackRemix} />
+      <RemixButton name={project.domain} isMember={isMember} onClick={trackRemix} />
     </>
   );
 
@@ -58,7 +58,6 @@ const ProjectEmbed = ({ project, top, isAuthorized, addProjectToCollection }) =>
 
 ProjectEmbed.propTypes = {
   project: PropTypes.object.isRequired,
-  isAuthorized: PropTypes.bool.isRequired,
   addProjectToCollection: PropTypes.func,
   top: PropTypes.any,
 };

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -209,12 +209,7 @@ const ProjectPage = ({ project: initialProject }) => {
         </ProjectProfileContainer>
       </section>
       <div className={styles.projectEmbedWrap}>
-        <ProjectEmbed
-          project={project}
-          isAuthorized={isAuthorized}
-          currentUser={currentUser}
-          addProjectToCollection={(_, collection) => addProjectToCollection(collection)}
-        />
+        <ProjectEmbed project={project} addProjectToCollection={(_, collection) => addProjectToCollection(collection)} />
       </div>
       <section id="readme">
         <ReadmeLoader domain={domain} />

--- a/stories/index.js
+++ b/stories/index.js
@@ -399,8 +399,6 @@ storiesOf('ProjectEmbed', module)
     provideContext({ currentUser: {} }, () => (
       <ProjectEmbed
         project={{ id: '123', domain: 'community-staging' }}
-        isAuthorized={false}
-        currentUser={{ login: null }}
         addProjectToCollection={addProjectToCollection}
       />
     )),
@@ -410,8 +408,6 @@ storiesOf('ProjectEmbed', module)
     provideContext({ currentUser: { login: '@sarahzinger' } }, () => (
       <ProjectEmbed
         project={{ id: '123', domain: 'community-staging' }}
-        isAuthorized={false}
-        currentUser={{ login: '@sarahzinger' }}
         addProjectToCollection={addProjectToCollection}
       />
     )),
@@ -419,8 +415,6 @@ storiesOf('ProjectEmbed', module)
   .add('owns project, is logged in', () => (
     <ProjectEmbed
       project={{ id: '123', domain: 'community-staging' }}
-      isAuthorized={true}
-      currentUser={{ login: '@sarahzinger' }}
       addProjectToCollection={addProjectToCollection}
     />
   ));
@@ -434,7 +428,6 @@ storiesOf('FeaturedProject', module)
       <FeaturedProject
         featuredProject={{ id: '123', domain: 'community-staging' }}
         isAuthorized={true}
-        currentUser={{ login: '@sarahzinger' }}
         addProjectToCollection={addProjectToCollection}
         unfeatureProject={unfeatureProject}
       />


### PR DESCRIPTION
## Links
* https://profuse-tea.glitch.me
* https://glitch.manuscript.com/f/cases/3328757/Edit-Project-button-is-visible-for-featured-projects-even-if-you-aren-t-a-member-of-the-project

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/60209378-83459500-9828-11e9-9628-6a8502fdc61e.png)
![image](https://user-images.githubusercontent.com/8932174/60208231-bcc8d100-9825-11e9-8b65-4455926564b7.png)

## Changes:
* Project embeds check if you are a project member rather than relying on collection/team level auth. This means if you feature someone else's project in your collection, you'll see a report button under it instead of an edit button, and the remix button will say 'remix your own' instead of 'remix this'
* I added `vertical-align: middle` to the button component. It was already applied by an old css `button, .button` selector, so this fixes alignment when there are button buttons next to link buttons.

## How To Test:
* Try looking at a bunch of different collections and see if they all behave
* See if there are any obscure buttons that align badly now