### PR TITLE
Dramatic haddock: proxy community home editor

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -78,5 +78,8 @@ module.exports = function(app) {
   // proxy projects, users, teams, collections sitemaps
   proxyGlitch('sitemaps', 'sitemaps.glitch.me');
 
+  // proxy home CMS (without rewriting paths)
+  app.use('/index/edit', proxy('community-home-editor.glitch.me'));
+
   return routes;
 };

--- a/src/presenters/pages/home-v2/index.js
+++ b/src/presenters/pages/home-v2/index.js
@@ -280,7 +280,6 @@ export const Home = ({ data, loggedIn, hasProjects }) => (
 export const HomePreview = () => {
   const api = useAPI();
   const { origin, ZINE_POSTS } = useGlobals();
-  console.log('HomePreview', origin);
   const onPublish = async (data) => {
     try {
       await api.post(`${origin}/api/home`, data);
@@ -298,7 +297,7 @@ export const HomePreview = () => {
         onPublish={onPublish}
         previewMessage={
           <>
-            This is a live preview of edits done with <Link to="https://community-home-editor.glitch.me">Community Home Editor.</Link>
+            This is a live preview of edits done with <Link to="/index/edit">Community Home Editor.</Link>
           </>
         }
       >


### PR DESCRIPTION
## Links
* Remix link: https://dramatic-haddock.glitch.me
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/301

## Changes:
* proxy `community-home-editor.glitch.me` as `/index/edit` 

## How To Test:
* sign into https://dramatic-haddock.glitch.me
* visit https://dramatic-haddock.glitch.me/index/edit
* you should be able to use the community home editor without logging in again
* your edits should be reflected in https://dramatic-haddock.glitch.me/index/preview
