### PR TITLE
psyched-damsel: lazy load qrcode package in two-factor settings view

### DIFF
--- a/src/components/account-settings-overlay/two-factor-settings.js
+++ b/src/components/account-settings-overlay/two-factor-settings.js
@@ -7,12 +7,12 @@ import Button from 'Components/buttons/button';
 import Loader from 'Components/loader';
 import Notification from 'Components/notification';
 
-import { useAPI, createAPIHook } from 'State/api';
+import { useAPI } from 'State/api';
 import { useCurrentUser } from 'State/current-user';
 
 import styles from './styles.styl';
 
-const useQRCode = createAPIHook(async () => import(/* webpackChunkName: "qrcode-bundle" */ 'qrcode'));
+const useQRCode = async () => import(/* webpackChunkName: "qrcode-bundle" */ 'qrcode');
 
 function TwoFactorSettings() {
   const { currentUser, reload } = useCurrentUser();


### PR DESCRIPTION
## Links
* [psyched-damsel.glitch.me](https://psyched-damsel.glitch.me)
* [#240](https://github.com/FogCreek/Glitch-Community-Work/issues/240)

## GIF/Screenshots:
**before**
<img width="721" alt="Screen Shot 2019-07-30 at 10 32 27 AM" src="https://user-images.githubusercontent.com/7584833/62138508-beb70180-b2b5-11e9-8a20-373eb0d789bc.png">

**after**
<img width="718" alt="Screen Shot 2019-07-30 at 10 30 51 AM" src="https://user-images.githubusercontent.com/7584833/62138697-0e95c880-b2b6-11e9-99ca-72eca90b2a61.png">

**QR codes in the two-factor settings still work**
<img width="450" src="https://user-images.githubusercontent.com/7584833/62138859-5ae10880-b2b6-11e9-9c48-b3690ea42528.png" />

## Changes:
- Lazy load `qrcode` in `two-factor-settings.js`

## Motivation
`qrcode` is only used on our two-factor settings view. It's ~85 kb, so not huge, but still substantial enough to warrant pulling it out of our dependencies bundle and only loading it in as we need it.

## How To Test:
1. Login
2. Enable user passwords at [psyched-damsel.glitch.me/secret](https://psyched-damsel.glitch.me/secret)
3. Go to account settings via the user options pop
4. Click "Two-factor authentication"
5. Enable two-factor, and confirm that everything still works

## Feedback I'm looking for:
* Does it still work as expected?
* Any unintended side effects?