### PR TITLE
tin-shoemaker: don't run webpack in a separate process if running the app locally

### DIFF
--- a/server/webpack.js
+++ b/server/webpack.js
@@ -28,7 +28,7 @@ function webpackExpressMiddleware() {
 }
 
 module.exports = function(app) {
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production' && !process.env.RUNNING_LOCALLY) {
     webpackBackgroundProcess();
   } else {
     app.use(webpackExpressMiddleware());


### PR DESCRIPTION
## Links
* [tin-shoemaker.glitch.me](tin-shoemaker.glitch.me)

## Changes:
* Add check to see if we're running the app locally, if so, don't run webpack in a separate process

## How To Test
* Not much to test here, just need a quick check that this won't have unintended consequences