### PR TITLE
Cassey-community: fix title on create page for embeds

### DIFF
--- a/src/components/project/embed.js
+++ b/src/components/project/embed.js
@@ -30,12 +30,12 @@ const Embed = ({ domain }) => (
       // Embed iframe for app
       <iframe
         className={styles.embedIframe}
-        src={`${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
         title={`${domain} on Glitch`}
         allow="geolocation; microphone; camera; midi; encrypted-media"
         height="100%"
         width="100%"
         allowvr="yes"
+        src={`${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
       />
     ) : (
       // Error message if JS not supported

--- a/src/curated/embed.js
+++ b/src/curated/embed.js
@@ -4,7 +4,7 @@ export default `
   <iframe
     allow="geolocation; microphone; camera; midi; encrypted-media"
     src="https://glitch.com/embed/#!/embed/mystify?path=README.md&previewSize=100"
-    alt="mystify on Glitch"
+    title="mystify on Glitch"
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>


### PR DESCRIPTION
## Links
* cassey-community.glitch.me
* FogCreek/Glitch-Community-Work#100

## Changes:
* Change order of params on `iframe` which more consistently causes all the parameters we're passing in to appear. 
  * I have no idea why this works - order of params should not make a difference at all
* Changes so if we ever use curated/embed.js we are setting the accessible name correctly. I _think_ that file isn't being used for anything now, though. 

## How To Test:
* Go to embeds on create page (homepage when logged in). Verify that they have the `title` attribute set. 
* Go to an embed on a project page. Verify that it looks normal and has the `title` attribute set.

## Feedback I'm looking for:
WHY?? 

