### PR TITLE
ninth-winter: add documentation about running ~community locally

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -89,7 +89,7 @@ RUNNING_LOCALLY=true
 ```
 4. Start the server:
 ```bash
-node server/server.js
+npm start
 ```
 
 ### How do I add a question to the FAQ?

--- a/FAQ.md
+++ b/FAQ.md
@@ -69,7 +69,28 @@ In production, our code goes through cloudfront. This is why there's a delay aft
 - if `glitch.com` is broken but `community.glitch.me` works fine it points to an issue with cloudfront and it's best to communicate with the glitch infrastructure team to figure out where the problem is.
 - if you find `glitch.com` working in some browsers and not others, take a look at the hashes for the bundled javascript files to see if you're serving different files:
     - if the hashes match but one is serving code and the other is not or they are serving different code, you know something went wrong in serving that file in our pipeline and it's probably best to generate a new hash. You'll want to swap staging and community to get back to the last working hash if you haven't already, and then rebuild the new staging project to get a new hash for your javascript bundles. 
-    - if the hashes don't match, you know why you're seeing different behavior, you're serving different code! The next question is to figure out why? Check to see where the code is being served from, is it from browser cache? if `glitch.com` hashes don't match that at `community.glitch.me` after a few minutes after a swap the issue sounds more likely to be with cloudfront or some other piece of our infrastructure. 
+    - if the hashes don't match, you know why you're seeing different behavior, you're serving different code! The next question is to figure out why? Check to see where the code is being served from, is it from browser cache? if `glitch.com` hashes don't match that at `community.glitch.me` after a few minutes after a swap the issue sounds more likely to be with cloudfront or some other piece of our infrastructure.
+    
+### Can I run this app locally?
+
+Yes! In rare cases, you may find that you need to run ~community in your local development environment.
+
+1. If you haven't already, clone [Glitch-Community](https://github.com/fogcreek/glitch-community) from GitHub:
+```bash
+git clone git@github.com:FogCreek/Glitch-Community.git
+```
+2. Install the dependencies:
+```
+npm install
+```
+3. Create a file called `.env` in the root directory, and populate it with the `RUNNING_LOCALLY` variable, which tells our build process to allow the app to run on `localhost`
+```yaml
+RUNNING_LOCALLY=true
+```
+4. Start the server:
+```bash
+node server/server.js
+```
 
 ### How do I add a question to the FAQ?
 


### PR DESCRIPTION
## Links
* [ninth-winter.glitch.me](https://ninth-winter.glitch.me)

## Changes:
* Document how to run the app locally