### PR TITLE
charming-memory: open the app in default browser if `RUNNING_LOCALLY` is set

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -83,17 +83,15 @@ git clone git@github.com:FogCreek/Glitch-Community.git
 ```
 npm install
 ```
-3. Create a file called `.env` in the root directory, and populate it with the `RUNNING_LOCALLY` variable, which tells our build process to allow the app to run on `localhost`
+3. Create a file called `.env` in the root directory, and populate it with the `RUNNING_LOCALLY` variable, which tells our build process to allow the app to run on `localhost`. Optionally, you can also choose which port the app will run on.
 ```yaml
 RUNNING_LOCALLY=true
+PORT=3000 # optional
 ```
 4. Start the server:
 ```bash
 npm start
 ```
-
-#### 
-
 
 ### How do I add a question to the FAQ?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -92,6 +92,9 @@ RUNNING_LOCALLY=true
 npm start
 ```
 
+#### 
+
+
 ### How do I add a question to the FAQ?
 
 I'd suggest remixing the site and adding the question.  Feel free to take a stab at the answer, if you like.  See CONTRIBUTING.md for how to contribute :-)

--- a/server/server.js
+++ b/server/server.js
@@ -94,5 +94,11 @@ app.use(Sentry.Handlers.errorHandler());
 
 // Listen on App port
 const listener = app.listen(process.env.PORT, () => {
-  console.log(`Your app is listening on port ${listener.address().port}.`);
+  const port = listener.address().port;
+  console.log(`Your app is listening on port ${port}.`);
+
+  if (process.env.RUNNING_LOCALLY) {
+    const open = require('open');
+    open(`http://localhost:${port}`);
+  }
 });

--- a/server/server.js
+++ b/server/server.js
@@ -94,6 +94,5 @@ app.use(Sentry.Handlers.errorHandler());
 
 // Listen on App port
 const listener = app.listen(process.env.PORT, () => {
-  const port = listener.address().port;
-  console.log(`Your app is listening on port ${port}.`);
+  console.log(`Your app is listening on port ${listener.address().port}.`);
 });

--- a/server/server.js
+++ b/server/server.js
@@ -96,9 +96,4 @@ app.use(Sentry.Handlers.errorHandler());
 const listener = app.listen(process.env.PORT, () => {
   const port = listener.address().port;
   console.log(`Your app is listening on port ${port}.`);
-
-  if (process.env.RUNNING_LOCALLY) {
-    const open = require('open');
-    open(`http://localhost:${port}`);
-  }
 });

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,7 @@ import { StaticRouter } from 'react-router-dom';
 import { resetIdCounter } from 'react-tabs';
 import { resetUniqueId } from 'Hooks/use-unique-id';
 import { GlobalsProvider } from 'State/globals';
-import App from './app'; 
+import App from './app';
 
 const Page = ({ origin, route, signedIn, EXTERNAL_ROUTES, HOME_CONTENT, ZINE_POSTS }) => (
   <StaticRouter location={route}>


### PR DESCRIPTION
## Links
* [charming-memory.glitch.me](https://charming-memory.glitch.me)

## Changes:
* Open `http://localhost:123whatever` in the default browser when`RUNNING_LOCALLY` is set.

## How To Test:
* Pull this branch
* Run the app locally ([instructions](https://github.com/FogCreek/Glitch-Community/blob/master/FAQ.md#can-i-run-this-app-locally))
* Running `npm start` should open the app in a new tab in your default browser

## Feedback I'm looking for:
* Is this helpful or annoying?
* @oliviacpu is this going to cause problems on CircleCI?