### PR TITLE
Foregoing-spell: move focus back to popover-opening-button after a popover is closed with keyboard

### DIFF
--- a/src/components/popover/container.js
+++ b/src/components/popover/container.js
@@ -18,9 +18,6 @@ const usePopoverToggle = ({ startOpen, onOpen, triggerButtonRef }) => {
   };
   const closePopover = () => {
     setStatus('closed');
-    if (triggerButtonRef && triggerButtonRef.current) {
-      triggerButtonRef.current.focus();
-    }
   };
 
   const togglePopover = (event) => {
@@ -45,6 +42,9 @@ const usePopoverToggle = ({ startOpen, onOpen, triggerButtonRef }) => {
       if (['Escape', 'Esc'].includes(event.key)) {
         event.preventDefault();
         setStatus('closed');
+      }
+      if (triggerButtonRef && triggerButtonRef.current) {
+        triggerButtonRef.current.focus();
       }
     };
     window.addEventListener('keyup', keyHandler);
@@ -90,7 +90,8 @@ const PopoverContainer = ({ children, onOpen, outer, startOpen, triggerButtonRef
 };
 PopoverContainer.propTypes = {
   children: PropTypes.func.isRequired,
-  triggerButtonRef: PropTypes.object.isRequired,
+  /* ref to the button that opened the popover. Used to reset focus back to that button after the user closes the popover by pressing escape */
+  triggerButtonRef: PropTypes.object,
   onOpen: PropTypes.func,
   outer: PropTypes.func,
   startOpen: PropTypes.bool,
@@ -99,6 +100,7 @@ PopoverContainer.defaultProps = {
   onOpen: null,
   outer: null,
   startOpen: false,
+  triggerButtonRef: null,
 };
 
 export default PopoverContainer;

--- a/src/components/popover/container.js
+++ b/src/components/popover/container.js
@@ -4,7 +4,7 @@ import onClickOutside from 'react-onclickoutside';
 import { isFragment } from 'react-is';
 
 // statuses: 'closed' | 'openedFromKeyboard' | 'openedFromClick'
-const usePopoverToggle = ({ startOpen, onOpen }) => {
+const usePopoverToggle = ({ startOpen, onOpen, triggerButtonRef }) => {
   const [status, setStatus] = useState(startOpen ? 'openedFromKeyboard' : 'closed');
   const openPopover = (event) => {
     if (event && event.detail === 0) {
@@ -18,6 +18,7 @@ const usePopoverToggle = ({ startOpen, onOpen }) => {
   };
   const closePopover = () => {
     setStatus('closed');
+    triggerButtonRef.focus();
   };
 
   const togglePopover = (event) => {
@@ -68,8 +69,8 @@ const MonitoredComponent = onClickOutside(({ children }) => children, {
 
 export const PopoverToggleContext = createContext(null);
 
-const PopoverContainer = ({ children, onOpen, outer, startOpen }) => {
-  const toggleState = usePopoverToggle({ startOpen, onOpen });
+const PopoverContainer = ({ children, onOpen, outer, startOpen, triggerButtonRef }) => {
+  const toggleState = usePopoverToggle({ startOpen, onOpen, triggerButtonRef });
 
   const inner = children(toggleState);
   if (isFragment(inner)) {
@@ -87,6 +88,7 @@ const PopoverContainer = ({ children, onOpen, outer, startOpen }) => {
 };
 PopoverContainer.propTypes = {
   children: PropTypes.func.isRequired,
+  triggerButtonRef: PropTypes.func.isRequired,
   onOpen: PropTypes.func,
   outer: PropTypes.func,
   startOpen: PropTypes.bool,

--- a/src/components/popover/container.js
+++ b/src/components/popover/container.js
@@ -18,7 +18,9 @@ const usePopoverToggle = ({ startOpen, onOpen, triggerButtonRef }) => {
   };
   const closePopover = () => {
     setStatus('closed');
-    triggerButtonRef.focus();
+    if (triggerButtonRef && triggerButtonRef.current) {
+      triggerButtonRef.current.focus();
+    }
   };
 
   const togglePopover = (event) => {
@@ -88,7 +90,7 @@ const PopoverContainer = ({ children, onOpen, outer, startOpen, triggerButtonRef
 };
 PopoverContainer.propTypes = {
   children: PropTypes.func.isRequired,
-  triggerButtonRef: PropTypes.func.isRequired,
+  triggerButtonRef: PropTypes.object.isRequired,
   onOpen: PropTypes.func,
   outer: PropTypes.func,
   startOpen: PropTypes.bool,

--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -102,7 +102,9 @@ PopoverWithButton.defaultProps = {
   onOpen: null,
 };
 
-export const PopoverMenu = ({ label, children: renderChildren, onOpen }) => (
+export const PopoverMenu = ({ label, children: renderChildren, onOpen }) => {
+    const buttonRef = useRef();
+  return (
   <div className={styles.popoverMenuWrap}>
     <PopoverContainer onOpen={onOpen}>
       {(popoverProps) => (
@@ -119,8 +121,8 @@ export const PopoverMenu = ({ label, children: renderChildren, onOpen }) => (
         </div>
       )}
     </PopoverContainer>
-  </div>
-);
+  </div>)
+}
 
 PopoverMenu.propTypes = {
   label: PropTypes.string,

--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -103,26 +103,27 @@ PopoverWithButton.defaultProps = {
 };
 
 export const PopoverMenu = ({ label, children: renderChildren, onOpen }) => {
-    const buttonRef = useRef();
+  const buttonRef = useRef();
   return (
-  <div className={styles.popoverMenuWrap}>
-    <PopoverContainer onOpen={onOpen}>
-      {(popoverProps) => (
-        <div>
-          <div className={styles.buttonWrap}>
-            <TransparentButton onClick={popoverProps.togglePopover}>
-              <span className={styles.arrowPadding}>
-                <span className={styles.downArrow} />
-              </span>
-              <span className={globalStyles.visuallyHidden}>{label}</span>
-            </TransparentButton>
+    <div className={styles.popoverMenuWrap}>
+      <PopoverContainer onOpen={onOpen} triggerButtonRef={buttonRef}>
+        {(popoverProps) => (
+          <div>
+            <div className={styles.buttonWrap}>
+              <TransparentButton onClick={popoverProps.togglePopover} ref={buttonRef}>
+                <span className={styles.arrowPadding}>
+                  <span className={styles.downArrow} />
+                </span>
+                <span className={globalStyles.visuallyHidden}>{label}</span>
+              </TransparentButton>
+            </div>
+            {popoverProps.visible && renderChildren(popoverProps)}
           </div>
-          {popoverProps.visible && renderChildren(popoverProps)}
-        </div>
-      )}
-    </PopoverContainer>
-  </div>)
-}
+        )}
+      </PopoverContainer>
+    </div>
+  );
+};
 
 PopoverMenu.propTypes = {
   label: PropTypes.string,

--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useMemo, createContext } from 'react';
+import React, { useState, useContext, useMemo, createContext, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { mapValues } from 'lodash';
 import TransparentButton from 'Components/buttons/transparent-button';
@@ -70,22 +70,25 @@ MultiPopoverTitle.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export const PopoverWithButton = ({ buttonProps, buttonText, children: renderChildren, onOpen }) => (
-  <div className={styles.popoverWithButtonWrap}>
-    <PopoverContainer onOpen={onOpen}>
-      {(popoverProps) => (
-        <div>
-          <div className={styles.buttonWrap}>
-            <Button {...buttonProps} onClick={popoverProps.togglePopover}>
-              {buttonText}
-            </Button>
+export const PopoverWithButton = ({ buttonProps, buttonText, children: renderChildren, onOpen }) => {
+  const buttonRef = useRef();
+  return (
+    <div className={styles.popoverWithButtonWrap}>
+      <PopoverContainer onOpen={onOpen} triggerButtonRef={buttonRef}>
+        {(popoverProps) => (
+          <div>
+            <div className={styles.buttonWrap}>
+              <Button {...buttonProps} ref={buttonRef} onClick={popoverProps.togglePopover}>
+                {buttonText}
+              </Button>
+            </div>
+            {popoverProps.visible && renderChildren(popoverProps)}
           </div>
-          {popoverProps.visible && renderChildren(popoverProps)}
-        </div>
-      )}
-    </PopoverContainer>
-  </div>
-);
+        )}
+      </PopoverContainer>
+    </div>
+  );
+};
 
 PopoverWithButton.propTypes = {
   buttonProps: PropTypes.object,
@@ -134,9 +137,7 @@ PopoverMenu.defaultProps = {
 export const PopoverMenuButton = ({ label, emoji, onClick }) => (
   <div className={styles.menuButtonWrap}>
     <Button size="small" type="tertiary" emoji={emoji} onClick={onClick}>
-      <div className={styles.popoverButtonContent}>
-        {label}
-      </div>
+      <div className={styles.popoverButtonContent}>{label}</div>
     </Button>
   </div>
 );


### PR DESCRIPTION
## Links
* foregoing-spell.glitch.me
* https://github.com/FogCreek/Glitch-Community-Work/issues/148 (see issue for context on how this is useful for accessibility - basically, it's to prevent an unexpected change in context for users navigating with the keyboard

## GIF/Screenshots:
![gif showing feature](https://media.giphy.com/media/ZCl5Uqjg6Q9L8Ydoia/giphy.gif)

## Changes:
* adds a prop to popover container for a ref to the button that is used to open the popover; if that prop is passed in, it's used to set focus back to said button when the popover is closed

## How To Test:
* open a popover basically anywhere on the site (both with keyboard and by clicking the button). Close it by clicking outside the popover; it should work normally. Close it by pressing the escape key; keyboard focus should return to the button you used to open the popover

## Feedback I'm looking for:
Is the ref passing around as clear as it could be?
