### PR TITLE
Gigantic chair: handle and log issue with determineProjectOptionsFunctions 

### DIFF
--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -36,7 +36,7 @@ const determineProjectOptionsFunctions = ({ currentUser, project, projectOptions
   const isAnon = !(currentUser && currentUser.login);
   // for some reason project.permissions does not always exist and it's not clear why
   // handling this edge case and logging project to sentry to better understand why.
-  // in the future this can be put back to just 
+  // in the future this can be put back to just
   // const projectUserIds = project.permissions.map(({ userId }) => userId);
   let projectUserIds;
   try {

--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -33,6 +33,7 @@ const promptThenLeaveProject = ({ event, project, leaveProject, currentUser }) =
 
 const determineProjectOptionsFunctions = ({ currentUser, project, projectOptions }) => {
   const isAnon = !(currentUser && currentUser.login);
+  
   const projectUserIds = project.permissions.map(({ userId }) => userId);
   const isProjectMember = currentUser && projectUserIds.includes(currentUser.id);
   const currentUserProjectPermissions = currentUser && project.permissions.find((p) => p.userId === currentUser.id);


### PR DESCRIPTION
## Links
* https://gigantic-chair.glitch.me
* https://sentry.io/organizations/fog-creek-software/issues/1076258278/?project=1246508&query=is%3Aunresolved

## Changes:
* for reasons that are not currently clear to me, we often get a project object that seems to be missing a permissions field. I would like to log what project is at this point in time to better understand what could be going wrong and pass an empty array for permissions so as to not break the function overall

## Feedback I'm looking for:
- if you have ideas for why we might be missing a permissions field that I can't think of at the moment that would be cool! Then we don't even need this pr lol. 
- or if you see reasons why it would be bad to continue rendering with an empty permissions field that would be good too!
