### PR TITLE
Nova chance: A few fixes for collection and team pages

### DIFF
--- a/src/components/collection/add-collection-project-pop.js
+++ b/src/components/collection/add-collection-project-pop.js
@@ -56,7 +56,7 @@ function AddCollectionProjectPop({ collection, togglePopover, addProjectToCollec
 
   const { createNotification } = useNotifications();
 
-  const onClick = useTrackedFunc(
+  const onSubmit = useTrackedFunc(
     async (project) => {
       togglePopover();
       // add project to page if successful & show notification
@@ -87,12 +87,13 @@ function AddCollectionProjectPop({ collection, togglePopover, addProjectToCollec
       <PopoverSearch
         value={query}
         onChange={setQuery}
+        onSubmit={onSubmit}
         results={visibleProjects}
         labelText="Project name or URL"
         placeholder="Search by project name or URL"
         status={status}
         renderItem={
-          ({ item: project, active }) => <ProjectResultItem project={project} active={active} onClick={() => onClick(project)} />
+          ({ item: project, active }) => <ProjectResultItem project={project} active={active} onClick={() => onSubmit(project)} />
         }
       />
       {status === 'ready' && excludingExactMatch && (

--- a/src/components/collections-list/index.js
+++ b/src/components/collections-list/index.js
@@ -10,7 +10,7 @@ import CreateCollectionButton from 'Components/collection/create-collection-pop'
 import SkipSectionButtons from 'Components/containers/skip-section-buttons';
 import { useAPIHandlers } from 'State/api';
 import { useCurrentUser } from 'State/current-user';
-import { useCollectionContext } from 'State/collection';
+import { useCollectionContext, useCollectionProjects } from 'State/collection';
 import { getCollectionsWithMyStuff } from 'Models/collection';
 import useDevToggle from 'State/dev-toggles';
 

--- a/src/components/collections-list/index.js
+++ b/src/components/collections-list/index.js
@@ -10,7 +10,7 @@ import CreateCollectionButton from 'Components/collection/create-collection-pop'
 import SkipSectionButtons from 'Components/containers/skip-section-buttons';
 import { useAPIHandlers } from 'State/api';
 import { useCurrentUser } from 'State/current-user';
-import { useCollectionProjects } from 'State/collection';
+import { useCollectionContext } from 'State/collection';
 import { getCollectionsWithMyStuff } from 'Models/collection';
 import useDevToggle from 'State/dev-toggles';
 
@@ -68,6 +68,7 @@ function CollectionsList({
   const { currentUser } = useCurrentUser();
   const [deletedCollectionIds, setDeletedCollectionIds] = useState([]);
   const myStuffEnabled = useDevToggle('My Stuff');
+  const getCollectionProjects = useCollectionContext();
 
   function deleteCollection(collection) {
     setDeletedCollectionIds((ids) => [...ids, collection.id]);
@@ -117,7 +118,7 @@ function CollectionsList({
                       enabled={enablePagination}
                       items={filteredProjects}
                       itemsPerPage={collectionsPerPage}
-                      fetchDataOptimistically={useCollectionProjects}
+                      fetchDataOptimistically={getCollectionProjects}
                     >
                       {(paginatedCollections, isExpanded) => (
                         <Grid items={paginatedCollections}>

--- a/src/components/containers/results-list.js
+++ b/src/components/containers/results-list.js
@@ -44,7 +44,7 @@ export const ResultItem = ({ className, onClick, href, children, active, selecte
   }, [active]);
 
   return (
-    <div className={classnames(className, styles.resultItem, href && styles.withLink, selected && styles.selected)}>
+    <div className={classnames(className, styles.resultItem, href && styles.withLink, { [styles.selected]: active || selected })}>
       <TransparentButton className={styles.resultItemButton} onClick={onClick} ref={buttonRef}>
         <span className={styles.resultWrap}>
           {children}

--- a/src/components/pagination-controller/index.js
+++ b/src/components/pagination-controller/index.js
@@ -73,50 +73,49 @@ function PaginationController({ enabled, items, itemsPerPage, fetchDataOptimisti
     dispatchState({ type: 'previous' });
   };
 
+  useEffect(() => {
+    if (canPaginate && fetchDataOptimistically) {
+      const startIdx = state.page * itemsPerPage;
+      const nextItems = items.slice(startIdx, startIdx + itemsPerPage);
+      console.log(nextItems);
+      nextItems.forEach(fetchDataOptimistically);
+    }
+  }, [state.page, canPaginate, itemsPerPage, fetchDataOptimistically]);
+
   if (canPaginate) {
     const startIdx = (state.page - 1) * itemsPerPage;
-    const nextItems = items.slice(startIdx + itemsPerPage, startIdx + itemsPerPage * 2);
     items = items.slice(startIdx, startIdx + itemsPerPage);
-
-    if (fetchDataOptimistically) {
-      Promise.all(nextItems.map(fetchDataOptimistically));
-    }
   }
 
-  useEffect(
-    () => {
-      dispatchState({ type: 'restart', totalPages: numPages });
-    },
-    [numItems],
-  );
+  useEffect(() => {
+    dispatchState({ type: 'restart', totalPages: numPages });
+  }, [numItems]);
 
   const arrow = 'https://cdn.glitch.com/11efcb07-3386-43b6-bab0-b8dc7372cba8%2Fleft-arrow.svg?1553883919269';
 
   return (
-    (
-      <>
-        {children(items, state.expanded)}
-        {canPaginate && (
-          <div className={styles.controls}>
-            <div className={styles.paginationControls}>
-              <Button ref={prevButtonRef} type="tertiary" disabled={state.page === 1} onClick={onPreviousButtonClick}>
-                <Image alt="Previous" className={styles.paginationArrow} src={arrow} />
-              </Button>
-              {state.announce && <LiveMessage message={state.announce} aria-live="assertive" />}
-              <div data-cy="page-numbers" className={styles.pageNumbers}>
-                {state.page} / {numPages}
-              </div>
-              <Button ref={nextButtonRef} type="tertiary" disabled={state.page === numPages} onClick={onNextButtonClick}>
-                <Image alt="Next" className={classNames(styles.paginationArrow, styles.next)} src={arrow} />
-              </Button>
+    <>
+      {children(items, state.expanded)}
+      {canPaginate && (
+        <div className={styles.controls}>
+          <div className={styles.paginationControls}>
+            <Button ref={prevButtonRef} type="tertiary" disabled={state.page === 1} onClick={onPreviousButtonClick}>
+              <Image alt="Previous" className={styles.paginationArrow} src={arrow} />
+            </Button>
+            {state.announce && <LiveMessage message={state.announce} aria-live="assertive" />}
+            <div data-cy="page-numbers" className={styles.pageNumbers}>
+              {state.page} / {numPages}
             </div>
-            <Button data-cy="show-all" type="tertiary" onClick={() => dispatchState({ type: 'expand' })}>
-              Show all <Badge>{numItems}</Badge>
+            <Button ref={nextButtonRef} type="tertiary" disabled={state.page === numPages} onClick={onNextButtonClick}>
+              <Image alt="Next" className={classNames(styles.paginationArrow, styles.next)} src={arrow} />
             </Button>
           </div>
-        )}
-      </>
-    )
+          <Button data-cy="show-all" type="tertiary" onClick={() => dispatchState({ type: 'expand' })}>
+            Show all <Badge>{numItems}</Badge>
+          </Button>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/components/pagination-controller/index.js
+++ b/src/components/pagination-controller/index.js
@@ -45,6 +45,7 @@ const paginationReducer = (oldState, action) => {
 function PaginationController({ enabled, items, itemsPerPage, fetchDataOptimistically, children }) {
   const numItems = items.length;
   const numPages = Math.ceil(items.length / itemsPerPage);
+  const allItems = items;
 
   const [state, dispatchState] = useReducer(paginationReducer, {
     page: 1,
@@ -73,19 +74,18 @@ function PaginationController({ enabled, items, itemsPerPage, fetchDataOptimisti
     dispatchState({ type: 'previous' });
   };
 
-  useEffect(() => {
-    if (canPaginate && fetchDataOptimistically) {
-      const startIdx = state.page * itemsPerPage;
-      const nextItems = items.slice(startIdx, startIdx + itemsPerPage);
-      console.log(nextItems);
-      nextItems.forEach(fetchDataOptimistically);
-    }
-  }, [state.page, canPaginate, itemsPerPage, fetchDataOptimistically]);
-
   if (canPaginate) {
     const startIdx = (state.page - 1) * itemsPerPage;
     items = items.slice(startIdx, startIdx + itemsPerPage);
   }
+
+  useEffect(() => {
+    if (canPaginate && fetchDataOptimistically) {
+      const startIdx = state.page * itemsPerPage;
+      const nextItems = allItems.slice(startIdx, startIdx + itemsPerPage);
+      nextItems.forEach(fetchDataOptimistically);
+    }
+  }, [state.page, canPaginate, itemsPerPage]);
 
   useEffect(() => {
     dispatchState({ type: 'restart', totalPages: numPages });

--- a/src/components/popover/search.js
+++ b/src/components/popover/search.js
@@ -10,9 +10,9 @@ import { PopoverActions, PopoverInfo, PopoverSection, InfoDescription } from './
 function useActiveIndex(items, onSelect) {
   const inputRef = useRef();
   const [activeIndex, setActiveIndex] = useState(-1);
+
   // reset activeIndex & focus when items change
   useEffect(() => {
-    console.log('reset');
     setActiveIndex(-1);
     inputRef.current.focus();
   }, [items]);
@@ -43,7 +43,6 @@ function useActiveIndex(items, onSelect) {
           return prev + 1;
         });
       } else if (e.key === 'Enter') {
-        console.log(items, activeIndex);
         e.preventDefault();
         if (items[activeIndex]) {
           onSelect(items[activeIndex]);
@@ -56,7 +55,7 @@ function useActiveIndex(items, onSelect) {
     return () => {
       window.removeEventListener('keydown', onKeyDown);
     };
-  }, [items]);
+  }, [items, activeIndex]);
 
   return { inputRef, activeIndex };
 }

--- a/src/components/popover/search.js
+++ b/src/components/popover/search.js
@@ -12,6 +12,7 @@ function useActiveIndex(items, onSelect) {
   const [activeIndex, setActiveIndex] = useState(-1);
   // reset activeIndex & focus when items change
   useEffect(() => {
+    console.log('reset');
     setActiveIndex(-1);
     inputRef.current.focus();
   }, [items]);
@@ -42,6 +43,7 @@ function useActiveIndex(items, onSelect) {
           return prev + 1;
         });
       } else if (e.key === 'Enter') {
+        console.log(items, activeIndex);
         e.preventDefault();
         if (items[activeIndex]) {
           onSelect(items[activeIndex]);

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -160,6 +160,7 @@ export function useTeamEditor(initialTeam) {
         ...prev,
         projects: [project, ...prev.projects],
       }));
+      reloadProjectMembers([project.id]);
     }, handleError),
     removeProjectFromTeam: withErrorHandler(async (project) => {
       await removeProjectFromTeam({ project, team });
@@ -167,6 +168,7 @@ export function useTeamEditor(initialTeam) {
         ...prev,
         projects: prev.projects.filter((p) => p.id !== project.id),
       }));
+      reloadProjectMembers([project.id]);
     }, handleError),
     deleteProject: withErrorHandler(async (project) => {
       await deleteItem({ project });


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me
- https://github.com/FogCreek/Glitch-Community-Work/issues/226
- https://github.com/FogCreek/Glitch-Community-Work/issues/230
- https://github.com/FogCreek/Glitch-Community-Work/issues/229

## Changes:
- Clear the project member cache when adding/removing projects from teams, so that the team avatar shows up correctly without needing a refresh
- Provide onSubmit in the add project to collection pop so that the proptypes warning goes away
- Fixed result item highlighting when using the arrow keys to navigate search results
- Fixed using the enter button to select a search result selected using the arrow keys
- Use the underlying function rather than the useCollectionProjects hook to preload the next page's projects so react doesn't get upset when you reach the last page

## How To Test:
- Try removing and then adding a project to a team. The team should not appear in the add project popover, and should appear once the project is added back
- Go to a collection page and click the add project button. Use the arrow keys to select a project and hit enter to add it
- Go to the glitch team and click through to the last page of collections. As long as you pace yourself, the collections should all appear with their projects already in place
- Look at the result items in other places they appear and make sure none of them look wrong

## Feedback I'm looking for:
This pr fixes multiple issues, which one should I link it to?