### PR TITLE
plastic-climb: fix Markdown component HTML validation

### DIFF
--- a/src/components/text/markdown.js
+++ b/src/components/text/markdown.js
@@ -41,11 +41,11 @@ const Markdown = ({ children, length, allowImages, renderAsPlaintext }) => {
     className = '';
 
     // in many cases we use the renderAsPlaintext prop to put markdown in a paragraph
-    // <div> can't be a descendent of a <p>, so use span
+    // <div> can't be a descendant of a <p>, so use span
     return <span className={className}>{rendered}</span>;
   }
 
-  // use <div> here, because <p> and other markup can't be a descendent of a <span>
+  // use <div> here, because <p> and other markup can't be a descendant of a <span>
   return (
     <div
       className={className}

--- a/src/components/text/markdown.js
+++ b/src/components/text/markdown.js
@@ -39,8 +39,13 @@ const Markdown = ({ children, length, allowImages, renderAsPlaintext }) => {
   if (renderAsPlaintext) {
     rendered = stripHtml(rendered);
     className = '';
+
+    // in many cases we use the renderAsPlaintext prop to put markdown in a paragraph
+    // <div> can't be a descendent of a <p>, so use span
+    return <span className={className}>{rendered}</span>;
   }
 
+  // use <div> here, because <p> and other markup can't be a descendent of a <span>
   return (
     <div
       className={className}


### PR DESCRIPTION
## Links
* [plastic-climb.glitch.me](https://plastic-climb.glitch.me)

## Changes:
Use `<span>` to wrap markdown content when `renderAsPlaintext` prop is used. The markdown component was [recently updated to wrap content in a `<div>`](https://github.com/FogCreek/Glitch-Community/commit/6ae6f63bd97a38f125442a2b5ccf20cccf091343#diff-3ce29a4a8845380d9e81b6e2533f5854), because `<p>`s and other things can't be descendants of `<span>`s.

But when we use the `renderAsPlaintext` prop, we often put that rendered markdown string in a `<p>`, and a `<div>` can't be a descendant of a `<p>`

## How To Test:
- Visit [/create](https://plastic-climb.glitch.me/create) and open the console. You shouldn't see any errors in the console
- Test out markdown elsewhere, it should still work
   - [Olivia's profile](https://plastic-climb.glitch.me/@oliviacpu)
   - Add project to collection pop