### PR TITLE
Nova-chance: Restore the remove project from team button

### DIFF
--- a/src/state/team.js
+++ b/src/state/team.js
@@ -161,7 +161,7 @@ export function useTeamEditor(initialTeam) {
         projects: [project, ...prev.projects],
       }));
     }, handleError),
-    removeProject: withErrorHandler(async (project) => {
+    removeProjectFromTeam: withErrorHandler(async (project) => {
       await removeProjectFromTeam({ project, team });
       setTeam((prev) => ({
         ...prev,


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me/
https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/247

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/62244056-9b22b280-b3ac-11e9-941e-2d2125d2fc2b.png)

## Changes:
The remove from team button went missing, but now it is back!

## How To Test:
Try removing a project from a team