### PR TITLE
fix borked new stuff tooltip

### DIFF
--- a/src/components/tooltips/tooltip.styl
+++ b/src/components/tooltips/tooltip.styl
@@ -96,7 +96,8 @@ tooltip-background = rgba(0,0,0,0.95)
 .tooltip.newStuff::before
   border-top-color: notification
   border-bottom-color: transparent
-
+  top: 85%
+  
 // fallback
 .fallback.tooltip::before,
 .fallback.tooltip::after


### PR DESCRIPTION
## Links
* https://feline-bail.glitch.me/
* https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/297

## GIF/Screenshots:
before:
<img width="88" alt="Screen Shot 2019-08-08 at 10 24 01 AM" src="https://user-images.githubusercontent.com/6620164/62712809-90c67100-b9c9-11e9-9db7-971320b6a715.png">
after:
<img width="100" alt="Screen Shot 2019-08-08 at 10 40 55 AM" src="https://user-images.githubusercontent.com/6620164/62712810-90c67100-b9c9-11e9-818e-956788439a4b.png">

## Changes:
* fix the "new stuff" arrows, I recently [made a change to tooltips](https://github.com/FogCreek/Glitch-Community/pull/798) to fix one bug but sadly created this one in the process. I think this should fix it. 

## How To Test:
* sign in to the remix and see that the arrow part of the tooltip looks good, briefly check other tooltips to ensure they also look good. 


