### PR TITLE
Superb guide: Use the server rendered page instead of the fallback in some cases

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -18,7 +18,7 @@ dayjs.extend(relativeTimePlugin);
 dayjs.extend(convertPlugin);
 
 // This function is used in index.ejs to set up the app
-window.bootstrap = () => {
+window.bootstrap = (container) => {
   if (location.hash.startsWith('#!/')) {
     window.location.replace(EDITOR_URL + window.location.hash);
     return;
@@ -44,7 +44,6 @@ window.bootstrap = () => {
       </GlobalsProvider>
     </BrowserRouter>
   );
-  const container = document.getElementById('main');
 
   if (container.hasChildNodes()) {
     hydrate(element, container);

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -24,11 +24,11 @@ const ResumeCoding = () => (
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay }) => {
   const { currentUser, clear, superUserHelpers } = useCurrentUser();
   const { SSR_SIGNED_IN } = useGlobals();
+  // signedIn and signedOut are both false on the server so the sign in button doesn't render
   const fakeSignedIn = !currentUser.id && SSR_SIGNED_IN;
   const signedIn = !!currentUser.login || fakeSignedIn;
-  const hasProjects = currentUser.projects.length > 0 || fakeSignedIn;
   const signedOut = !!currentUser.id && !signedIn;
-  // signedIn and signedOut are both false on the server so 
+  const hasProjects = currentUser.projects.length > 0 || fakeSignedIn;
   return (
     <header role="banner" className={styles.header}>
       <Button href="#main" className={styles.visibleOnFocus}>Skip to Main Content</Button>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -27,6 +27,8 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay }
   const fakeSignedIn = !currentUser.id && SSR_SIGNED_IN;
   const signedIn = !!currentUser.login || fakeSignedIn;
   const hasProjects = currentUser.projects.length > 0 || fakeSignedIn;
+  const signedOut = !!currentUser.id && !signedIn;
+  // signedIn and signedOut are both false on the server so 
   return (
     <header role="banner" className={styles.header}>
       <Button href="#main" className={styles.visibleOnFocus}>Skip to Main Content</Button>
@@ -39,15 +41,17 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay }
           <SearchForm defaultValue={searchQuery} />
         </div>
         <ul className={styles.buttons}>
-          <li className={styles.buttonWrap}>
-            <NewProjectPop />
-          </li>
+          {(signedIn || signedOut) && (
+            <li className={styles.buttonWrap}>
+              <NewProjectPop />
+            </li>
+          )}
           {hasProjects && (
             <li className={styles.buttonWrap}>
               <ResumeCoding />
             </li>
           )}
-          {!signedIn && (
+          {signedOut && (
             <li className={styles.buttonWrap}>
               <SignInPop align="right" />
             </li>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -93,16 +93,18 @@
       if (isIe) {
         showFallback('ie');
       } else if (isCodeRunningInsideGoogleTranslateIframe) {
-        showFallback('translate');
-        setTimeout(function(){
-          window.location.href = "https://glitch.com";      
-        }, 3000);
+        if (!container.hasChildNodes()) {
+          showFallback('translate');
+          setTimeout(function() {
+            window.location.href = "https://glitch.com";      
+          }, 3000);
+        }
       } else if (window.bootstrap) {
         window.bootstrap(container);
       } else if (!BUILD_COMPLETE) {
         showFallback('notbuilt');
       } else {
-        sho
+        showFallback('noscript');
       }
       analytics.load("ZE6VsqXhz5izMM2cqRrVEDIrJWUKntoX");
     </script>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -106,7 +106,7 @@
       } else if (window.bootstrap) {
         window.bootstrap(container);
       } else if (!BUILD_COMPLETE) {
-        // js not built means the css is not built yet either
+        // we can't show the server rendered page if the css is still building
         showFallback('notbuilt');
       } else {
         // js failed to parse, odds are the css would be broken too

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -81,8 +81,9 @@
     <script src="<%= scripts[i] %>"></script>
     <% } %>
     <script>
+      var container = document.getElementById('main');
       var isIe = /Trident\/[7]{1}/i.test(navigator.userAgent);
-      const isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com";
+      var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com";
       if (isIe) {
         document.getElementById('fallback').removeAttribute('style');
         document.getElementById('fallback-img').removeAttribute('style');
@@ -97,7 +98,7 @@
           window.location.href = "https://glitch.com";      
         }, 3000);
       } else if (window.bootstrap) {
-        window.bootstrap();
+        window.bootstrap(container);
       } else if (!BUILD_COMPLETE) {
         document.getElementById('fallback').removeAttribute('style');
         document.getElementById('fallback-img').removeAttribute('style');

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -30,7 +30,7 @@
     <link rel="stylesheet" type="text/css" href="<%= styles[i] %>">
     <% } %>
     
-    <!-- <noscript><style>#fallback, #fallback-noscript { display: inline-block !important; } #fallback-img {display: block !important}</style></noscript> -->
+    <noscript><style>#fallback, #fallback-noscript{display: inline-block !important} #fallback-img{display: block !important} #main{display: none}</style></noscript>
   </head>
   <body>
     <script>
@@ -82,33 +82,27 @@
     <% } %>
     <script>
       var container = document.getElementById('main');
+      function showFallback(name) {
+        document.getElementById('fallback').removeAttribute('style');
+        document.getElementById('fallback-img').removeAttribute('style');
+        document.getElementById('fallback-' + name).removeAttribute('style');
+        container.style.display = 'none';
+      }
       var isIe = /Trident\/[7]{1}/i.test(navigator.userAgent);
       var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com";
       if (isIe) {
-        document.getElementById('fallback').removeAttribute('style');
-        document.getElementById('fallback-img').removeAttribute('style');
-        document.getElementById('fallback-ie').removeAttribute('style');
-        document.getElementById('main').style.display = 'none';
+        showFallback('ie');
       } else if (isCodeRunningInsideGoogleTranslateIframe) {
-        document.getElementById('fallback').removeAttribute('style');
-        document.getElementById('fallback-img').removeAttribute('style');
-        document.getElementById('fallback-translate').removeAttribute('style');
-        document.getElementById('main').style.display = 'none';
+        showFallback('translate');
         setTimeout(function(){
           window.location.href = "https://glitch.com";      
         }, 3000);
       } else if (window.bootstrap) {
         window.bootstrap(container);
       } else if (!BUILD_COMPLETE) {
-        document.getElementById('fallback').removeAttribute('style');
-        document.getElementById('fallback-img').removeAttribute('style');
-        document.getElementById('fallback-notbuilt').removeAttribute('style');
-        document.getElementById('main').style.display = 'none';
+        showFallback('notbuilt');
       } else {
-        document.getElementById('fallback').removeAttribute('style');
-        document.getElementById('fallback-img').removeAttribute('style');
-        document.getElementById('fallback-noscript').removeAttribute('style');
-        document.getElementById('main').style.display = 'none';
+        sho
       }
       analytics.load("ZE6VsqXhz5izMM2cqRrVEDIrJWUKntoX");
     </script>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <title><%= title %></title>
     <meta name="description" content="<%= description %>">
-    <% for (let i = 0; i < scripts.length; ++i) { %>
-    <link rel="preload" href="<%= scripts[i] %>" as="script">
-    <% } %>
     <script>
       var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";}
     </script> 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -30,7 +30,9 @@
     <link rel="stylesheet" type="text/css" href="<%= styles[i] %>">
     <% } %>
     
-    <noscript><style>#fallback, #fallback-noscript{display: inline-block !important} #fallback-img{display: block !important} #main{display: none}</style></noscript>
+    <% if (!rendered) { %>
+    <noscript><style>#fallback, #fallback-noscript { display: inline-block !important } #fallback-img { display: block !important } #main { display: none }</style></noscript>
+    <% } %>
   </head>
   <body>
     <script>
@@ -91,8 +93,10 @@
       var isIe = /Trident\/[7]{1}/i.test(navigator.userAgent);
       var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com";
       if (isIe) {
+        // ie doesn't support our css
         showFallback('ie');
       } else if (isCodeRunningInsideGoogleTranslateIframe) {
+        // only translate server rendered pages
         if (!container.hasChildNodes()) {
           showFallback('translate');
           setTimeout(function() {
@@ -102,8 +106,10 @@
       } else if (window.bootstrap) {
         window.bootstrap(container);
       } else if (!BUILD_COMPLETE) {
+        // js not built means the css is not built yet either
         showFallback('notbuilt');
       } else {
+        // js failed to parse, odds are the css would be broken too
         showFallback('noscript');
       }
       analytics.load("ZE6VsqXhz5izMM2cqRrVEDIrJWUKntoX");

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <title><%= title %></title>
     <meta name="description" content="<%= description %>">
+    <% for (let i = 0; i < scripts.length; ++i) { %>
+    <link rel="preload" href="<%= scripts[i] %>" as="script">
+    <% } %>
     <script>
       var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";}
     </script> 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -31,7 +31,7 @@
     <% } %>
     
     <% if (!rendered) { %>
-    <noscript><style>#fallback, #fallback-noscript { display: inline-block !important } #fallback-img { display: block !important } #main { display: none }</style></noscript>
+    <noscript><style>#fallback, #fallback-noscript { display: inline-block !important } #fallback-img { display: block !important }</style></noscript>
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/
https://github.com/FogCreek/Glitch-Community-Work/issues/190

## Changes:
- If js is disabled prefer to show the server rendered page over the no js error page
- If running in google translate ( https://translate.google.com/translate?hl=&sl=auto&tl=fr&u=https%3A%2F%2Fsuperb-guide.glitch.me%2F ) only redirect out if not server rendered
- The new project/sign in buttons wait until you have an anon user (aka rendering in the browser)

## How To Test:
Load up the site and check the homepage and a non ssr page
- In a modern/supported browser
- With js disabled (you can do it from dev tools > settings > advanced in ff)
- In google translate

## Feedback I'm looking for:
- Are there any dangers to leaving the ssr content visible in these two cases? Anything interactive won't work but navigating around the site should be ok.
- I opted keep ie/not built/js failed to parse blocked because they'll probably have broken css even in ssr.
- The sign in and new project buttons sometimes take a second to appear the first time you load the site in an incognito window because it has to wait until an anon user gets created. Is that ok?