### PR TITLE
Foregoing-spell: more descriptive labels for collection & project options dropdowns

### DIFF
--- a/src/components/collection/collection-options-pop.js
+++ b/src/components/collection/collection-options-pop.js
@@ -5,7 +5,7 @@ import DeleteCollection from 'Components/collection/delete-collection-pop';
 
 export default function CollectionOptions({ collection, deleteCollection }) {
   return (
-    <PopoverMenu>
+    <PopoverMenu label={`Collection options for ${collection.name}`}>
       {() => (
         <DeleteCollection collection={collection} deleteCollection={deleteCollection} />
       )}

--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -82,7 +82,7 @@ export default function ProjectOptionsPop({ project, projectOptions }) {
     );
 
   return (
-    <PopoverMenu>
+    <PopoverMenu label={`Project Options for ${project.domain}`}>
       {({ togglePopover }) => (
         <MultiPopover
           views={{


### PR DESCRIPTION
## Links
* foregoing-spell.glitch.me
* [issue](https://github.com/FogCreek/Glitch-Community-Work/issues/177) 

## GIF/Screenshots:
Before: 
![image](https://user-images.githubusercontent.com/4480480/61242009-49bac800-a70a-11e9-8248-55e89da31f5d.png)

After: 

![image](https://user-images.githubusercontent.com/4480480/61242291-f5fcae80-a70a-11e9-80e3-c523c2ffea0d.png)
![image](https://user-images.githubusercontent.com/4480480/61242322-03b23400-a70b-11e9-8467-940c271c3912.png)

## Changes:
* Added non-default labels (default is just 'options') to project options pop buttons and collection options pop buttons

## How To Test:
* Check the accessible name of a project options dropdown arrow, make sure you see the project name as part of the label. 

![image](https://user-images.githubusercontent.com/4480480/61242160-a322f700-a70a-11e9-9ff2-df15391ed773.png)

