### PR TITLE
steadfast-ticket: don't use VisibilityContainer on /create

### DIFF
--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -83,7 +83,7 @@ function WhatIsGlitch() {
         </Heading>
         <div className={classNames(styles.sectionDescription, styles.whatIsGlitchDescription)}>
           <Text size="16px">Glitch is a collaborative programming environment that lives in your browser and deploys code as you type.</Text>
-          <Text size="16px">Use Glitch to build anything from a good ol’ static webpage to fullstack Node apps.</Text>
+          <Text size="16px">Use Glitch to build anything from a good ol’ static webpage to full-stack Node apps.</Text>
         </div>
       </div>
       <div className={styles.whatIsGlitchVideoContainer}>

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -14,7 +14,6 @@ import Embed from 'Components/project/embed';
 import WistiaVideo from 'Components/wistia-video';
 import Layout from 'Components/layout';
 import Loader from 'Components/loader';
-import VisibilityContainer from 'Components/visibility-container';
 import { useAPI } from 'State/api';
 import { useTracker } from 'State/segment-analytics';
 import { getRemixUrl } from 'Models/project';
@@ -575,7 +574,7 @@ const CreatePage = () => (
       <main className={styles.main}>
         <Banner />
         <WhatIsGlitch />
-        <VisibilityContainer>{({ wasEverVisible }) => wasEverVisible && <Starters />}</VisibilityContainer>
+        <Starters />
         <Collaborate />
         <YourAppIsLive />
         <Tools />


### PR DESCRIPTION
## Links
* [steadfast-ticket.glitch.me/create](https://steadfast-ticket.glitch.me/create)
* [GitHub issue](https://github.com/FogCreek/Glitch-Community-Work/issues/113)
* Specs/Notion docs

## Changes:
Get rid of Visibility container, in this case it doesn't help much with initial load time anyway, and it was causing the page to jump.

## How To Test:
Open /create. You shouldn't see starter content jumping around.