### PR TITLE
Prickly swim: fix default button styles

### DIFF
--- a/src/components/images/emoji.js
+++ b/src/components/images/emoji.js
@@ -38,6 +38,7 @@ const EMOJIS = {
   newspaper: 'https://cdn.glitch.com/d1106f7a-2623-4461-8326-5945e5b97d8b%2Fnewspaper_1f4f0.png',
   octocat: 'https://gomix.com/images/emojis/github-logo-light.svg',
   park: 'https://cdn.glitch.com/4f4a169a-9b63-4daa-8b6a-0e50d5c06e25%2Fnational-park_1f3de.png',
+  playButton: 'https://cdn.glitch.com/6ce807b5-7214-49d7-aadd-f11803bc35fd%2Fplay.svg',
   policeOfficer: 'https://cdn.glitch.com/d1106f7a-2623-4461-8326-5945e5b97d8b%2Fpolice-officer_1f46e.png',
   pushpin: 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fpushpin.png',
   rainbow: 'https://cdn.glitch.com/e5154318-7816-4ec9-a72a-a0e767031e99%2Frainbow.png',

--- a/src/presenters/pages/index.js
+++ b/src/presenters/pages/index.js
@@ -45,7 +45,6 @@ const WhatIsGlitch = () => {
   const remix = 'https://cdn.glitch.com/a67e7e84-c063-4c8e-a7fc-f4c7ab86186f%2Fremix-illustration.svg?1543508529783';
   const collaborate = 'https://cdn.glitch.com/a67e7e84-c063-4c8e-a7fc-f4c7ab86186f%2Fcollaborate-illustration.svg?1543508686482';
 
-  const play = 'https://cdn.glitch.com/6ce807b5-7214-49d7-aadd-f11803bc35fd%2Fplay.svg';
   const whatsGlitchAlt = "Glitch is the friendly community where you'll find the app of your dreams";
 
   return (
@@ -57,10 +56,11 @@ const WhatIsGlitch = () => {
           </Heading>
 
           <OverlayVideo>
-            <div className="button video">
-              <Image src={play} className="play-button" alt="How it works" width="" height="" />
-              <span>How it works</span>
-            </div>
+            <span className="video">
+              <Button decorative emoji="playButton" imagePosition="left">
+                How it works
+              </Button>
+            </span>
           </OverlayVideo>
         </figure>
 

--- a/styles/globals.styl
+++ b/styles/globals.styl
@@ -100,6 +100,12 @@ hr
 button,
 input
   font-family: sansserif
+  
+button
+  text-align: left
+  font-size: 14px
+  line-height: 14px
+  font-weight: 600
 
 main,
 section


### PR DESCRIPTION
## Links
* Remix link: https://prickly-swim.glitch.me/

## GIF/Screenshots:
![Screen Shot 2019-07-02 at 1 45 38 PM](https://user-images.githubusercontent.com/938722/60534530-0f940400-9cd0-11e9-9131-6c63b8710404.png)
![Screen Shot 2019-07-02 at 1 46 52 PM](https://user-images.githubusercontent.com/938722/60534531-0f940400-9cd0-11e9-9bb2-832403a908b2.png)

## Changes:
* restore global button styles (e.g. font size, alignment) that were being implicitly depended on by some buttons
* fix play button on home page

## How To Test:
* visit https://prickly-swim.glitch.me/
* verify the 'how it works' button renders correctly
* log in
* verify popover navigation menus render correctly
