### PR TITLE
Profuse tea: Fix a race condition in user loading

### DIFF
--- a/src/components/sign-in-pop/index.js
+++ b/src/components/sign-in-pop/index.js
@@ -138,7 +138,7 @@ const EmailHandler = ({ align, showView }) => {
   return (
     <PopoverDialog align={align}>
       <MultiPopoverTitle>
-        Email Sign In <Emoji name="email" />
+        Email Sign In&nbsp;<Emoji name="email" />
       </MultiPopoverTitle>
       <PopoverActions>
         {status === 'ready' && (

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -159,19 +159,11 @@ const logSharedUserError = (sharedUser, newSharedUser) => {
   captureMessage('Invalid cachedUser');
 };
 
-const useValueRef = (value) => {
-  const ref = useRef(value);
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-  return ref;
-};
-
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const useDebouncedAsync = (fn) => {
-  const [working, setWorking] = useState(false); // Used to prevent simultaneous loading
-  const [pending, setPending] = useState(false); // Set true if fn is called while working
+  const [working, setWorking] = useState(false); // tracks if fn is currently running
+  const [pending, setPending] = useState(false); // run fn again whenever it finishes
   const debouncedFn = async () => {
     if (working) {
       setPending(true);
@@ -199,7 +191,10 @@ export const CurrentUserProvider = ({ children }) => {
   const [sharedUser, setSharedUser] = useLocalStorage('cachedUser', null);
   // put sharedUser in a ref so that we can access its current value in load(),
   // even if it was changed elsewhwere
-  const sharedUserRef = useValueRef(sharedUser);
+  const sharedUserRef = useRef(sharedUser);
+  useEffect(() => {
+    sharedUserRef.current = sharedUser;
+  }, [sharedUser]);
 
   // cachedUser mirrors GET /users/{id} and is what we actually display
   const [cachedUser, setCachedUser] = useLocalStorage('community-cachedUser', null);

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -175,7 +175,6 @@ const useDebouncedAsync = (fn) => {
   return async (...args) => {
     // delay loading a moment so both items from storage have a chance to update
     await sleep(1);
-    console.log(workingRef.current);
     if (workingRef.current) return;
     setWorking(true);
     await fn(...args);

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -159,15 +159,25 @@ const logSharedUserError = (sharedUser, newSharedUser) => {
   captureMessage('Invalid cachedUser');
 };
 
+const useValueRef = (value) => {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref;
+};
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const useDebouncedAsync = (fn) => {
   const [working, setWorking] = useState(false); // Used to prevent simultaneous loading
+  const workingRef = useValueRef(working);
   return async (...args) => {
-    if (working) return;
-    setWorking(true);
     // delay loading a moment so both items from storage have a chance to update
     await sleep(1);
+    console.log(workingRef.current);
+    if (workingRef.current) return;
+    setWorking(true);
     await fn(...args);
     setWorking(false);
   };
@@ -180,10 +190,7 @@ export const CurrentUserProvider = ({ children }) => {
   const [sharedUser, setSharedUser] = useLocalStorage('cachedUser', null);
   // put sharedUser in a ref so that we can access its current value in load(),
   // even if it was changed elsewhwere
-  const sharedUserRef = useRef(sharedUser);
-  useEffect(() => {
-    sharedUserRef.current = sharedUser;
-  }, [sharedUser]);
+  const sharedUserRef = useValueRef(sharedUser);
 
   // cachedUser mirrors GET /users/{id} and is what we actually display
   const [cachedUser, setCachedUser] = useLocalStorage('community-cachedUser', null);

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -171,6 +171,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const useDebouncedAsync = (fn) => {
   const [working, setWorking] = useState(false); // Used to prevent simultaneous loading
+  const [pending, se]
   const workingRef = useValueRef(working);
   return async (...args) => {
     // delay loading a moment so both items from storage have a chance to update

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -171,16 +171,25 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const useDebouncedAsync = (fn) => {
   const [working, setWorking] = useState(false); // Used to prevent simultaneous loading
-  const [pending, se]
-  const workingRef = useValueRef(working);
-  return async (...args) => {
+  const [pending, setPending] = useState(false); // Set true if fn is called while working
+  const debouncedFn = async () => {
+    if (working) {
+      setPending(true);
+      return;
+    }
+    setWorking(true);
+    setPending(false);
     // delay loading a moment so both items from storage have a chance to update
     await sleep(1);
-    if (workingRef.current) return;
-    setWorking(true);
-    await fn(...args);
+    await fn();
     setWorking(false);
   };
+  useEffect(() => {
+    if (!working && pending) {
+      debouncedFn();
+    }
+  }, [working, pending]);
+  return debouncedFn;
 };
 
 export const CurrentUserProvider = ({ children }) => {


### PR DESCRIPTION
## Links
https://profuse-tea.glitch.me/

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/60830150-90497900-a184-11e9-8e53-97fde02f1404.png)

## Changes:
- Adds a little whitespace to the email sign in pop between the title and the emoji
- If a call to a useDebouncedAsync-ed function is blocked, it'll be flagged so the function gets called again when it finishes. This fixes an occasional issue where a user isn't fully loaded after using the console to write their token to localstorage

## How To Test:
Run `localStorage.cachedUser = JSON.stringify({ persistentToken: "TOKEN" })` in the console and refresh the browser. On glitch.com it'll only partially load your user (evidenced by a missing resume coding button). This happens most consistently on pages without embeds. On profuse-tea it'll consistently load everything.