### PR TITLE
Superb-guide: Load collection projects in order

### DIFF
--- a/src/state/collection.js
+++ b/src/state/collection.js
@@ -10,7 +10,7 @@ export const getCollectionWithProjects = async (api, { owner, name }) => {
   try {
     const [collection, projects] = await Promise.all([
       getSingleItem(api, `/v1/collections/by/fullUrl?fullUrl=${fullUrl}`, `${owner}/${name}`),
-      getAllPages(api, `/v1/collections/by/fullUrl/projects?limit=100&fullUrl=${fullUrl}`),
+      getAllPages(api, `/v1/collections/by/fullUrl/projects?fullUrl=${fullUrl}&orderKey=projectOrder&limit=100`),
     ]);
     return { ...collection, projects };
   } catch (error) {


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/
https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/246

## Changes:
Use `orderKey=projectOrder` when loading collection projects so they stay in the user defined order

## How To Test:
Try reordering some projects in a collection, then refresh