### PR TITLE
periodic-weeder: Fix overflow of note on featured project

### DIFF
--- a/src/components/project/featured-project.styl
+++ b/src/components/project/featured-project.styl
@@ -4,6 +4,7 @@
 
 .left
   flex: 1 0 auto
+  max-width: 100%
 
 .note
   margin-bottom: 15px


### PR DESCRIPTION
## Links
* [periodic-weeder.glitch.me](https://periodic-weeder.glitch.me)
* [#204](https://github.com/FogCreek/Glitch-Community-Work/issues/204)

## GIF/Screenshots:
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td>
<img width="300" src="https://user-images.githubusercontent.com/7584833/62653775-493dd780-b92c-11e9-9087-621dd775d0f4.png"/>
</td>
<td>
<img width="300" src="https://user-images.githubusercontent.com/7584833/62653780-4d69f500-b92c-11e9-9a5a-79f8223147e7.png"/>
</td>
</tr>
</table>

## How To Test:
View the [Material starter kits collection](https://periodic-weeder.glitch.me/@material/material-starter-kits). The note on the featured project should not overflow.
