### PR TITLE
Nova chance: Prefer to build collection urls over fullUrl, fix collection page renaming

### DIFF
--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -50,10 +50,10 @@ export function getCollectionOwnerLink(collection) {
 }
 
 export function getCollectionLink(collection) {
-  if (collection.fullUrl) {
-    return `/@${collection.fullUrl}`;
+  if (collection.team || collection.user) {
+    return `${getCollectionOwnerLink(collection)}/${collection.url}`;
   }
-  return `${getCollectionOwnerLink(collection)}/${collection.url}`;
+  return `/@${collection.fullUrl}`;
 }
 
 export async function createCollection({ api, name, teamId, createNotification, myStuffEnabled = false }) {

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
-import { withRouter } from 'react-router-dom';
 import { kebabCase } from 'lodash';
 
 import { getCollectionLink } from 'Models/collection';
@@ -18,7 +17,7 @@ import { useCurrentUser } from 'State/current-user';
 import { useCollectionEditor, userOrTeamIsAuthor, getCollectionWithProjects } from 'State/collection';
 import useFocusFirst from 'Hooks/use-focus-first';
 
-const CollectionPageContents = withRouter(({ history, collection: initialCollection }) => {
+const CollectionPageContents = ({ collection: initialCollection }) => {
   const { currentUser } = useCurrentUser();
   const [collection, baseFuncs] = useCollectionEditor(initialCollection);
   useFocusFirst();
@@ -30,7 +29,7 @@ const CollectionPageContents = withRouter(({ history, collection: initialCollect
     onNameChange: async (name) => {
       const url = kebabCase(name);
       const result = await funcs.updateNameAndUrl({ name, url });
-      history.replace(getCollectionLink({ ...collection, url }));
+      window.history.replaceState(null, null, getCollectionLink({ ...collection, url }));
       return result;
     },
   };
@@ -49,7 +48,7 @@ const CollectionPageContents = withRouter(({ history, collection: initialCollect
       <MoreCollectionsContainer collection={collection} />
     </>
   );
-});
+};
 
 CollectionPageContents.propTypes = {
   collection: PropTypes.shape({


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me
https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/198

## Changes:
- getCollectionLink builds the url from the user/team name and url if possible, before using the fullUrl
- Don't use react-router's history to update the url, because it will trigger a data load and page rebuild

## How To Test:
- Go to a collection and change the name. The window title, url, and text field should all update with whatever you typed in. The collection should also still load after a refresh
- Click links to collections from elsewhere around the site, they should all still work