### PR TITLE
add back descriptions to my stuff in add to collection popover

### DIFF
--- a/src/components/collection/collection-result-item.js
+++ b/src/components/collection/collection-result-item.js
@@ -38,7 +38,7 @@ const CollectionResultItem = ({ onClick, collection, active }) => {
       <ResultInfo>
         <VisuallyHidden>Add to collection</VisuallyHidden>
         <ResultName>{collection.name}</ResultName>
-        {collection.description.length > 0 && !collectionIsMyStuff && (
+        {collection.description.length > 0 && (
           <ResultDescription>
             <VisuallyHidden>with description</VisuallyHidden>
             <Markdown renderAsPlaintext>{collection.description}</Markdown>


### PR DESCRIPTION
## Links
* Remix link: https://happy-cobra.glitch.me

## GIF/Screenshots:
![Screen Shot 2019-08-14 at 10 33 19 AM](https://user-images.githubusercontent.com/6620164/63029669-f78ed300-be7e-11e9-9c27-110a748a0914.png)

## Changes:
* we decided during qa the description is needed after all

## How To Test:
* go to https://happy-cobra.glitch.me/secret
* click my stuff
* login
* go to any project and try adding it to a collection, you should see the description.
