### PR TITLE
Prioritize the hostname for determining environment-specific constants.

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,14 +1,23 @@
 const { envs } = require('Shared/constants');
 /* global RUNNING_ON */
 
-let envFromOrigin = 'production';
-if (origin.includes('staging.glitch.com')) {
-  envFromOrigin = 'staging';
-} else if (origin.includes('glitch.development')) {
-  envFromOrigin = 'development';
+// The current environment is based on the RUNNING_ON environment variable,
+// unless we're running under a staging/dev hostname, in which case we use the
+// corresponding environment config.
+function getCurrentEnv() {
+  if (origin.includes('staging.glitch.com')) {
+    return 'staging';
+  }
+  if (origin.includes('glitch.development')) {
+    return 'development';
+  }
+  if (envs[RUNNING_ON]) {
+    return RUNNING_ON;
+  }
+  return 'production';
 }
 
-const currentEnv = envs[RUNNING_ON] ? RUNNING_ON : envFromOrigin;
+const currentEnv = getCurrentEnv();
 
 const {
   APP_URL,


### PR DESCRIPTION
Marked @GregWeil as reviewer since we've already discussed the root issue.

## Links
* Remix link: https://osmose-community.glitch.me/
* Issue-tracker link: None
* Specs/doc links: None

## Changes:
The backend development setup runs a proxy to the production instance of the
community site, and expects the community site to detect that it is running
under the glitch.development hostname and make API requests to
api.glitch.development. Prior to this fix, the RUNNING_ON environment varible
overrode this hostname detection and made requests to the production API even
when running under the glitch.development hostname.

This updates the existing logic so that the RUNNING_ON environment variable
doesn't override the hostname detection that the backend dev setup expects.

## How To Test:
Testing that the site works as expected should work normally, but testing that the fix works requires a working [backend](https://github.com/FogCreek/Glitch) development setup. If you have that:

1. Create a file in your backend repo at `frontend/.community-url` with the contents:

   ```
   https://osmose-community.glitch.me
   ```

   This instructs your backend to proxy to my community remix instead of the production community app.
2. Start the full backend watcher.
3. Visit https://glitch.development and verify that API requests are going to `api.glitch.development` instead of `api.glitch.com`.

## Feedback I'm looking for:
General code review + help merging. I submitted this PR from my local checkout of the community site and don't really know the proper flow for getting it merged+deployed, so help would be appreciated. :D