### PR TITLE
bodega-boys: make sure search queries are URL-encoded

### DIFF
--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -128,11 +128,10 @@ const AlgoliaSearchController = withRouter(({ history, visible, openPopover, def
   const onSubmit = (event) => {
     event.preventDefault();
     if (!query) return;
-    const encodedQuery = encodeURIComponent(query);
     if (selectedResult) {
       history.push(urlForItem[selectedResult.type](selectedResult, query));
     } else {
-      history.push(`/search?q=${encodedQuery}`);
+      history.push(`/search?q=${encodeURIComponent(query)}`);
     }
   };
 

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -106,12 +106,15 @@ const AlgoliaSearchController = withRouter(({ history, visible, openPopover, def
   const [{ query, results, selectedResult }, dispatch] = useReducer(reducer, initialState);
   const algoliaResults = useAlgoliaSearch(query);
 
-  useEffect(() => {
-    // use last complete results
-    if (algoliaResults.status === 'ready') {
-      dispatch(actions.resultsChanged(algoliaResults));
-    }
-  }, [algoliaResults]);
+  useEffect(
+    () => {
+      // use last complete results
+      if (algoliaResults.status === 'ready') {
+        dispatch(actions.resultsChanged(algoliaResults));
+      }
+    },
+    [algoliaResults],
+  );
 
   const onKeyDown = (e) => {
     if (e.key === 'ArrowUp') {
@@ -125,10 +128,11 @@ const AlgoliaSearchController = withRouter(({ history, visible, openPopover, def
   const onSubmit = (event) => {
     event.preventDefault();
     if (!query) return;
+    const encodedQuery = encodeURIComponent(query);
     if (selectedResult) {
       history.push(urlForItem[selectedResult.type](selectedResult, query));
     } else {
-      history.push(`/search?q=${query}`);
+      history.push(`/search?q=${encodedQuery}`);
     }
   };
 

--- a/src/presenters/pages/search.js
+++ b/src/presenters/pages/search.js
@@ -12,7 +12,7 @@ import { useAlgoliaSearch } from 'State/search';
 const SearchPage = withRouter(({ query, activeFilter, history }) => {
   const searchResults = useAlgoliaSearch(query);
   const setActiveFilter = (filter) => {
-    history.push(`/search?q=${query}&activeFilter=${filter}`);
+    history.push(`/search?q=${encodeURIComponent(query)}&activeFilter=${filter}`);
   };
 
   return (


### PR DESCRIPTION
## Links
* [bodega-boys.glitch.me/search](https://bodega-boys.glitch.me/search)
* [#233: queries on /search aren't URL-encoded](https://github.com/FogCreek/Glitch-Community-Work/issues/233)

## GIF/Screenshots:
![search-bug-fix](https://user-images.githubusercontent.com/7584833/62002483-07629500-b0d3-11e9-993f-d431974bb07d.gif)

## Changes:
* URL-encode search queries in query strings on [/search](https://bodega-boys.glitch.me/search)

## How To Test:
* Enter a search query with a special character like `&`, `+` or `/`, the character should be URL-encoded
* Refresh the page, things should still work
* Click a result type tab, things should still work