### PR TITLE
Little health: fix input css

### DIFF
--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -153,12 +153,12 @@ const ProjectPage = ({ project: initialProject }) => {
                   placeholder="Name your project"
                 />
               </Heading>
-              <div className={styles.privateToggleWrap}><PrivateToggle isPrivate={project.private} setPrivate={updatePrivate} /></div>
+              <PrivateToggle isPrivate={project.private} setPrivate={updatePrivate} />
             </div>
           ) : (
             <div className={styles.headingWrap}>
               <Heading tagName="h1">{!currentUser.isSupport && suspendedReason ? 'suspended project' : domain}</Heading>
-              {project.private && <div className={styles.privateToggleWrap}><PrivateBadge /></div>}
+              {project.private && <PrivateBadge />}
             </div>
           )}
           {users.length + teams.length > 0 && (

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -153,12 +153,12 @@ const ProjectPage = ({ project: initialProject }) => {
                   placeholder="Name your project"
                 />
               </Heading>
-              <PrivateToggle isPrivate={project.private} setPrivate={updatePrivate} />
+              <div className={styles.privateToggleWrap}><PrivateToggle isPrivate={project.private} setPrivate={updatePrivate} /></div>
             </div>
           ) : (
             <div className={styles.headingWrap}>
               <Heading tagName="h1">{!currentUser.isSupport && suspendedReason ? 'suspended project' : domain}</Heading>
-              {project.private && <PrivateBadge />}
+              {project.private && <div className={styles.privateToggleWrap}><PrivateBadge /></div>}
             </div>
           )}
           {users.length + teams.length > 0 && (

--- a/src/presenters/pages/project.styl
+++ b/src/presenters/pages/project.styl
@@ -13,5 +13,8 @@
   align-items: center
   margin-bottom: 12px
   h1
-    flex-grow: 1
+    flex: 1 1 auto
     margin-bottom: 0
+
+  .privateToggleWrap
+    flex: 0 0 100px

--- a/src/presenters/pages/project.styl
+++ b/src/presenters/pages/project.styl
@@ -16,4 +16,4 @@
     flex: 1 1 auto
     margin-bottom: 0
   input
-    font-size: 0.9em
+    width: 100%

--- a/src/presenters/pages/project.styl
+++ b/src/presenters/pages/project.styl
@@ -15,6 +15,5 @@
   h1
     flex: 1 1 auto
     margin-bottom: 0
-
-  .privateToggleWrap
-    flex: 0 0 100px
+  input
+    font-size: 0.9em


### PR DESCRIPTION
## Links
* Remix link: https://little-health.glitch.me

## GIF/Screenshots:
Before:
![Screen Shot 2019-07-02 at 10 42 53 AM](https://user-images.githubusercontent.com/938722/60522026-42310300-9cb6-11e9-9b57-1eb2afef5834.png)

After:
![Screen Shot 2019-07-02 at 10 42 42 AM](https://user-images.githubusercontent.com/938722/60522031-44935d00-9cb6-11e9-8e8c-8685d5f990cd.png)

## Changes:
* set input width to 100%

## How To Test:
* log into https://little-health.glitch.me
* visit a project you own
* the public/private toggle should be inside the container
