### PR TITLE
Garrulous season: styling links in collection descriptions

### DIFF
--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -145,7 +145,7 @@
     &:empty
       margin-top: 0
     a
-      color: inherit
+      color: link
   &.dark
     color: white
     a

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -11,11 +11,11 @@
 
   a
     color: link
-    text-decoration: underline
 
     &:hover
       text-decoration: underline
-      
+
+  // p,    
   pre,
   table,
   ul

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -15,7 +15,6 @@
     &:hover
       text-decoration: underline
 
-  // p,    
   pre,
   table,
   ul

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -15,14 +15,6 @@
 
     &:hover
       text-decoration: underline
-    
-  p
-    a
-      color: link
-      text-decoration: underline
-
-      &:hover
-        text-decoration: underline
       
   pre,
   table,

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -11,10 +11,19 @@
 
   a
     color: link
+    text-decoration: underline
+
     &:hover
       text-decoration: underline
     
-  //p,
+  p
+    a
+      color: link
+      text-decoration: underline
+
+      &:hover
+        text-decoration: underline
+      
   pre,
   table,
   ul


### PR DESCRIPTION
## Links
* https://garrulous-season.glitch.me/@sarahzinger
* Ihttps://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/130

## GIF/Screenshots:
![Screen Shot 2019-08-09 at 3 28 44 PM](https://user-images.githubusercontent.com/6620164/62804146-66a0ac00-baba-11e9-9e51-60ba09640ce2.png)

## Changes:
* change the styling of links to match what we have on the collections page to make it more clear to users that they are links.... although I'm wondering if we should add text underline even without hover? or just remove the linkified text altogether because putting links in links is a weird experience. 

## How To Test:
* check out a collection description on a user page that has a link in it like "my collection" here: https://garrulous-season.glitch.me/@sarahzinger

## Feedback I'm looking for:
whatcha think? it's a small fix, but now I'm doubting my own solution for it tbh. 