### PR TITLE
Kaput aftermath: fix main element

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -77,13 +77,13 @@
       </div>
     </div>
 
-    <div id="main"><%- rendered %></div>
+    <div id="react-root"><%- rendered %></div>
 
     <% for (let i = 0; i < scripts.length; ++i) { %>
     <script src="<%= scripts[i] %>"></script>
     <% } %>
     <script>
-      var container = document.getElementById('main');
+      var container = document.getElementById('react-root');
       function showFallback(name) {
         document.getElementById('fallback').removeAttribute('style');
         document.getElementById('fallback-img').removeAttribute('style');


### PR DESCRIPTION
## Links
* Remix link: https://kaput-aftermath.glitch.me/
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/309

## Changes:
* change react root element id from "main" to "react-root"

## How To Test:
* visit https://kaput-aftermath.glitch.me/
* pressing tab should focus a previously hidden button reading "Skip to Main Content"
* pressing space should move the page focus and scroll position to the page's content
* pressing tab again should select the first button or link on the page's main content, skipping the header
