### PR TITLE
West foam: better handling of My Stuff on search results page

### DIFF
--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -40,26 +40,21 @@ const groups = [
   { id: 'collection', label: 'Collections' },
 ];
 
-const useProjectWithUserData = createAPIHook(async (api, id) => getSingleItem(api, `v1/projects/by/id?id=${id}`, id), { captureException: true });
+const useProjectsWithUserData = () => {
+  
+}
 
-const ProjectWithUserData = ({ project }) => {
-  const { value: projectWithUserData } = useProjectWithUserData(project.id);
-  if (projectWithUserData) {
-    return <ProjectItem project={projectWithUserData} />;
-  }
-  return <ProjectItem project={project} />;
-};
 
 const resultComponents = {
   team: ({ result }) => <TeamItem team={result} />,
   user: ({ result }) => <UserItem user={result} />,
-  project: ({ result }) => <ProjectWithUserData project={result} />,
+  project: ({ result, projectsWithUserData }) => <ProjectItem project={projectsWithUserData[result.id] || result} />,
   collection: ({ result }) => <CollectionItemSmall showCurator collection={result} />,
 };
 
-const ResultComponent = ({ result }) => {
+const ResultComponent = ({ result, ...props }) => {
   const Component = resultComponents[result.type];
-  return <Component result={result} />;
+  return <Component result={result} {...props} />;
 };
 
 const ShowAllButton = ({ label, onClick }) => (
@@ -116,6 +111,8 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
     }))
     .filter((group) => group.results.length > 0);
 
+  const projectsWithUserData = useProjectsWithUserData(groups.project);
+  
   return (
     <main className={styles.page} id="main">
       {ready && searchResults.totalHits > 0 && (
@@ -130,7 +127,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
             {(result) => <StarterKitItem result={result} />}
           </Grid>
           <Grid items={searchResults.topResults} className={styles.resultsContainer}>
-            {(result) => <ResultComponent result={result} />}
+            {(result) => <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />}
           </Grid>
         </article>
       )}
@@ -139,7 +136,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
           <article key={id} className={styles.groupContainer}>
             <Heading tagName="h2">{label}</Heading>
             <Grid items={results} className={styles.resultsContainer}>
-              {(result) => <ResultComponent result={result} />}
+              {(result) => <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />}
             </Grid>
             {canShowMoreResults && <ShowAllButton label={label} onClick={() => setActiveFilter(id)} />}
           </article>

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { useAPI } from 'State/api';
-import { getProjectDetails } from 'State/project-options';
+import { createAPIHook } from 'State/api';
+import { getSingleItem } from 'Shared/api';
 
 import SegmentedButtons from 'Components/buttons/segmented-buttons';
 import Button from 'Components/buttons/button';
@@ -40,23 +40,20 @@ const groups = [
   { id: 'collection', label: 'Collections' },
 ];
 
-const DetailsLoader = ({ project }) => {
-  const api = useAPI();
-  React.useEffect(() => {
-    async function fillInDetails() {
-      const details = await getProjectDetails(api, project.domain);
-      project.permissions = details.permissions || [];
-      project.authUserHasBookmarked = details.authUserHasBookmarked;
-    }
-    fillInDetails();
-  }, []);
+const useProjectWithUserData = createAPIHook(async (api, id) => getSingleItem(api, `v1/projects/by/id?id=${id}`, id), { captureException: true });
+
+const ProjectWithUserData = ({ project }) => {
+  const { value: projectWithUserData } = useProjectWithUserData(project.id);
+  if (projectWithUserData) {
+    return <ProjectItem project={projectWithUserData} />;
+  }
   return <ProjectItem project={project} />;
 };
 
 const resultComponents = {
   team: ({ result }) => <TeamItem team={result} />,
   user: ({ result }) => <UserItem user={result} />,
-  project: ({ result }) => <DetailsLoader project={result} />,
+  project: ({ result }) => <ProjectWithUserData project={result} />,
   collection: ({ result }) => <CollectionItemSmall showCurator collection={result} />,
 };
 

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { createAPIHook } from 'State/api';
-import { getSingleItem } from 'Shared/api';
 
 import SegmentedButtons from 'Components/buttons/segmented-buttons';
 import Button from 'Components/buttons/button';
@@ -40,10 +39,11 @@ const groups = [
   { id: 'collection', label: 'Collections' },
 ];
 
-const useProjectsWithUserData = () => {
-  
-}
-
+const useProjectsWithUserData = createAPIHook(async (api, projects) => {
+  const idString = projects.map((p) => `id=${p.id}`).join('&');
+  const { data } = await api.get(`/v1/projects/by/id?${idString}&limit=100`);
+  return data;
+}, { captureException: true });
 
 const resultComponents = {
   team: ({ result }) => <TeamItem team={result} />,
@@ -111,8 +111,8 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
     }))
     .filter((group) => group.results.length > 0);
 
-  const projectsWithUserData = useProjectsWithUserData(groups.project);
-  
+  const { value: projectsWithUserData = {} } = useProjectsWithUserData(searchResults.project);
+
   return (
     <main className={styles.page} id="main">
       {ready && searchResults.totalHits > 0 && (

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -8,8 +8,6 @@ import { userOrTeamIsAuthor, useCollectionReload } from 'State/collection';
 import { useProjectReload } from 'State/project';
 import { userIsOnTeam } from 'Models/team';
 import { userIsProjectMember, userIsProjectAdmin, userIsOnlyProjectAdmin } from 'Models/project';
-import { getSingleItem } from 'Shared/api';
-import { captureException } from 'Utils/sentry';
 
 const bind = (fn, ...args) => {
   if (!fn) return null;
@@ -39,16 +37,6 @@ const useDefaultProjectOptions = () => {
     }, handleError),
   };
 };
-
-export async function getProjectDetails(api, domain) {
-  try {
-    const project = await getSingleItem(api, `v1/projects/by/domain?domain=${domain}`, domain);
-    return project;
-  } catch (error) {
-    captureException(error);
-    return {};
-  }
-}
 
 // eslint-disable-next-line import/prefer-default-export
 export const useProjectOptions = (project, { user, team, collection, ...options } = {}) => {


### PR DESCRIPTION
## Links
* Remix link: https://west-foam.glitch.me/search?q=react&activeFilter=project
* Issue-tracker link: https://sentry.io/organizations/fog-creek-software/issues/1146512614/?project=1246508&query=is%3Aunresolved&statsPeriod=14d

## Changes:
* get projects in a single request instead of multiples (no more 429 errors)
* use id instead of domain (I think original error is caused by search results returning projects that have been renamed, and therefore cannot be found under the previous name)
* don't mutate the project data
* use `createAPIHook` (has error handling built-in)

## How To Test:
* log into west-foam.glitch.me
* enable My Stuff
* search for a project that's in your My Stuff collection
* that project should indicate that you have collected it

## Further considerations
* depending on how big people's My Stuff collections are vs how much we depend on algolia search, it will probably make more sense to just keep the My Stuff collection in memory and check it against all projects, instead of hitting the project API 
