### PR TITLE
Superb-guide: Remove a workaround that isn't needed any more

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -147,18 +147,7 @@ export const useAPIHandlers = () => {
 
       // projects
       removeUserFromProject: ({ project, user }) => api.delete(`/projects/${project.id}/authorization`, { data: { targetUserId: user.id } }),
-      updateProjectDomain: ({ project }) =>
-        api.post(
-          `/project/domainChanged?projectId=${project.id}&authorization=${api.persistentToken}`,
-          {},
-          {
-            transformRequest: (data, headers) => {
-              // this endpoint doesn't like OPTIONS requests, which axios sends if there is an auth header (case 3328590)
-              delete headers.Authorization;
-              return data;
-            },
-          },
-        ),
+      updateProjectDomain: ({ project }) => api.post(`/project/domainChanged?projectId=${project.id}`),
       undeleteProject: ({ project }) => api.post(`/projects/${project.id}/undelete`),
 
       // teams


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me
https://glitch.fogbugz.com/f/cases/3328590/The-domainChanged-endpoint-doesn-t-support-OPTIONS

## Changes:
The domainChanged endpoint supports OPTIONS requests, so we don't need to jump through a hoop to avoid sending it headers.

## How To Test:
Try renaming a project and check for network errors