### PR TITLE
Quixotic rocket: Use updatedAt for image cache busting, differentiate getLink names

### DIFF
--- a/src/components/collection/delete-collection-pop.js
+++ b/src/components/collection/delete-collection-pop.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
-import { getOwnerLink, getLink } from 'Models/collection';
+import { getCollectionOwnerLink, getCollectionLink } from 'Models/collection';
 import Image from 'Components/images/image';
 import Loader from 'Components/loader';
 import { PopoverDialog, PopoverActions, PopoverTitle, ActionDescription, PopoverMenuButton } from 'Components/popover';
@@ -19,9 +19,9 @@ const DeleteCollectionPop = withRouter(({ location, history, collection, animate
     if (collectionIsDeleting) return;
     setCollectionIsDeleting(true);
     try {
-      if (location.pathname === getLink(coll)) {
+      if (location.pathname === getCollectionLink(coll)) {
         baseFuncs.deleteCollection();
-        history.push(getOwnerLink(collection));
+        history.push(getCollectionOwnerLink(collection));
       } else {
         animateAndDeleteCollection(collection.id);
       }

--- a/src/components/containers/cover-container.js
+++ b/src/components/containers/cover-container.js
@@ -19,9 +19,8 @@ const CoverContainer = ({ coverActions, children, type, item }) => {
     coverContainer: true,
     hasCoverImage: item.hasCoverImage,
   });
-  const cache = item.updatedAt;
   return (
-    <div className={className} style={getProfileStyles[type]({ ...item, cache })}>
+    <div className={className} style={getProfileStyles[type](item)}>
       {children}
       <div className={styles.buttonWrap}>{coverActions && <TrackedButtonGroup actions={coverActions} />}</div>
     </div>

--- a/src/components/containers/cover-container.js
+++ b/src/components/containers/cover-container.js
@@ -4,7 +4,7 @@ import classNames from 'classnames/bind';
 import TrackedButtonGroup from 'Components/buttons/tracked-button-group';
 
 import { getProfileStyle as getTeamProfileStyle } from 'Models/team';
-import { getProfileStyle as getUserProfileStyle } from 'Models/user';
+import { getUserProfileStyle } from 'Models/user';
 import styles from './cover-container.styl';
 
 const cx = classNames.bind(styles);

--- a/src/components/containers/cover-container.js
+++ b/src/components/containers/cover-container.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import TrackedButtonGroup from 'Components/buttons/tracked-button-group';
 
-import { getProfileStyle as getTeamProfileStyle } from 'Models/team';
+import { getTeamProfileStyle } from 'Models/team';
 import { getUserProfileStyle } from 'Models/user';
 import styles from './cover-container.styl';
 

--- a/src/components/containers/profile/project.js
+++ b/src/components/containers/profile/project.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import TrackedButtonGroup from 'Components/buttons/tracked-button-group';
-import { getAvatarUrl as getProjectAvatarUrl } from 'Models/project';
+import { getProjectAvatarUrl } from 'Models/project';
 import styles from './styles.styl';
 
 const suspendedAvatarUrl = 'https://cdn.glitch.com/2b785d6f-8e71-423f-b484-ec2383060a9b%2Fno-entry.png?1556733100930';
@@ -12,7 +12,7 @@ const getAvatarUrl = (currentUser, isAuthorized, project) => {
   if (project.suspendedReason && !isAuthorized && !currentUser.isSupport) {
     return suspendedAvatarUrl;
   }
-  return getProjectAvatarUrl(project.id).concat('?', project.avatarUpdatedAt);
+  return getProjectAvatarUrl(project);
 };
 
 const ProjectProfileContainer = ({ currentUser, project, children, avatarActions, isAuthorized }) => (

--- a/src/components/containers/profile/team.js
+++ b/src/components/containers/profile/team.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 
 import CoverContainer from 'Components/containers/cover-container';
 import TrackedButtonGroup from 'Components/buttons/tracked-button-group';
-import { getAvatarStyle as getTeamAvatarStyle } from 'Models/team';
+import { getTeamAvatarStyle } from 'Models/team';
 import styles from './styles.styl';
 
 const TeamProfileContainer = ({ item, children, avatarActions, coverActions }) => (

--- a/src/components/containers/profile/team.js
+++ b/src/components/containers/profile/team.js
@@ -12,7 +12,7 @@ const TeamProfileContainer = ({ item, children, avatarActions, coverActions }) =
     <div className={classnames(styles.profileWrap)}>
       <div className={styles.avatarContainer}>
         {/* eslint-disable-next-line no-underscore-dangle */}
-        <div className={classnames(styles.avatar, styles.team)} style={getTeamAvatarStyle({ ...item, cache: item.updatedAt })} />
+        <div className={classnames(styles.avatar, styles.team)} style={getTeamAvatarStyle(item)} />
         <div className={styles.avatarButtons}>{avatarActions && <TrackedButtonGroup actions={avatarActions} />}</div>
       </div>
       <div className={styles.profileInfo}>{children}</div>

--- a/src/components/containers/profile/user.js
+++ b/src/components/containers/profile/user.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import CoverContainer from 'Components/containers/cover-container';
 import ProfileList from 'Components/profile-list';
 import TrackedButtonGroup from 'Components/buttons/tracked-button-group';
-import { getAvatarStyle as getUserAvatarStyle } from 'Models/user';
+import { getUserAvatarStyle } from 'Models/user';
 import styles from './styles.styl';
 
 const UserProfileContainer = ({ item, children, avatarActions, coverActions, teams }) => {

--- a/src/components/create-team-pop/index.js
+++ b/src/components/create-team-pop/index.js
@@ -8,7 +8,7 @@ import { MultiPopoverTitle, PopoverDialog, PopoverInfo, PopoverActions, InfoDesc
 import Button from 'Components/buttons/button';
 import Emoji from 'Components/images/emoji';
 import { getPredicates, getTeamPair } from 'Models/words';
-import { getLink } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { useAPI } from 'State/api';
 import { useTracker } from 'State/segment-analytics';
 
@@ -106,7 +106,7 @@ const CreateTeamPop = withRouter(({ history }) => {
         hasCoverImage: false,
         isVerified: false,
       });
-      history.push(getLink(data));
+      history.push(getTeamLink(data));
     } catch (error) {
       const message = error && error.response && error.response.data && error.response.data.message;
       setState({

--- a/src/components/deleted-projects/index.js
+++ b/src/components/deleted-projects/index.js
@@ -12,7 +12,7 @@ import TransparentButton from 'Components/buttons/transparent-button';
 import AnimationContainer from 'Components/animation-container';
 import Grid from 'Components/containers/grid';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
-import { getAvatarUrl } from 'Models/project';
+import { getProjectAvatarUrl } from 'Models/project';
 import { useAPI } from 'State/api';
 import { useTrackedFunc } from 'State/segment-analytics';
 
@@ -23,7 +23,7 @@ const DeletedProject = ({ project, onClick }) => {
   if (!onClick) {
     return (
       <div className={styles.deletedProject}>
-        <img className={styles.avatar} src={getAvatarUrl(project.id)} alt="" />
+        <img className={styles.avatar} src={getProjectAvatarUrl(project)} alt="" />
         <div className={styles.projectName}>{project.domain}</div>
         <TooltipContainer
           type="action"
@@ -43,7 +43,7 @@ const DeletedProject = ({ project, onClick }) => {
     <AnimationContainer type="slideUp" onAnimationEnd={onClick}>
       {(animateAndDeleteProject) => (
         <TransparentButton onClick={animateAndDeleteProject} className={styles.deletedProject}>
-          <img className={styles.avatar} src={getAvatarUrl(project.id)} alt="" />
+          <img className={styles.avatar} src={getProjectAvatarUrl(project)} alt="" />
           <span className={styles.projectName}>{project.domain}</span>
           <div className={styles.buttonWrap}>
             <Button size="small" decorative>

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -8,7 +8,7 @@ import CollectionAvatarBase from 'Components/collection/defaultAvatar';
 import { hexToRgbA } from 'Utils/color';
 import { CDN_URL } from 'Utils/constants';
 
-import { DEFAULT_TEAM_AVATAR, getAvatarUrl as getTeamAvatarUrl } from 'Models/team';
+import { DEFAULT_TEAM_AVATAR, getTeamAvatarUrl } from 'Models/team';
 import { ANON_AVATAR_URL, getUserAvatarThumbnailUrl, getDisplayName } from 'Models/user';
 import { FALLBACK_AVATAR_URL, getAvatarUrl as getProjectAvatarUrl } from 'Models/project';
 

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -10,7 +10,7 @@ import { CDN_URL } from 'Utils/constants';
 
 import { DEFAULT_TEAM_AVATAR, getTeamAvatarUrl } from 'Models/team';
 import { ANON_AVATAR_URL, getUserAvatarThumbnailUrl, getDisplayName } from 'Models/user';
-import { FALLBACK_AVATAR_URL, getAvatarUrl as getProjectAvatarUrl } from 'Models/project';
+import { FALLBACK_AVATAR_URL, getProjectAvatarUrl } from 'Models/project';
 
 import styles from './avatar.styl';
 
@@ -91,7 +91,7 @@ UserAvatar.defaultProps = {
 };
 
 export const ProjectAvatar = ({ project, hasAlt }) => (
-  <Avatar name={hasAlt ? project.domain : ''} src={getProjectAvatarUrl(project.id)} srcFallback={FALLBACK_AVATAR_URL} type="team" hideTooltip />
+  <Avatar name={hasAlt ? project.domain : ''} src={getProjectAvatarUrl(project)} srcFallback={FALLBACK_AVATAR_URL} type="team" hideTooltip />
 );
 
 ProjectAvatar.propTypes = {

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -9,7 +9,7 @@ import { hexToRgbA } from 'Utils/color';
 import { CDN_URL } from 'Utils/constants';
 
 import { DEFAULT_TEAM_AVATAR, getAvatarUrl as getTeamAvatarUrl } from 'Models/team';
-import { ANON_AVATAR_URL, getAvatarThumbnailUrl, getDisplayName } from 'Models/user';
+import { ANON_AVATAR_URL, getUserAvatarThumbnailUrl, getDisplayName } from 'Models/user';
 import { FALLBACK_AVATAR_URL, getAvatarUrl as getProjectAvatarUrl } from 'Models/project';
 
 import styles from './avatar.styl';
@@ -63,7 +63,7 @@ TeamAvatar.defaultProps = {
 export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton }) => (
   <Avatar
     name={getDisplayName(user) + suffix}
-    src={getAvatarThumbnailUrl(user)}
+    src={getUserAvatarThumbnailUrl(user)}
     color={user.color}
     srcFallback={ANON_AVATAR_URL}
     type="user"

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -6,7 +6,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
 import { getLink as getTeamLink } from 'Models/team';
-import { getLink as getUserLink } from 'Models/user';
+import { getUserLink } from 'Models/user';
 import { useGlobals } from 'State/globals';
 import WrappingLink from './wrapping-link';
 import TrackedExternalLink from './tracked-external-link';

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -5,7 +5,7 @@ import { Link as RouterLink } from 'react-router-dom';
 
 import { getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
-import { getLink as getTeamLink } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { getUserLink } from 'Models/user';
 import { useGlobals } from 'State/globals';
 import WrappingLink from './wrapping-link';

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { getCollectionLink } from 'Models/collection';
-import { getLink as getProjectLink } from 'Models/project';
+import { getProjectLink } from 'Models/project';
 import { getTeamLink } from 'Models/team';
 import { getUserLink } from 'Models/user';
 import { useGlobals } from 'State/globals';

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Link as RouterLink } from 'react-router-dom';
 
-import { getLink as getCollectionLink } from 'Models/collection';
+import { getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
 import { getLink as getTeamLink } from 'Models/team';
 import { getLink as getUserLink } from 'Models/user';

--- a/src/components/project/project-item-small.js
+++ b/src/components/project/project-item-small.js
@@ -6,12 +6,12 @@ import classnames from 'classnames';
 import Image from 'Components/images/image';
 import Text from 'Components/text/text';
 import Badge from 'Components/badges/badge';
-import { FALLBACK_AVATAR_URL, getAvatarUrl } from 'Models/project';
+import { FALLBACK_AVATAR_URL, getProjectAvatarUrl } from 'Models/project';
 import { ProjectLink } from 'Components/link';
 
 import styles from './project-item.styl';
 
-const ProfileAvatar = ({ project }) => <Image className={styles.avatar} src={getAvatarUrl(project.id)} defaultSrc={FALLBACK_AVATAR_URL} alt="" />;
+const ProfileAvatar = ({ project }) => <Image className={styles.avatar} src={getProjectAvatarUrl(project)} defaultSrc={FALLBACK_AVATAR_URL} alt="" />;
 
 const getLinkBodyStyles = (project) => classnames(styles.linkBodySmall, { [styles.private]: project.private });
 

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -10,7 +10,7 @@ import { ProjectLink } from 'Components/link';
 import { PrivateIcon } from 'Components/private-badge';
 import AnimationContainer from 'Components/animation-container';
 import VisibilityContainer from 'Components/visibility-container';
-import { FALLBACK_AVATAR_URL, getAvatarUrl } from 'Models/project';
+import { FALLBACK_AVATAR_URL, getProjectAvatarUrl } from 'Models/project';
 import { useProjectMembers } from 'State/project';
 import { useProjectOptions } from 'State/project-options';
 import { useCurrentUser } from 'State/current-user';
@@ -18,7 +18,7 @@ import { useCurrentUser } from 'State/current-user';
 import ProjectOptionsPop from './project-options-pop';
 import styles from './project-item.styl';
 
-const ProfileAvatar = ({ project }) => <Image className={styles.avatar} src={getAvatarUrl(project.id)} defaultSrc={FALLBACK_AVATAR_URL} alt="" />;
+const ProfileAvatar = ({ project }) => <Image className={styles.avatar} src={getProjectAvatarUrl(project)} defaultSrc={FALLBACK_AVATAR_URL} alt="" />;
 
 const getLinkBodyStyles = (project) =>
   classnames(styles.linkBody, {

--- a/src/components/project/project-result-item.js
+++ b/src/components/project/project-result-item.js
@@ -7,7 +7,7 @@ import ProfileList from 'Components/profile-list';
 import VisibilityContainer from 'Components/visibility-container';
 import { ResultItem, ResultInfo, ResultName, ResultDescription } from 'Components/containers/results-list';
 import { ProjectAvatar } from 'Components/images/avatar';
-import { getLink } from 'Models/project';
+import { getProjectLink } from 'Models/project';
 import { useProjectMembers } from 'State/project';
 
 import styles from './project-result-item.styl';
@@ -30,7 +30,7 @@ const ProfileListWrap = ({ project }) => (
 const ProjectResultItem = ({ project, selected, active, onClick }) => (
   <ResultItem
     className={classnames(project.private && styles.private)}
-    href={getLink(project)}
+    href={getProjectLink(project)}
     onClick={onClick}
     active={active}
     selected={selected}

--- a/src/components/recent-projects/index.js
+++ b/src/components/recent-projects/index.js
@@ -8,7 +8,7 @@ import { UserLink, WrappingLink } from 'Components/link';
 import Button from 'Components/buttons/button';
 import Arrow from 'Components/arrow';
 import SignInPop from 'Components/sign-in-pop';
-import { getAvatarStyle, getLink } from 'Models/user';
+import { getUserAvatarStyle, getUserLink } from 'Models/user';
 import { useCurrentUser } from 'State/current-user';
 
 import styles from './styles.styl';
@@ -54,8 +54,8 @@ const RecentProjects = () => {
       <CoverContainer type="user" item={currentUser}>
         <div className={styles.coverWrap}>
           <div className={styles.avatarWrap}>
-            <WrappingLink user={currentUser} href={getLink(currentUser)}>
-              <div className={styles.userAvatar} style={getAvatarStyle(currentUser)} />
+            <WrappingLink user={currentUser} href={getUserLink(currentUser)}>
+              <div className={styles.userAvatar} style={getUserAvatarStyle(currentUser)} />
             </WrappingLink>
           </div>
           <div className={styles.projectsWrap}>

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { mapValues, flatMap } from 'lodash';
 
 import { PopoverContainer } from 'Components/popover';
-import { getLink as getProjectLink } from 'Models/project';
+import { getProjectLink } from 'Models/project';
 import { getUserLink } from 'Models/user';
 import { getTeamLink } from 'Models/team';
 import { useAlgoliaSearch } from 'State/search';

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -5,7 +5,7 @@ import { mapValues, flatMap } from 'lodash';
 
 import { PopoverContainer } from 'Components/popover';
 import { getLink as getProjectLink } from 'Models/project';
-import { getLink as getUserLink } from 'Models/user';
+import { getUserLink } from 'Models/user';
 import { getLink as getTeamLink } from 'Models/team';
 import { useAlgoliaSearch } from 'State/search';
 

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -6,7 +6,7 @@ import { mapValues, flatMap } from 'lodash';
 import { PopoverContainer } from 'Components/popover';
 import { getLink as getProjectLink } from 'Models/project';
 import { getUserLink } from 'Models/user';
-import { getLink as getTeamLink } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { useAlgoliaSearch } from 'State/search';
 
 import TextInput from '../inputs/text-input';

--- a/src/components/search-result-cover-bar/index.js
+++ b/src/components/search-result-cover-bar/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Image from 'Components/images/image';
 import { getCoverUrl as getTeamCoverUrl } from 'Models/team';
-import { getCoverUrl as getUserCoverUrl, lightColors } from 'Models/user';
+import { getUserCoverUrl, lightColors } from 'Models/user';
 import { hexToRgbA } from 'Utils/color';
 import styles from './search-result-cover-bar.styl';
 

--- a/src/components/search-result-cover-bar/index.js
+++ b/src/components/search-result-cover-bar/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Image from 'Components/images/image';
-import { getCoverUrl as getTeamCoverUrl } from 'Models/team';
+import { getTeamCoverUrl } from 'Models/team';
 import { getUserCoverUrl, lightColors } from 'Models/user';
 import { hexToRgbA } from 'Utils/color';
 import styles from './search-result-cover-bar.styl';

--- a/src/components/search-result-cover-bar/index.js
+++ b/src/components/search-result-cover-bar/index.js
@@ -6,8 +6,6 @@ import { getUserCoverUrl, lightColors } from 'Models/user';
 import { hexToRgbA } from 'Utils/color';
 import styles from './search-result-cover-bar.styl';
 
-const cacheBuster = Math.floor(Math.random() * 1000);
-
 const defaultCoverURL = 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fdefault-cover-wide.svg?1503518400625';
 
 const coverUrlForType = {
@@ -15,13 +13,13 @@ const coverUrlForType = {
   user: getUserCoverUrl,
 };
 
-const SearchResultCoverBar = ({ type, item, size, cache = cacheBuster }) => {
+const SearchResultCoverBar = ({ type, item, size }) => {
   const getCoverUrl = coverUrlForType[type];
   const coverBackground = hexToRgbA(lightColors[item.id % 4]);
 
   return (
     <div className={styles.cover} style={{ backgroundColor: coverBackground }}>
-      <Image src={getCoverUrl({ ...item, size, cache })} defaultSrc={defaultCoverURL} alt="" />
+      <Image src={getCoverUrl({ ...item, size })} defaultSrc={defaultCoverURL} alt="" />
     </div>
   );
 };

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -10,7 +10,7 @@ import Thanks from 'Components/thanks';
 import VerifiedBadge from 'Components/verified-badge';
 import ProfileList from 'Components/profile-list';
 import { WrappingLink } from 'Components/link';
-import { getLink, getAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
+import { getTeamLink, getTeamAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
 import { createAPIHook } from 'State/api';
 import { captureException } from 'Utils/sentry';
 
@@ -26,14 +26,14 @@ const useTeamUsers = createAPIHook(async (api, teamID) => {
   }
 });
 
-const ProfileAvatar = ({ team }) => <Image className={styles.avatar} src={getAvatarUrl(team)} defaultSrc={DEFAULT_TEAM_AVATAR} alt="" />;
+const ProfileAvatar = ({ team }) => <Image className={styles.avatar} src={getTeamAvatarUrl(team)} defaultSrc={DEFAULT_TEAM_AVATAR} alt="" />;
 
 const getTeamThanksCount = (team) => sumBy(team.users, (user) => user.thanksCount);
 
 const TeamItem = ({ team }) => {
   const { value: users } = useTeamUsers(team.id);
   return (
-    <WrappingLink className={styles.container} href={getLink(team)}>
+    <WrappingLink className={styles.container} href={getTeamLink(team)}>
       <Cover type="team" item={team} size="medium" />
       <div className={styles.mainContent}>
         <div className={styles.avatarWrap}>
@@ -41,7 +41,7 @@ const TeamItem = ({ team }) => {
         </div>
         <div className={styles.body}>
           <div className={styles.itemButtonWrap}>
-            <Button href={getLink(team)}>{team.name}</Button>
+            <Button href={getTeamLink(team)}>{team.name}</Button>
             {!!team.isVerified && <VerifiedBadge />}
           </div>
           <div className={styles.usersList}>

--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { orderBy } from 'lodash';
 
-import { getLink as getTeamLink, getAvatarUrl as getTeamAvatarUrl } from 'Models/team';
+import { getTeamLink, getTeamAvatarUrl } from 'Models/team';
 import { getUserAvatarThumbnailUrl } from 'Models/user';
 import Image from 'Components/images/image';
 import { UserAvatar } from 'Components/images/avatar';

--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { orderBy } from 'lodash';
 
 import { getLink as getTeamLink, getAvatarUrl as getTeamAvatarUrl } from 'Models/team';
-import { getAvatarThumbnailUrl as getUserAvatarUrl } from 'Models/user';
+import { getUserAvatarThumbnailUrl } from 'Models/user';
 import Image from 'Components/images/image';
 import { UserAvatar } from 'Components/images/avatar';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
@@ -111,7 +111,7 @@ Are you sure you want to sign out?`)
       <PopoverTitle>
         <UserLink user={user}>
           <div className={styles.userAvatarContainer} style={{ backgroundColor: user.color }}>
-            <Image src={getUserAvatarUrl(user)} alt="Your avatar" />
+            <Image src={getUserAvatarThumbnailUrl(user)} alt="Your avatar" />
           </div>
           <div className={styles.userInfo}>
             <InfoDescription>{user.name || 'Anonymous'}</InfoDescription>

--- a/src/components/user/user-item.js
+++ b/src/components/user/user-item.js
@@ -6,11 +6,11 @@ import Markdown from 'Components/text/markdown';
 import Cover from 'Components/search-result-cover-bar';
 import Thanks from 'Components/thanks';
 import Image from 'Components/images/image';
-import { getAvatarUrl, ANON_AVATAR_URL } from 'Models/user';
+import { getUserAvatarUrl, ANON_AVATAR_URL } from 'Models/user';
 import { UserLink } from 'Components/link';
 import styles from './user-item.styl';
 
-const ProfileAvatar = ({ user }) => <Image className={styles.avatar} src={getAvatarUrl(user)} backgroundColor={user.color} defaultSrc={ANON_AVATAR_URL} alt="" />;
+const ProfileAvatar = ({ user }) => <Image className={styles.avatar} src={getUserAvatarUrl(user)} backgroundColor={user.color} defaultSrc={ANON_AVATAR_URL} alt="" />;
 
 const NameAndLogin = ({ user }) =>
   user.name ? (

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -1,10 +1,9 @@
 import { kebabCase } from 'lodash';
 
-import { CDN_URL } from 'Utils/constants';
 import { pickRandomColor } from 'Utils/color';
 
 import { getLink as getTeamLink } from './team';
-import { getLink as getUserLink } from './user';
+import { getUserLink } from './user';
 
 import { getCollectionPair } from './words';
 
@@ -38,10 +37,6 @@ export function getCollectionsWithMyStuff({ collections }) {
   updatedCollections.unshift(myStuffCollection);
 
   return updatedCollections;
-}
-
-export function getCollectionAvatarUrl({ id, updatedAt }) {
-  return `${CDN_URL}/collection-avatar/${id}.png?${updatedAt}`;
 }
 
 export function getCollectionOwnerLink(collection) {

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -2,7 +2,7 @@ import { kebabCase } from 'lodash';
 
 import { pickRandomColor } from 'Utils/color';
 
-import { getLink as getTeamLink } from './team';
+import { getTeamLink } from './team';
 import { getUserLink } from './user';
 
 import { getCollectionPair } from './words';

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -40,11 +40,11 @@ export function getCollectionsWithMyStuff({ collections }) {
   return updatedCollections;
 }
 
-export function getAvatarUrl(id) {
-  return `${CDN_URL}/collection-avatar/${id}.png`;
+export function getCollectionAvatarUrl({ id, updatedAt }) {
+  return `${CDN_URL}/collection-avatar/${id}.png?${updatedAt}`;
 }
 
-export function getOwnerLink(collection) {
+export function getCollectionOwnerLink(collection) {
   if (collection.team) {
     return getTeamLink(collection.team);
   }
@@ -54,11 +54,11 @@ export function getOwnerLink(collection) {
   throw new Error(`Collection ${collection.id} has no team or user field!`);
 }
 
-export function getLink(collection) {
+export function getCollectionLink(collection) {
   if (collection.fullUrl) {
     return `/@${collection.fullUrl}`;
   }
-  return `${getOwnerLink(collection)}/${collection.url}`;
+  return `${getCollectionOwnerLink(collection)}/${collection.url}`;
 }
 
 export async function createCollection({ api, name, teamId, createNotification, myStuffEnabled = false }) {

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -2,8 +2,8 @@ import { CDN_URL, EDITOR_URL, PROJECTS_DOMAIN } from 'Utils/constants';
 
 export const FALLBACK_AVATAR_URL = 'https://cdn.glitch.com/c53fd895-ee00-4295-b111-7e024967a033%2Ffallback-project-avatar.svg?1528812220123';
 
-export function getProjectAvatarUrl({ id }) {
-  return `${CDN_URL}/project-avatar/${id}.png`;
+export function getProjectAvatarUrl({ id, avatarUpdatedAt }) {
+  return `${CDN_URL}/project-avatar/${id}.png?${avatarUpdatedAt}`;
 }
 
 export function getProjectLink({ domain }) {

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -2,7 +2,7 @@ import { CDN_URL, EDITOR_URL, PROJECTS_DOMAIN } from 'Utils/constants';
 
 export const FALLBACK_AVATAR_URL = 'https://cdn.glitch.com/c53fd895-ee00-4295-b111-7e024967a033%2Ffallback-project-avatar.svg?1528812220123';
 
-export function getAvatarUrl(id, cdnUrl = CDN_URL) {
+export function getProjectAvatarUrl(id, cdnUrl = CDN_URL) {
   return `${cdnUrl}/project-avatar/${id}.png`;
 }
 

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -6,7 +6,7 @@ export function getAvatarUrl(id, cdnUrl = CDN_URL) {
   return `${cdnUrl}/project-avatar/${id}.png`;
 }
 
-export function getLink({ domain }) {
+export function getProjectLink({ domain }) {
   return `/~${domain}`;
 }
 

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -2,8 +2,8 @@ import { CDN_URL, EDITOR_URL, PROJECTS_DOMAIN } from 'Utils/constants';
 
 export const FALLBACK_AVATAR_URL = 'https://cdn.glitch.com/c53fd895-ee00-4295-b111-7e024967a033%2Ffallback-project-avatar.svg?1528812220123';
 
-export function getProjectAvatarUrl(id, cdnUrl = CDN_URL) {
-  return `${cdnUrl}/project-avatar/${id}.png`;
+export function getProjectAvatarUrl({ id }) {
+  return `${CDN_URL}/project-avatar/${id}.png`;
 }
 
 export function getProjectLink({ domain }) {

--- a/src/models/team.js
+++ b/src/models/team.js
@@ -10,7 +10,7 @@ export const getTeamAvatarUrl = ({ id, hasAvatarImage, updatedAt, size = 'large'
   return hasAvatarImage ? customImage : DEFAULT_TEAM_AVATAR;
 };
 
-export const getAvatarStyle = (team) => {
+export const getTeamAvatarStyle = (team) => {
   const image = getTeamAvatarUrl(team);
   if (team.hasAvatarImage) {
     return {
@@ -23,14 +23,14 @@ export const getAvatarStyle = (team) => {
   };
 };
 
-export const getCoverUrl = ({ id, hasCoverImage, updatedAt, size = 'large' }) => {
+export const getTeamCoverUrl = ({ id, hasCoverImage, updatedAt, size = 'large' }) => {
   const customImage = `${CDN_URL}/team-cover/${id}/${size}?${updatedAt}`;
   const defaultImage = 'https://cdn.glitch.com/b065beeb-4c71-4a9c-a8aa-4548e266471f%2Fteam-cover-pattern.svg?v=1559853406967';
   return hasCoverImage ? customImage : defaultImage;
 };
 
-export const getProfileStyle = (team) => {
-  const image = getCoverUrl(team);
+export const getTeamProfileStyle = (team) => {
+  const image = getTeamCoverUrl(team);
   return {
     backgroundColor: lightColors[team.id % 4],
     backgroundImage: `url('${image}')`,

--- a/src/models/team.js
+++ b/src/models/team.js
@@ -18,26 +18,21 @@ export const getAvatarStyle = (team) => {
     };
   }
   return {
-    backgroundColor,
+    backgroundColor: team.backgroundColor,
     backgroundImage: `url('${image}')`,
   };
 };
 
 export const getCoverUrl = ({ id, hasCoverImage, updatedAt, size = 'large' }) => {
-  const customImage = `${CDN_URL}/team-cover/${id}/${size}?${cache}`;
+  const customImage = `${CDN_URL}/team-cover/${id}/${size}?${updatedAt}`;
   const defaultImage = 'https://cdn.glitch.com/b065beeb-4c71-4a9c-a8aa-4548e266471f%2Fteam-cover-pattern.svg?v=1559853406967';
   return hasCoverImage ? customImage : defaultImage;
 };
 
-export const getProfileStyle = ({ id, hasCoverImage, cache, size }) => {
-  const image = getCoverUrl({
-    id,
-    hasCoverImage,
-    cache,
-    size,
-  });
+export const getProfileStyle = (team) => {
+  const image = getCoverUrl(team);
   return {
-    backgroundColor: lightColors[id % 4],
+    backgroundColor: lightColors[team.id % 4],
     backgroundImage: `url('${image}')`,
   };
 };

--- a/src/models/team.js
+++ b/src/models/team.js
@@ -1,25 +1,18 @@
 import { lightColors } from 'Models/user';
 import { CDN_URL } from 'Utils/constants';
 
-const cacheBuster = Math.floor(Math.random() * 1000);
-
 export const DEFAULT_TEAM_AVATAR = 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fdefault-team-avatar.svg?1503510366819';
 
-export const getLink = ({ url }) => `/@${url}`;
+export const getTeamLink = ({ url }) => `/@${url}`;
 
-export const getAvatarUrl = ({ id, hasAvatarImage, cache = cacheBuster, size = 'large' }) => {
-  const customImage = `${CDN_URL}/team-avatar/${id}/${size}?${cache}`;
+export const getTeamAvatarUrl = ({ id, hasAvatarImage, updatedAt, size = 'large' }) => {
+  const customImage = `${CDN_URL}/team-avatar/${id}/${size}?${updatedAt}`;
   return hasAvatarImage ? customImage : DEFAULT_TEAM_AVATAR;
 };
 
-export const getAvatarStyle = ({ id, hasAvatarImage, backgroundColor, cache, size }) => {
-  const image = getAvatarUrl({
-    id,
-    hasAvatarImage,
-    cache,
-    size,
-  });
-  if (hasAvatarImage) {
+export const getAvatarStyle = (team) => {
+  const image = getTeamAvatarUrl(team);
+  if (team.hasAvatarImage) {
     return {
       backgroundImage: `url('${image}')`,
     };
@@ -30,7 +23,7 @@ export const getAvatarStyle = ({ id, hasAvatarImage, backgroundColor, cache, siz
   };
 };
 
-export const getCoverUrl = ({ id, hasCoverImage, cache = cacheBuster, size = 'large' }) => {
+export const getCoverUrl = ({ id, hasCoverImage, updatedAt, size = 'large' }) => {
   const customImage = `${CDN_URL}/team-cover/${id}/${size}?${cache}`;
   const defaultImage = 'https://cdn.glitch.com/b065beeb-4c71-4a9c-a8aa-4548e266471f%2Fteam-cover-pattern.svg?v=1559853406967';
   return hasCoverImage ? customImage : defaultImage;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,7 +1,5 @@
 import { CDN_URL } from 'Utils/constants';
 
-const cacheBuster = Math.floor(Math.random() * 1000);
-
 export const ANON_AVATAR_URL = 'https://cdn.glitch.com/f6949da2-781d-4fd5-81e6-1fdd56350165%2Fanon-user-on-project-avatar.svg?1488556279399';
 
 export const lightColors = ['#FFC761', '#9BFFB5', '#FF9BA1', '#9B9EFF'];
@@ -44,16 +42,16 @@ export function getUserAvatarStyle({ avatarUrl, color }) {
   };
 }
 
-export function getUserCoverUrl({ id, hasCoverImage, cache = cacheBuster, size = 'large' }) {
-  const customImage = `${CDN_URL}/user-cover/${id}/${size}?${cache}`;
+export function getUserCoverUrl({ id, hasCoverImage, updatedAt, size = 'large' }) {
+  const customImage = `${CDN_URL}/user-cover/${id}/${size}?${updatedAt}`;
   const defaultImage = 'https://cdn.glitch.com/b065beeb-4c71-4a9c-a8aa-4548e266471f%2Fuser-pattern.svg';
   return hasCoverImage ? customImage : defaultImage;
 }
 
-export function getProfileStyle(params) {
+export function getUserProfileStyle(params) {
   // five random light colors from randomcolor
   return {
     backgroundColor: lightColors[params.id % 4],
-    backgroundImage: `url('${getCoverUrl(params)}')`,
+    backgroundImage: `url('${getUserCoverUrl(params)}')`,
   };
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -16,35 +16,35 @@ export function getDisplayName({ login, name }) {
   return 'Anonymous User';
 }
 
-export function getLink({ id, login }) {
+export function getUserLink({ id, login }) {
   if (login) {
     return `/@${login}`;
   }
   return `/user/${id}`;
 }
 
-export function getAvatarUrl({ login, avatarUrl }) {
+export function getUserAvatarUrl({ login, avatarUrl }) {
   if (login && avatarUrl) {
     return avatarUrl;
   }
   return ANON_AVATAR_URL;
 }
 
-export function getAvatarThumbnailUrl({ login, avatarThumbnailUrl }) {
+export function getUserAvatarThumbnailUrl({ login, avatarThumbnailUrl }) {
   if (login && avatarThumbnailUrl) {
     return avatarThumbnailUrl;
   }
   return ANON_AVATAR_URL;
 }
 
-export function getAvatarStyle({ avatarUrl, color }) {
+export function getUserAvatarStyle({ avatarUrl, color }) {
   return {
     backgroundColor: color,
     backgroundImage: `url('${avatarUrl || ANON_AVATAR_URL}')`,
   };
 }
 
-export function getCoverUrl({ id, hasCoverImage, cache = cacheBuster, size = 'large' }) {
+export function getUserCoverUrl({ id, hasCoverImage, cache = cacheBuster, size = 'large' }) {
   const customImage = `${CDN_URL}/user-cover/${id}/${size}?${cache}`;
   const defaultImage = 'https://cdn.glitch.com/b065beeb-4c71-4a9c-a8aa-4548e266471f%2Fuser-pattern.svg';
   return hasCoverImage ? customImage : defaultImage;

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import { withRouter } from 'react-router-dom';
 import { kebabCase } from 'lodash';
 
-import { getLink } from 'Models/collection';
+import { getCollectionLink } from 'Models/collection';
 import { PopoverWithButton } from 'Components/popover';
 import NotFound from 'Components/errors/not-found';
 import DataLoader from 'Components/data-loader';
@@ -30,7 +30,7 @@ const CollectionPageContents = withRouter(({ history, collection: initialCollect
     onNameChange: async (name) => {
       const url = kebabCase(name);
       const result = await funcs.updateNameAndUrl({ name, url });
-      history.replace(getLink({ ...collection, url }));
+      history.replace(getCollectionLink({ ...collection, url }));
       return result;
     },
   };

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -20,7 +20,7 @@ import LazyLoader from 'Components/lazy-loader';
 import { useAPI } from 'State/api';
 import { useTracker } from 'State/segment-analytics';
 import { getRemixUrl } from 'Models/project';
-import { getLink as getTeamLink } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { emojiPattern } from 'Shared/regex';
 import { CDN_URL } from 'Utils/constants';
 

--- a/src/presenters/pages/home-v2/collection-container.js
+++ b/src/presenters/pages/home-v2/collection-container.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-import { getAvatarStyle, getDisplayName } from 'Models/user';
+import { getUserAvatarStyle, getDisplayName } from 'Models/user';
 import Link from 'Components/link';
 
 import styles from './styles.styl';
@@ -19,7 +19,7 @@ const UserMask = ({ users, config }) => (
           width: `${(100 * point.d) / config.width}%`,
         }}
       >
-        <div className={styles.userMaskBubble} style={getAvatarStyle(users[i])} />
+        <div className={styles.userMaskBubble} style={getUserAvatarStyle(users[i])} />
       </div>
     ))}
   </div>

--- a/src/presenters/pages/home-v2/index.js
+++ b/src/presenters/pages/home-v2/index.js
@@ -19,7 +19,7 @@ import Mark from 'Components/mark';
 import PreviewContainer from 'Components/containers/preview-container';
 import Arrow from 'Components/arrow';
 import { useCurrentUser } from 'State/current-user';
-import { getEditorUrl, getAvatarUrl } from 'Models/project';
+import { getEditorUrl, getProjectAvatarUrl } from 'Models/project';
 import { useAPI } from 'State/api';
 import { useGlobals } from 'State/globals';
 
@@ -85,7 +85,7 @@ const AppsWeLove = ({ content }) => {
       <div className={styles.appsWeLoveSmallLayout}>
         {content.map(({ id, title, description, domain }) => (
           <Link key={id} to={`/~${domain}`} className={classnames(styles.plainLink, styles.appItemMini)}>
-            <img src={getAvatarUrl(id)} alt="" className={styles.appAvatar} />
+            <img src={getProjectAvatarUrl({ id })} alt="" className={styles.appAvatar} />
             <div className={styles.appContent}>
               <h4 className={styles.h4}>{title}</h4>
               <p>{description}</p>
@@ -107,7 +107,7 @@ const AppsWeLove = ({ content }) => {
                   <h4 className={styles.h4}>{title}</h4>
                   <p>{description}</p>
                 </div>
-                <img src={getAvatarUrl(id)} alt="" className={styles.appAvatar} />
+                <img src={getProjectAvatarUrl({ id })} alt="" className={styles.appAvatar} />
               </div>
             </Tab>
           ))}

--- a/src/presenters/pages/join-team.js
+++ b/src/presenters/pages/join-team.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
-import { getLink } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { useAPI } from 'State/api';
 import { useCurrentUser } from 'State/current-user';
 import { useNotifications } from 'State/notifications';
@@ -30,7 +30,7 @@ const JoinTeamPage = withRouter(({ history, teamUrl, joinToken }) => {
         }
         createNotification('Invite failed, try asking your teammate to resend the invite', { type: 'error' });
       }
-      history.push(getLink({ url: teamUrl }));
+      history.push(getTeamLink({ url: teamUrl }));
     })();
   }, []);
 

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -27,7 +27,7 @@ import { PrivateBadge, PrivateToggle } from 'Components/private-badge';
 import { AnalyticsContext } from 'State/segment-analytics';
 import { useCurrentUser } from 'State/current-user';
 import { useProjectEditor, getProjectByDomain } from 'State/project';
-import { getLink as getUserLink } from 'Models/user';
+import { getUserLink } from 'Models/user';
 import { userIsProjectMember } from 'Models/project';
 import { addBreadcrumb } from 'Utils/sentry';
 import { getAllPages } from 'Shared/api';

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -22,7 +22,7 @@ import TeamAnalytics from 'Components/team-analytics';
 import AuthDescription from 'Components/fields/auth-description';
 import ErrorBoundary from 'Components/error-boundary';
 import Link from 'Components/link';
-import { getLink, userIsOnTeam, userIsTeamAdmin } from 'Models/team';
+import { getTeamLink, userIsOnTeam, userIsTeamAdmin } from 'Models/team';
 import { AnalyticsContext } from 'State/segment-analytics';
 import { useCurrentUser } from 'State/current-user';
 import { useNotifications } from 'State/notifications';
@@ -32,7 +32,7 @@ import useFocusFirst from 'Hooks/use-focus-first';
 import styles from './team.styl';
 
 function syncPageToUrl(team) {
-  history.replaceState(null, null, getLink(team));
+  history.replaceState(null, null, getTeamLink(team));
 }
 
 const Beta = () => (

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -15,7 +15,7 @@ import CollectionsList from 'Components/collections-list';
 import DeletedProjects from 'Components/deleted-projects';
 import ReportButton from 'Components/report-abuse-pop';
 import AuthDescription from 'Components/fields/auth-description';
-import { getLink } from 'Models/user';
+import { getUserLink } from 'Models/user';
 import { AnalyticsContext } from 'State/segment-analytics';
 import { useCurrentUser } from 'State/current-user';
 import { useUserEditor } from 'State/user';
@@ -24,7 +24,7 @@ import useFocusFirst from 'Hooks/use-focus-first';
 import styles from './user.styl';
 
 function syncPageToLogin(login) {
-  history.replaceState(null, null, getLink({ login }));
+  history.replaceState(null, null, getUserLink({ login }));
 }
 
 const NameAndLogin = ({ name, login, isAuthorized, updateName, updateLogin }) => {

--- a/src/utils/abuse-reporting.js
+++ b/src/utils/abuse-reporting.js
@@ -1,4 +1,4 @@
-import { getLink, getDisplayName } from 'Models/user';
+import { getUserLink, getDisplayName } from 'Models/user';
 import { getUrlForModel, getDisplayNameForModel } from 'Utils/models';
 import { APP_URL } from 'Utils/constants';
 
@@ -39,7 +39,7 @@ export const getAbuseReportBody = (currentUser, submitterEmail, reportedType, re
 
   return `${thingIdentifiers}
 
-- Submitted by: [${getDisplayName(currentUser)}](${APP_URL}${getLink(currentUser)})
+- Submitted by: [${getDisplayName(currentUser)}](${APP_URL}${getUserLink(currentUser)})
 
 - Contact: ${pickEmailForReport(currentUser, submitterEmail)}
 

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -1,6 +1,6 @@
 import { getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
-import { getLink as getTeamLink } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { getUserLink } from 'Models/user';
 
 export const getUrlForModel = (model, modelType) => {

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -1,7 +1,7 @@
 import { getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
 import { getLink as getTeamLink } from 'Models/team';
-import { getLink as getUserLink } from 'Models/user';
+import { getUserLink } from 'Models/user';
 
 export const getUrlForModel = (model, modelType) => {
   switch (modelType) {

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -1,5 +1,5 @@
 import { getCollectionLink } from 'Models/collection';
-import { getLink as getProjectLink } from 'Models/project';
+import { getProjectLink } from 'Models/project';
 import { getTeamLink } from 'Models/team';
 import { getUserLink } from 'Models/user';
 

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -1,4 +1,4 @@
-import { getLink as getCollectionLink } from 'Models/collection';
+import { getCollectionLink } from 'Models/collection';
 import { getLink as getProjectLink } from 'Models/project';
 import { getLink as getTeamLink } from 'Models/team';
 import { getLink as getUserLink } from 'Models/user';


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/
https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/250

## Changes:
- Renamed getLink to get(User|Team|Project|Collection)Link, same for getAvatarUrl and related stuff
- The get avatar url functions use the updatedAt field instead of a random number for cache busting (this fixes an ssr warning and enables longer caching for images) (user avatars don't have a cache buster because the url changes with each upload)

## How To Test:
Try loading some pages and check that the images still load as expected