### PR TITLE
Only enforce https if not running locally (based on env variable that doesn't exist on glitch.com containers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "prestart": "nodemon --watch server --watch shared --exec 'eslint --config server/.eslintrc.server.js server shared webpack.config.js' &",
     "start": "nodemon --watch server --watch shared --watch views --exec 'forever --minUptime 5000 --spinSleepTime 5000' ./server/server.js",
+    "start_local": "nodemon --watch server --watch shared --watch views --exec 'forever --minUptime 5000 --spinSleepTime 5000' -r dotenv/config ./server/server.js",
     "storybook": "build-storybook -c storybook-config -o build/storybook"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "prestart": "nodemon --watch server --watch shared --exec 'eslint --config server/.eslintrc.server.js server shared webpack.config.js' &",
     "start": "nodemon --watch server --watch shared --watch views --exec 'forever --minUptime 5000 --spinSleepTime 5000' ./server/server.js",
-    "start_local": "nodemon --watch server --watch shared --watch views --exec 'forever --minUptime 5000 --spinSleepTime 5000' -r dotenv/config ./server/server.js",
     "storybook": "build-storybook -c storybook-config -o build/storybook"
   },
   "dependencies": {

--- a/server/routes.js
+++ b/server/routes.js
@@ -23,7 +23,10 @@ const DEFAULT_PROJECT_DESCRIPTION = (domain) => `Check out ~${domain} on Glitch,
 module.exports = function(external) {
   const app = express.Router();
 
-  app.use(enforce.HTTPS({ trustProtoHeader: true }));
+  // don't enforce HTTPS if building the site locally, not on glitch.com
+  if (!process.env.RUNNING_LOCALLY) {
+    app.use(enforce.HTTPS({ trustProtoHeader: true }));
+  }
 
   // CORS - Allow pages from any domain to make requests to our API
   app.use(function(request, response, next) {

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const compression = require('compression');
 const constants = require('./constants');
 const moduleAlias = require('module-alias');
+const dotenv = require('dotenv');
 
 moduleAlias.addAliases(require('../shared/aliases'));
 
@@ -9,6 +10,9 @@ const sentryHelpers = require('Shared/sentryHelpers');
 
 // https://docs.sentry.io/error-reporting/quickstart/?platform=node
 const Sentry = require('@sentry/node');
+
+// required for using .env when not on glitch; no-op when running on glitch
+dotenv.config();
 
 try {
   Sentry.init({


### PR DESCRIPTION
## Links
* foregoing-spell.glitch.me
* Issue-tracker link: n/a

## Changes:
* If the env variable RUNNING_LOCALLY is set, don't enforce HTTPS. This enables local development (on your machine vs on glitch.com) without code changes that could get accidentally committed

## How To Test:
* Try going to a http version of foregoing-spell, you should get redirected to https
* Run `RUNNING_LOCALLY=true node server/server.js` in your local development environment if you have one. You should be able to go to localhost and see the site running. (Without setting the env variable, you'd get redirected to `https://localhost` and told that your connection wasn't secure, therefore you couldn't connect. 

## Feedback I'm looking for:
* Any considerations for why we shouldn't do this that I'm overlooking?
* Any possible way this will break sitemaps?
