### PR TITLE
Superb guide: Fix globals use in sentry, move collection color functions into utils/color

### DIFF
--- a/src/components/collection/collection-item-small.js
+++ b/src/components/collection/collection-item-small.js
@@ -10,7 +10,7 @@ import { CollectionAvatar } from 'Components/images/avatar';
 import VisibilityContainer from 'Components/visibility-container';
 import Arrow from 'Components/arrow';
 import { PrivateIcon } from 'Components/private-badge';
-import { isDarkColor } from 'Models/collection';
+import { isDarkColor } from 'Utils/color';
 import { useCollectionCurator } from 'State/collection';
 
 import styles from './collection-item.styl';

--- a/src/components/collection/collection-item-small.js
+++ b/src/components/collection/collection-item-small.js
@@ -61,12 +61,7 @@ const CollectionItemSmall = ({ collection, showCurator }) => (
             </div>
           </div>
         </div>
-        <div
-          className={styles.description}
-          style={{
-            color: isDarkColor(collection.coverColor) ? 'white' : '',
-          }}
-        >
+        <div className={classnames(styles.description, { [styles.dark]: isDarkColor(collection.coverColor) })}>
           <Markdown length={80}>{collection.description || ' '}</Markdown>
         </div>
       </div>

--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -16,7 +16,7 @@ import AnimationContainer from 'Components/animation-container';
 import { CollectionAvatar } from 'Components/images/avatar';
 import VisibilityContainer from 'Components/visibility-container';
 import Arrow from 'Components/arrow';
-import { isDarkColor } from 'Models/collection';
+import { isDarkColor } from 'Utils/color';
 import { useCollectionProjects, useCollectionCurator } from 'State/collection';
 
 import CollectionOptions from './collection-options-pop';

--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -110,7 +110,7 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
             <div className={styles.itemButtonWrap}>
               <Button decorative>{collection.name}</Button>
             </div>
-            <div className={styles.description} style={{ color: isDarkColor(collection.coverColor) ? 'white' : '' }}>
+            <div className={classNames(styles.description, { [styles.dark]: isDarkColor(collection.coverColor) })}>
               <Markdown length={100}>{collection.description || ' '}</Markdown>
             </div>
           </div>

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -142,6 +142,12 @@
       margin-top: 0
     a
       color: inherit
+  &.dark
+    color: white
+    a
+      color: #D2FEFF
+    code
+      background: #252525
   
 .collectionAvatarContainer
   flex: 0 0 40px

--- a/src/components/collection/container.js
+++ b/src/components/collection/container.js
@@ -4,7 +4,7 @@ import Pluralize from 'react-pluralize';
 import { partition, sampleSize } from 'lodash';
 import classnames from 'classnames';
 
-import { isDarkColor } from 'Models/collection';
+import { isDarkColor } from 'Utils/color';
 import Text from 'Components/text/text';
 import Image from 'Components/images/image';
 import FeaturedProject from 'Components/project/featured-project';

--- a/src/components/collection/container.styl
+++ b/src/components/collection/container.styl
@@ -25,6 +25,8 @@
     color: inherit
   a
     color: #D2FEFF
+  code
+    background: #252525
     
 .collectionContents
   flex: 1 1 auto

--- a/src/components/collection/edit-collection-color-pop.js
+++ b/src/components/collection/edit-collection-color-pop.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import randomColor from 'randomcolor';
 import { throttle } from 'lodash';
 
-import { getContrastWithDarkText, getContrastWithLightText } from 'Models/collection';
+import { getContrastWithDarkText, getContrastWithLightText } from 'Utils/color';
 import TextInput from 'Components/inputs/text-input';
 import ColorInput from 'Components/inputs/color';
 import Button from 'Components/buttons/button';

--- a/src/components/collection/note.js
+++ b/src/components/collection/note.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import _ from 'lodash';
 
-import { isDarkColor } from 'Models/collection';
+import { isDarkColor } from 'Utils/color';
 import AuthDescription from 'Components/fields/auth-description';
 import { CollectionCuratorLoader } from 'Components/collection/collection-item';
 

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -1,6 +1,5 @@
 import { kebabCase } from 'lodash';
 import randomColor from 'randomcolor';
-import { hex as getHexContrastRatio } from 'wcag-contrast';
 
 import { CDN_URL } from 'Utils/constants';
 
@@ -11,17 +10,6 @@ import { getCollectionPair } from './words';
 
 export const FALLBACK_AVATAR_URL = 'https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fcollection-avatar.svg?1541449590339';
 export const defaultAvatar = 'https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fcollection-avatar.svg?1540389405633';
-
-export const getContrastWithLightText = (hex) => getHexContrastRatio(hex, '#fff');
-
-export const getContrastWithDarkText = (hex) => getHexContrastRatio(hex, '#222');
-
-export const isDarkColor = (hex) => {
-  if (!hex.startsWith('#')) return false;
-  const contrastWithLightText = getContrastWithLightText(hex);
-  const contrastWithDarkText = getContrastWithDarkText(hex);
-  return contrastWithLightText > contrastWithDarkText;
-};
 
 export function getAvatarUrl(id) {
   return `${CDN_URL}/collection-avatar/${id}.png`;

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,5 +1,16 @@
 /* eslint-disable no-bitwise */
-/* eslint-disable import/prefer-default-export */
+import { hex as getHexContrastRatio } from 'wcag-contrast';
+
+export const getContrastWithLightText = (hex) => getHexContrastRatio(hex, '#fff');
+
+export const getContrastWithDarkText = (hex) => getHexContrastRatio(hex, '#222');
+
+export const isDarkColor = (hex) => {
+  if (!hex.startsWith('#')) return false;
+  const contrastWithLightText = getContrastWithLightText(hex);
+  const contrastWithDarkText = getContrastWithDarkText(hex);
+  return contrastWithLightText > contrastWithDarkText;
+};
 
 // from https://stackoverflow.com/a/21648508/1720985
 export const hexToRgbA = (hex) => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,20 +1,21 @@
 const { envs } = require('Shared/constants');
 /* globals RUNNING_ON */
 
-let currentEnv;
+let env;
 if (RUNNING_ON === 'development') {
-  currentEnv = 'development';
+  env = 'development';
 } else if (RUNNING_ON === 'staging') {
-  currentEnv = 'staging';
+  env = 'staging';
 } else if (RUNNING_ON === 'production') {
-  currentEnv = 'production';
+  env = 'production';
 } else if (document.location.hostname.indexOf('glitch.development') >= 0) {
-  currentEnv = 'development';
+  env = 'development';
 } else if (document.location.hostname.indexOf('staging.glitch.com') >= 0) {
-  currentEnv = 'staging';
+  env = 'staging';
 } else {
-  currentEnv = 'production';
+  env = 'production';
 }
+const currentEnv = env;
 
 const {
   APP_URL,
@@ -27,6 +28,7 @@ const {
 } = envs[currentEnv];
 
 export {
+  currentEnv,
   APP_URL,
   API_URL,
   EDITOR_URL,

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,4 +1,4 @@
-/* globals BUILD_TIMESTAMP, ENVIRONMENT, PROJECT_DOMAIN, _env */
+/* globals BUILD_TIMESTAMP, ENVIRONMENT, PROJECT_DOMAIN */
 
 //
 // This utility wraps the Sentry library so that we can guarantee
@@ -9,6 +9,7 @@
 //
 
 import * as Sentry from '@sentry/browser';
+import { currentEnv } from './constants';
 
 export * from '@sentry/browser';
 const SentryHelpers = require('Shared/sentryHelpers');
@@ -30,7 +31,7 @@ try {
         return null;
       }
       try {
-        return SentryHelpers.beforeSend(PROJECT_DOMAIN, _env, event);
+        return SentryHelpers.beforeSend(PROJECT_DOMAIN, currentEnv, event);
       } catch (error) {
         console.error(error);
         if (!beforeSendFailed) {

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -11,7 +11,7 @@
 import * as Sentry from '@sentry/browser';
 
 export * from '@sentry/browser';
-const SentryHelpers = require('../../shared/sentryHelpers');
+const SentryHelpers = require('Shared/sentryHelpers');
 
 let beforeSendFailed = false;
 let beforeBreadcrumbFailed = false;


### PR DESCRIPTION
## Links
- https://superb-guide.glitch.me/@gregs-test-team-1/zany-playlist
- https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/135

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/61072370-1f52cd00-a3e1-11e9-9785-fbcefb6ad2b9.png)

## Changes:
- Export the current env from utils/constants.js, and use it in utils/sentry.js rather than the removed window._env
- Moved generic color checking functions from models/collection.js to utils/color.js
- Collection items now have a .dark class like collection pages, rather than using inline styles
- Code blocks in dark collections use a dark background so the white text is legible

## How To Test:
- Check out the collection and make sure it is easy to read
- Force a sentry error and make sure beforeSend doesn't break