### PR TITLE
Superb-guide: Fix invalid attempt to spread... + some notification regressions

### DIFF
--- a/src/state/notifications.js
+++ b/src/state/notifications.js
@@ -38,8 +38,8 @@ export const NotificationsProvider = (props) => {
     return notification.id;
   };
 
-  const createError = (content = 'Something went wrong. Try refreshing?', opts) => {
-    create(content, ...opts);
+  const createError = (content = 'Something went wrong. Try refreshing?', opts = {}) => {
+    create(content, { type: 'error', ...opts });
   };
 
   const funcs = {

--- a/src/state/uploader.js
+++ b/src/state/uploader.js
@@ -36,13 +36,13 @@ async function uploadWrapper(notifications, upload) {
     });
   } catch (error) {
     captureException(error);
-    notifications.createNotification(<NotifyError error={error} />, { type: 'error' });
+    notifications.createErrorNotification(<NotifyError error={error} />);
     removeNotification();
     return result;
   }
 
   removeNotification();
-  notifications.createNotification('Image uploaded!');
+  notifications.createNotification('Image uploaded!', { type: 'success' });
   return result;
 }
 


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/
https://github.com/fogcreek/glitch-community-work/issues/181

## Changes:
- Don't try to spread an object parameter that is potentially not there
- Error notifications default to using the error styling (appear red not purple)
- Asset upload success notification is green rather than purple

## How To Test:
Try forcing some errors (easiest way is to check the offline box in chrome's network tab)
I haven't been able to reproduce the sentry error, but `console.log(...undefined)` throws

## Feedback I'm looking for:
Were either of those two color changes intentional?