### PR TITLE
jolly-hardboard: make autoplay videos work on iOS Safari

### DIFF
--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 
 import useWindowSize from 'Hooks/use-window-size';
 
-function Video({ sources, track, ...props }) {
+function Video({ sources, track, autoPlay, ...props }) {
   const [windowWidth] = useWindowSize();
   const visibleVideos = sources.filter((s) => windowWidth >= s.minWidth && (!s.maxWidth || windowWidth <= s.maxWidth));
 
   // disabling this rule here because the linter doesn't understand that the track is inside .map
   return (
-    <video muted={track === 'muted'} {...props}> {/* eslint-disable-line jsx-a11y/media-has-caption */}
+    <video muted={track === 'muted'} autoPlay={autoPlay} playsInline={autoPlay} {...props}> {/* eslint-disable-line jsx-a11y/media-has-caption */}
       {visibleVideos.map((video) => (
         <React.Fragment key={video.src}>
           {track !== 'muted' && <track kind="captions" src={track} srcLang="en" />}


### PR DESCRIPTION
## Links
* [jolly-hardboard.glitch.me](https://jolly-hardboard.glitch.me/)
* [#293](https://github.com/FogCreek/Glitch-Community-Work/issues/293)

## Changes:
Updates `<Video>` component to set `playsinline` attribute if `autoPlay` prop is set.

## How To Test:
Visit [/create](https://jolly-hardboard.glitch.me/create), the autoPlay videos should have the `playsinline` attribute