### PR TITLE
Quixotic rocket: Fix 'more collections by' display

### DIFF
--- a/src/components/collections-list/more-collections.js
+++ b/src/components/collections-list/more-collections.js
@@ -12,7 +12,7 @@ import Arrow from 'Components/arrow';
 import { UserLink, TeamLink } from 'Components/link';
 import { getDisplayName } from 'Models/user';
 import { getSingleItem } from 'Shared/api';
-import { useCollectionContext } from 'State/collection';
+import { useCollectionContext, useCollectionCurator } from 'State/collection';
 
 import styles from './styles.styl';
 
@@ -49,6 +49,7 @@ function useCollectionsWithProjects(collections) {
 }
 
 const MoreCollections = ({ currentCollection, collections }) => {
+  const curator = useCollectionCurator(currentCollection);
   const collectionsWithProjects = useCollectionsWithProjects(collections);
   if (!collectionsWithProjects) return <Loader />;
   if (!collectionsWithProjects.length) return null;
@@ -60,9 +61,9 @@ const MoreCollections = ({ currentCollection, collections }) => {
       <div className={styles.moreByLinkWrap}>
         <Heading tagName="h2">
           {isUserCollection ? (
-            <UserLink user={currentCollection.user}>More by {getDisplayName(currentCollection.user)} <Arrow /></UserLink>
+            <UserLink user={currentCollection.user}>More by {getDisplayName(curator ? curator.user : currentCollection.user)} <Arrow /></UserLink>
           ) : (
-            <TeamLink team={currentCollection.team}>More from {currentCollection.team.name} <Arrow /></TeamLink>
+            <TeamLink team={currentCollection.team}>More from {curator ? curator.team.name : `@${currentCollection.team.url}`} <Arrow /></TeamLink>
           )}
         </Heading>
       </div>

--- a/src/components/collections-list/more-collections.js
+++ b/src/components/collections-list/more-collections.js
@@ -60,10 +60,13 @@ const MoreCollections = ({ currentCollection, collections }) => {
     <>
       <div className={styles.moreByLinkWrap}>
         <Heading tagName="h2">
-          {isUserCollection ? (
-            <UserLink user={currentCollection.user}>More by {getDisplayName(curator ? curator.user : currentCollection.user)} <Arrow /></UserLink>
+          {curator.status === 'ready' ? (
+            <>
+              {curator.value.user && <UserLink user={curator.value.user}>More by {getDisplayName(curator.value.user)} <Arrow /></UserLink>}
+              {curator.value.team && <TeamLink team={curator.value.team}>More from {curator.value.team.name} <Arrow /></TeamLink>}
+            </>
           ) : (
-            <TeamLink team={currentCollection.team}>More from {curator ? curator.team.name : `@${currentCollection.team.url}`} <Arrow /></TeamLink>
+            <>More collections</>
           )}
         </Heading>
       </div>

--- a/src/components/create-team-pop/index.js
+++ b/src/components/create-team-pop/index.js
@@ -65,7 +65,7 @@ const CreateTeamPop = withRouter(({ history }) => {
     }
   };
 
-  const debouncedValidate = debounce(validate, 200);
+  const [debouncedValidate] = useState(() => debounce(validate, 200));
   useEffect(() => {
     const getName = async () => {
       const teamName = await getTeamPair();


### PR DESCRIPTION
## Links
- https://quixotic-rocket.glitch.me/
- https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/42

## Screenshot
![image](https://user-images.githubusercontent.com/8932174/60533515-cd69c300-9ccd-11e9-81f7-1cec4aa10baa.png)

## Changes:
- Use the new collection curator loader to make sure that we have a name for the collection owner
- Reuse create team validate debounce across renders so it doesn't hit the api every kesytroke

## How To Test:
- Look at some collections owned by users and teams and make sure they both have correct titles
- Try typing into the create team pop and watch the network tab