### PR TITLE
Quixotic rocket: Fix link components using hash/relative urls

### DIFF
--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -13,7 +13,7 @@ import TrackedExternalLink from './tracked-external-link';
 
 export { WrappingLink, TrackedExternalLink };
 
-const Link = withRouter(React.forwardRef(({ to, children, location, ...props }, ref) => {
+const Link = withRouter(React.forwardRef(({ to, children, history, location, match, staticContext, ...props }, ref) => {
   const { origin, EXTERNAL_ROUTES } = useGlobals();
   if (typeof to === 'string') {
     const currentUrl = new URL(location.pathname + location.search + location.hash, origin);

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link as RouterLink, withRouter } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
 import { getLink as getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
@@ -13,12 +13,11 @@ import TrackedExternalLink from './tracked-external-link';
 
 export { WrappingLink, TrackedExternalLink };
 
-const Link = withRouter(React.forwardRef(({ to, children, history, location, match, staticContext, ...props }, ref) => {
-  const { origin, EXTERNAL_ROUTES } = useGlobals();
+const Link = React.forwardRef(({ to, children, ...props }, ref) => {
+  const { location, EXTERNAL_ROUTES } = useGlobals();
   if (typeof to === 'string') {
-    const currentUrl = new URL(location.pathname + location.search + location.hash, origin);
-    const targetUrl = new URL(to, currentUrl);
-    if (targetUrl.origin !== currentUrl.origin || EXTERNAL_ROUTES.some((route) => targetUrl.pathname.startsWith(route))) {
+    const targetUrl = new URL(to, location);
+    if (targetUrl.origin !== location.origin || EXTERNAL_ROUTES.some((route) => targetUrl.pathname.startsWith(route))) {
       return (
         <a href={to} {...props} ref={ref}>
           {children}
@@ -37,7 +36,7 @@ const Link = withRouter(React.forwardRef(({ to, children, history, location, mat
       {children}
     </RouterLink>
   );
-}));
+});
 Link.propTypes = {
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   children: PropTypes.node.isRequired,

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, withRouter } from 'react-router-dom';
 
 import { getLink as getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
@@ -13,11 +13,12 @@ import TrackedExternalLink from './tracked-external-link';
 
 export { WrappingLink, TrackedExternalLink };
 
-const Link = React.forwardRef(({ to, children, ...props }, ref) => {
+const Link = withRouter(React.forwardRef(({ to, children, location, ...props }, ref) => {
   const { origin, EXTERNAL_ROUTES } = useGlobals();
   if (typeof to === 'string') {
-    const targetUrl = new URL(to, origin);
-    if (targetUrl.origin !== origin || EXTERNAL_ROUTES.some((route) => targetUrl.pathname.startsWith(route))) {
+    const currentUrl = new URL(location.pathname + location.search + location.hash, origin);
+    const targetUrl = new URL(to, currentUrl);
+    if (targetUrl.origin !== currentUrl.origin || EXTERNAL_ROUTES.some((route) => targetUrl.pathname.startsWith(route))) {
       return (
         <a href={to} {...props} ref={ref}>
           {children}
@@ -36,7 +37,7 @@ const Link = React.forwardRef(({ to, children, ...props }, ref) => {
       {children}
     </RouterLink>
   );
-});
+}));
 Link.propTypes = {
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   children: PropTypes.node.isRequired,

--- a/src/state/globals.js
+++ b/src/state/globals.js
@@ -1,14 +1,16 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
 
 const Context = createContext({});
 
-export const GlobalsProvider = ({ children, origin, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES }) => {
-  const value = useMemo(() => ({
-    origin, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES,
-  }), [origin, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES]);
+export const GlobalsProvider = withRouter(({ children, history, location, origin, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES }) => {
+  const value = useMemo(() => {
+    const url = new URL(location.pathname + location.search + location.hash, origin);
+    return { history, location: url, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES };
+  }, [history, location.key, origin, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES]);
   return <Context.Provider value={value}>{children}</Context.Provider>;
-};
+});
 
 GlobalsProvider.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/

## Changes:
Use withRouter to map urls relative to the current url and not just the origin

## Feedback I'm looking for:
TODO in a separate pr: make our own `useRouter()` thing so we don't have to mess around with HOCs