### PR TITLE
Rambunctious bathroom: bug fixes for project page

### DIFF
--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -61,7 +61,7 @@ function RelatedProjects({ project }) {
         <li key={team.id}>
           <DataLoader get={(api) => getProjects(api, { type: 'team', id: team.id, ignoreProjectId })}>
             {(projects) =>
-              projects && (
+              projects && projects.length > 0 && (
                 <>
                   <h2>
                     <TeamLink team={team}>More by {team.name} →</TeamLink>
@@ -77,7 +77,7 @@ function RelatedProjects({ project }) {
         <li key={user.id}>
           <DataLoader get={(api) => getProjects(api, { type: 'user', id: user.id, ignoreProjectId })}>
             {(projects) =>
-              projects && (
+              projects && projects.length > 0 && (
                 <>
                   <h2>
                     <UserLink user={user}>More by {getDisplayName(user)} →</UserLink>

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -36,16 +36,15 @@ function syncPageToDomain(domain) {
   history.replaceState(null, null, `/~${domain}`);
 }
 
-function getCollections(api) {
-  return getAllPages(api, `/v1/projects/by/id/collections?id=${projectId}&limit=100`)
-}
+const filteredCollections = (collections) => collections.filter((c) => c.user || c.team);
+
 const IncludedInCollections = ({ projectId }) => (
   <DataLoader get={(api) => getAllPages(api, `/v1/projects/by/id/collections?id=${projectId}&limit=100`)} renderLoader={() => null}>
     {(collections) =>
       collections.length > 0 && (
         <>
           <Heading tagName="h2">Included in Collections</Heading>
-          <Row items={collections}>{(collection) => <CollectionItem collection={collection} showCurator />}</Row>
+          <Row items={filteredCollections(collections)}>{(collection) => <CollectionItem collection={collection} showCurator />}</Row>
         </>
       )
     }
@@ -118,10 +117,7 @@ function DeleteProjectPopover({ projectDomain, deleteProject }) {
 
   return (
     <section>
-      <PopoverWithButton
-        buttonProps={{ size: 'small', type: 'dangerZone', emoji: 'bomb' }}
-        buttonText="Delete Project"
-      >
+      <PopoverWithButton buttonProps={{ size: 'small', type: 'dangerZone', emoji: 'bomb' }} buttonText="Delete Project">
         {({ togglePopover }) => (
           <PopoverDialog align="left" wide>
             <PopoverActions>

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -36,6 +36,9 @@ function syncPageToDomain(domain) {
   history.replaceState(null, null, `/~${domain}`);
 }
 
+function getCollections(api) {
+  return getAllPages(api, `/v1/projects/by/id/collections?id=${projectId}&limit=100`)
+}
 const IncludedInCollections = ({ projectId }) => (
   <DataLoader get={(api) => getAllPages(api, `/v1/projects/by/id/collections?id=${projectId}&limit=100`)} renderLoader={() => null}>
     {(collections) =>


### PR DESCRIPTION
## Links
* https://rambunctious-bathroom.glitch.me/~face-the-music
* https://sentry.io/organizations/fog-creek-software/issues/1087738883/?project=1246508&query=is%3Aunresolved

## Changes:
* we have a collection that doesn't seem to have a user or a team. I'm not sure how it got into this abandoned state, but imo there's no need to show when projects are included in abandoned collections, and currently in prod it's breaking certain project pages, for an example see ~face-the-music
* I also noticed that sometimes we had these More by links for users/teams that only have one project. I'm not sure it makes much sense to show those links in this case (but feel free to disagree! wasn't sure if this was an actual bug or as designed tbh) 

## How To Test:
* compare https://rambunctious-bathroom.glitch.me/~face-the-music with glitch.com/~face-the-music

## Feedback I'm looking for:
- do we think we should still link back to users/teams when this is their first project?
