### PR TITLE
Quixotic rocket: Fix add to collection title styling, fix a proptypes warning

### DIFF
--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -15,9 +15,9 @@ import { FALLBACK_AVATAR_URL, getProjectAvatarUrl } from 'Models/project';
 import styles from './avatar.styl';
 
 // UserAvatar
-export const Avatar = ({ name, src, color, srcFallback, type, hideTooltip, withinButton }) => {
+export const Avatar = ({ name, src, color, srcFallback, type, width, hideTooltip, withinButton }) => {
   const contents = (
-    <Image width="32px" height="32px" src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={styles[type]} />
+    <Image width={width} height={width} src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={styles[type]} />
   );
 
   if (!hideTooltip) {
@@ -34,16 +34,18 @@ Avatar.propTypes = {
   color: PropTypes.string,
   hideTooltip: PropTypes.bool,
   withinButton: PropTypes.bool,
+  width: PropTypes.string,
 };
 
 Avatar.defaultProps = {
   color: null,
   srcFallback: '',
   hideTooltip: false,
+  width: '32px',
 };
 
-export const TeamAvatar = ({ team, size, hideTooltip }) => (
-  <Avatar name={team.name} src={getTeamAvatarUrl({ ...team, size })} srcFallback={DEFAULT_TEAM_AVATAR} type="team" hideTooltip={hideTooltip} />
+export const TeamAvatar = ({ team, size, hideTooltip, width }) => (
+  <Avatar name={team.name} src={getTeamAvatarUrl({ ...team, size })} srcFallback={DEFAULT_TEAM_AVATAR} type="team" hideTooltip={hideTooltip} width={width} />
 );
 TeamAvatar.propTypes = {
   team: PropTypes.shape({
@@ -59,7 +61,7 @@ TeamAvatar.defaultProps = {
   size: 'small',
 };
 
-export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton }) => (
+export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton, width }) => (
   <Avatar
     name={getDisplayName(user) + suffix}
     src={getUserAvatarThumbnailUrl(user)}
@@ -68,6 +70,7 @@ export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton }) => 
     type="user"
     hideTooltip={hideTooltip}
     withinButton={withinButton}
+    width={width}
   />
 );
 UserAvatar.propTypes = {
@@ -89,8 +92,8 @@ UserAvatar.defaultProps = {
   withinButton: false,
 };
 
-export const ProjectAvatar = ({ project, hasAlt }) => (
-  <Avatar name={hasAlt ? project.domain : ''} src={getProjectAvatarUrl(project)} srcFallback={FALLBACK_AVATAR_URL} type="team" hideTooltip />
+export const ProjectAvatar = ({ project, hasAlt, width }) => (
+  <Avatar name={hasAlt ? project.domain : ''} src={getProjectAvatarUrl(project)} srcFallback={FALLBACK_AVATAR_URL} type="team" hideTooltip width={width} />
 );
 
 ProjectAvatar.propTypes = {
@@ -105,7 +108,9 @@ ProjectAvatar.defaultProps = {
   hasAlt: false,
 };
 
-export const CollectionAvatar = ({ collection }) => <CollectionAvatarBase backgroundFillColor={hexToRgbA(collection.coverColor)} />;
+export const CollectionAvatar = ({ collection, width }) => (
+  <CollectionAvatarBase backgroundFillColor={hexToRgbA(collection.coverColor)} width={width} />
+);
 
 CollectionAvatar.propTypes = {
   collection: PropTypes.shape({

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -15,7 +15,7 @@ import { FALLBACK_AVATAR_URL, getProjectAvatarUrl } from 'Models/project';
 import styles from './avatar.styl';
 
 // UserAvatar
-export const Avatar = ({ name, src, color, srcFallback, type, width, hideTooltip, withinButton }) => {
+export const Avatar = ({ name, src, color, srcFallback, type, tiny, hideTooltip, withinButton }) => {
   const contents = (
     <Image width={width} height={width} src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={styles[type]} />
   );
@@ -34,14 +34,14 @@ Avatar.propTypes = {
   color: PropTypes.string,
   hideTooltip: PropTypes.bool,
   withinButton: PropTypes.bool,
-  width: PropTypes.string,
+  tiny: PropTypes.bool,
 };
 
 Avatar.defaultProps = {
   color: null,
   srcFallback: '',
   hideTooltip: false,
-  width: '32px',
+  tiny: false,
 };
 
 export const TeamAvatar = ({ team, size, hideTooltip, width }) => (

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -17,11 +17,8 @@ import styles from './avatar.styl';
 
 // UserAvatar
 export const Avatar = ({ name, src, color, srcFallback, type, tiny, hideTooltip, withinButton }) => {
-  const size = tiny ? '16px' : '32px';
-  const className = classNames(styles[type], { [styles.tiny]: tiny });
-  const contents = (
-    <Image width={size} height={size} src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={className} />
-  );
+  const className = classNames(styles.avatar, styles[type], { [styles.tiny]: tiny });
+  const contents = <Image src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={className} />;
 
   if (!hideTooltip) {
     return <TooltipContainer tooltip={name} target={contents} type="action" align={['left']} fallback={withinButton} />;

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import TooltipContainer from 'Components/tooltips/tooltip-container';
 import Image from 'Components/images/image';
@@ -16,8 +17,10 @@ import styles from './avatar.styl';
 
 // UserAvatar
 export const Avatar = ({ name, src, color, srcFallback, type, tiny, hideTooltip, withinButton }) => {
+  const size = tiny ? '16px' : '32px';
+  const className = classNames(styles[type], { [styles.tiny]: tiny });
   const contents = (
-    <Image width={width} height={width} src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={styles[type]} />
+    <Image width={size} height={size} src={src} defaultSrc={srcFallback} alt={name} backgroundColor={color} className={className} />
   );
 
   if (!hideTooltip) {
@@ -44,8 +47,8 @@ Avatar.defaultProps = {
   tiny: false,
 };
 
-export const TeamAvatar = ({ team, size, hideTooltip, width }) => (
-  <Avatar name={team.name} src={getTeamAvatarUrl({ ...team, size })} srcFallback={DEFAULT_TEAM_AVATAR} type="team" hideTooltip={hideTooltip} width={width} />
+export const TeamAvatar = ({ team, size, hideTooltip, tiny }) => (
+  <Avatar name={team.name} src={getTeamAvatarUrl({ ...team, size })} srcFallback={DEFAULT_TEAM_AVATAR} type="team" hideTooltip={hideTooltip} tiny={tiny} />
 );
 TeamAvatar.propTypes = {
   team: PropTypes.shape({
@@ -61,7 +64,7 @@ TeamAvatar.defaultProps = {
   size: 'small',
 };
 
-export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton, width }) => (
+export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton, tiny }) => (
   <Avatar
     name={getDisplayName(user) + suffix}
     src={getUserAvatarThumbnailUrl(user)}
@@ -70,7 +73,7 @@ export const UserAvatar = ({ user, suffix = '', hideTooltip, withinButton, width
     type="user"
     hideTooltip={hideTooltip}
     withinButton={withinButton}
-    width={width}
+    tiny={tiny}
   />
 );
 UserAvatar.propTypes = {
@@ -92,8 +95,8 @@ UserAvatar.defaultProps = {
   withinButton: false,
 };
 
-export const ProjectAvatar = ({ project, hasAlt, width }) => (
-  <Avatar name={hasAlt ? project.domain : ''} src={getProjectAvatarUrl(project)} srcFallback={FALLBACK_AVATAR_URL} type="team" hideTooltip width={width} />
+export const ProjectAvatar = ({ project, hasAlt, tiny }) => (
+  <Avatar name={hasAlt ? project.domain : ''} src={getProjectAvatarUrl(project)} srcFallback={FALLBACK_AVATAR_URL} type="project" hideTooltip tiny={tiny} />
 );
 
 ProjectAvatar.propTypes = {
@@ -108,9 +111,7 @@ ProjectAvatar.defaultProps = {
   hasAlt: false,
 };
 
-export const CollectionAvatar = ({ collection, width }) => (
-  <CollectionAvatarBase backgroundFillColor={hexToRgbA(collection.coverColor)} width={width} />
-);
+export const CollectionAvatar = ({ collection, tiny }) => <CollectionAvatarBase backgroundFillColor={hexToRgbA(collection.coverColor)} tiny={tiny} />;
 
 CollectionAvatar.propTypes = {
   collection: PropTypes.shape({

--- a/src/components/images/avatar.styl
+++ b/src/components/images/avatar.styl
@@ -7,5 +7,10 @@
 .bookmark
   top: -25%
   position: relative
+.avatar
+  width: 32px
+  height: 32px
 .tiny
   vertical-align: bottom
+  width: 16px
+  height: 16px

--- a/src/components/images/avatar.styl
+++ b/src/components/images/avatar.styl
@@ -1,7 +1,11 @@
 .user
   border-radius: 50%
-.team
+.team, .project
   border-radius: 5px
+  &.tiny
+    border-radius: 3px
 .bookmark
   top: -25%
   position: relative
+.tiny
+  vertical-align: bottom

--- a/src/components/popover/styles.styl
+++ b/src/components/popover/styles.styl
@@ -66,7 +66,7 @@
   font-weight: bold
 
 .backArrow
-  padding: 1px 3px 3px
+  padding: 0 3px 4px
   border-radius: 3px
   opacity: 0.7
 .popoverTitle:hover .backArrow

--- a/src/components/popover/styles.styl
+++ b/src/components/popover/styles.styl
@@ -66,7 +66,7 @@
   font-weight: bold
 
 .backArrow
-  padding: 0 3px 4px
+  padding: 0 3px 3px
   border-radius: 3px
   opacity: 0.7
 .popoverTitle:hover .backArrow

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -45,7 +45,7 @@ const collectionTypeOptions = [
 const AddProjectPopoverTitle = ({ project }) => (
   <MultiPopoverTitle>
     <div className={styles.popoverTitleWrap}>
-      <ProjectAvatar project={project} /> Add {project.domain} to collection
+      <ProjectAvatar project={project} width="15px" /> Add {project.domain} to collection
     </div>
   </MultiPopoverTitle>
 );

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -44,9 +44,7 @@ const collectionTypeOptions = [
 
 const AddProjectPopoverTitle = ({ project }) => (
   <MultiPopoverTitle>
-    <div className={styles.popoverTitleWrap}>
-      <ProjectAvatar project={project} width="15px" /> Add {project.domain} to collection
-    </div>
+    <ProjectAvatar project={project} tiny />&nbsp;Add {project.domain} to collection
   </MultiPopoverTitle>
 );
 AddProjectPopoverTitle.propTypes = {

--- a/src/components/project/popover.styl
+++ b/src/components/project/popover.styl
@@ -5,9 +5,3 @@
   // remove margin on Badge component, ideally the Badge component would not specify margin
   > *
     margin: 0
-
-.popoverTitleWrap
-  :global .avatar
-    width: 15px
-    height: 15px
-    vertical-align: bottom

--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -2,10 +2,10 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { orderBy } from 'lodash';
 
-import { getTeamLink, getTeamAvatarUrl } from 'Models/team';
+import { getTeamLink } from 'Models/team';
 import { getUserAvatarThumbnailUrl } from 'Models/user';
 import Image from 'Components/images/image';
-import { UserAvatar } from 'Components/images/avatar';
+import { UserAvatar, TeamAvatar } from 'Components/images/avatar';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
 import { UserLink } from 'Components/link';
 import Button from 'Components/buttons/button';
@@ -46,7 +46,7 @@ const TeamList = ({ teams, showCreateTeam }) => {
             href={getTeamLink(team)}
             size="small"
             type="tertiary"
-            image={<TeamAvatar className={styles.teamAvatar} src={getTeamAvatarUrl({ ...team, size: 'small' })} alt="" width={16} height={16} />}
+            image={<TeamAvatar team={team} size="small" tiny hideTooltip />}
           >
             {team.name}
           </Button>

--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -46,7 +46,7 @@ const TeamList = ({ teams, showCreateTeam }) => {
             href={getTeamLink(team)}
             size="small"
             type="tertiary"
-            image={<Image className={styles.teamAvatar} src={getTeamAvatarUrl({ ...team, size: 'small' })} alt="" width={16} height={16} />}
+            image={<TeamAvatar className={styles.teamAvatar} src={getTeamAvatarUrl({ ...team, size: 'small' })} alt="" width={16} height={16} />}
           >
             {team.name}
           </Button>

--- a/src/components/user-options-pop/styles.styl
+++ b/src/components/user-options-pop/styles.styl
@@ -25,8 +25,6 @@
   font-weight: bold
 .userLogin
   color: text-on-secondary-background
-.teamAvatar
-  border-radius: 3px
 .checkbox
   margin-bottom: 10px
 .buttonWrap

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -169,11 +169,8 @@ function TeamPage({ team: initialTeam }) {
       {pinnedProjects.length > 0 && (
         <ProjectsList
           layout="grid"
-          title={
-            <>
-              Pinned Projects <Emoji inTitle name="pushpin" />
-            </>
-          }
+          title="Pinned Projects"
+          titleEmoji="pushpin"
           projects={pinnedProjects}
           isAuthorized={currentUserIsOnTeam}
           projectOptions={projectOptions}


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/@glitch

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/62389983-3774c280-b52f-11e9-9dfd-84a7985c14ef.png)

## Changes:
- Split the emoji out of the title on team page pinned projects
- Fixed the size of the project avatar in the add project to collection pop
- Use TeamAvatars in the user options pop rather than Image

## How To Test:
Look at both of those things and see that they are the same or better

## Feedback I'm looking for:
Both `size` and `type` already have meaning for avatars, so I opted for a boolean `tiny` prop. Should avatars support every size they get rendered at?