### PR TITLE
Community-side setup for targeting local API server instances (far-cushion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./src/polyfills.js"
   ],
   "scripts": {
+    "prestart": "nodemon --watch server --watch shared --exec 'eslint --config server/.eslintrc.server.js server shared webpack.config.js' &",
     "start": "forever --minUptime 5000 --spinSleepTime 1000 -c 'nodemon --watch server --watch shared --watch views --exitcrash' ./server/server.js",
     "storybook": "build-storybook -c storybook-config -o build/storybook"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "./src/polyfills.js"
   ],
   "scripts": {
-    "prestart": "nodemon --watch server --watch shared --exec 'eslint --config server/.eslintrc.server.js server shared webpack.config.js' &",
     "start": "forever --minUptime 5000 --spinSleepTime 1000 -c 'nodemon --watch server --watch shared --watch views --exitcrash' ./server/server.js",
     "storybook": "build-storybook -c storybook-config -o build/storybook"
   },

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,8 +1,14 @@
+const os = require('os');
 const { envs, tagline } = require('../shared/constants');
 
-// in the backend, just switch between staging and production
+// in the backend, just switch between local, staging and production
 // the client supports RUNNING_ON = development
-const currentEnv = process.env.RUNNING_ON === 'staging' ? 'staging' : 'production';
+const currentEnv = ['local', 'staging'].includes(process.env.RUNNING_ON) ? process.env.RUNNING_ON : 'production';
+const current = envs[currentEnv];
+if (currentEnv === 'local') {
+  current.API_URL = `https://${process.env.FWD_SUBDOMAIN_PREFIX}-glitch.fwd.wf/`;
+}
+
 module.exports = {
   ...envs,
   current: envs[currentEnv],

--- a/server/constants.js
+++ b/server/constants.js
@@ -5,13 +5,15 @@ const { envs, tagline } = require('../shared/constants');
 // the client supports RUNNING_ON = development
 const currentEnv = ['local', 'staging'].includes(process.env.RUNNING_ON) ? process.env.RUNNING_ON : 'production';
 const current = envs[currentEnv];
+
 if (currentEnv === 'local') {
-  current.API_URL = `https://${process.env.FWD_SUBDOMAIN_PREFIX}-glitch.fwd.wf/`;
+  const fwdSubdomainPrefix = process.env.FWD_SUBDOMAIN_PREFIX || process.env.PROJECT_NAME || os.userInfo().username;
+  current.API_URL = `https://${fwdSubdomainPrefix}-glitch.fwd.wf/`;
 }
 
 module.exports = {
   ...envs,
-  current: envs[currentEnv],
+  current,
   currentEnv,
   tagline,
 };

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -28,6 +28,15 @@ const envs = {
     FACEBOOK_CLIENT_ID: '1121393391305429',
     PROJECTS_DOMAIN: 'glitch.development',
   },
+	local: {
+    APP_URL: 'https://glitch.com',
+    API_URL: process.env.FWD_SUBDOMAIN_PREFIX ? `https://${process.env.FWD_SUBDOMAIN_PREFIX}-glitch.fwd.wf/` : null,
+    EDITOR_URL: 'https://glitch.com/edit/',
+    CDN_URL: 'https://s3.amazonaws.com/hyperdev-development',
+    GITHUB_CLIENT_ID: '5d4f1392f69bcdf73d9f',
+    FACEBOOK_CLIENT_ID: '1121393391305429',
+    PROJECTS_DOMAIN: 'glitch.me',
+  }  
 };
 
 const tagline = 'friendly community where everyone can discover & create the best apps on the web.';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,20 +103,20 @@ module.exports = smp.wrap({
   },
   module: {
     rules: [
-      {
-        enforce: 'pre',
-        test: /\.js$/,
-        include: SRC,
-        loader: 'eslint-loader',
-        options: {
-          fix: false, //mode === 'development', // Only change source files in development
-          cache: false, // Keep this off, it can use a lot of space.  Let Webpack --watch do the heavy lifting for us.
-          emitError: false,
-          emitWarning: true,
-          failOnError: false,
-          ignorePattern: 'src/curated/**',
-        },
-      },
+      // {
+      //   enforce: 'pre',
+      //   test: /\.js$/,
+      //   include: SRC,
+      //   loader: 'eslint-loader',
+      //   options: {
+      //     fix: false, //mode === 'development', // Only change source files in development
+      //     cache: false, // Keep this off, it can use a lot of space.  Let Webpack --watch do the heavy lifting for us.
+      //     emitError: false,
+      //     emitWarning: true,
+      //     failOnError: false,
+      //     ignorePattern: 'src/curated/**',
+      //   },
+      // },
       {
         oneOf: [
           {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -7,6 +8,7 @@ const AutoprefixerStylus = require('autoprefixer-stylus');
 const StatsPlugin = require('stats-webpack-plugin');
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const { EnvironmentPlugin } = require('webpack');
 const aliases = require('./shared/aliases');
 
 const BUILD = path.resolve(__dirname, 'build');
@@ -184,6 +186,9 @@ module.exports = smp.wrap({
       publicPath: true,
     }),
     new CleanWebpackPlugin({ dry: false, verbose: true, cleanOnceBeforeBuildPatterns: ['**/*', '!storybook/**', ...prevBuildAssets] }),
+    new EnvironmentPlugin({
+      FWD_SUBDOMAIN_PREFIX: process.env.PROJECT_NAME || os.userInfo().username,
+    }),    
   ],
   watchOptions: {
     ignored: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,20 +103,20 @@ module.exports = smp.wrap({
   },
   module: {
     rules: [
-      // {
-      //   enforce: 'pre',
-      //   test: /\.js$/,
-      //   include: SRC,
-      //   loader: 'eslint-loader',
-      //   options: {
-      //     fix: false, //mode === 'development', // Only change source files in development
-      //     cache: false, // Keep this off, it can use a lot of space.  Let Webpack --watch do the heavy lifting for us.
-      //     emitError: false,
-      //     emitWarning: true,
-      //     failOnError: false,
-      //     ignorePattern: 'src/curated/**',
-      //   },
-      // },
+      {
+        enforce: 'pre',
+        test: /\.js$/,
+        include: SRC,
+        loader: 'eslint-loader',
+        options: {
+          fix: false, //mode === 'development', // Only change source files in development
+          cache: false, // Keep this off, it can use a lot of space.  Let Webpack --watch do the heavy lifting for us.
+          emitError: false,
+          emitWarning: true,
+          failOnError: false,
+          ignorePattern: 'src/curated/**',
+        },
+      },
       {
         oneOf: [
           {


### PR DESCRIPTION
We are going to make it possible to work on the API locally (without a full dev backend) and point a community remix at it to test against. The other half of this work is in [this infra repo pull](https://github.com/FogCreek/Glitch/pull/1707).

## Links
* Remix link: https://far-cushion.glitch.me/
* Issue-tracker link: in infra ZenHub [here](https://app.zenhub.com/workspaces/glitch-infrastructure-5d2db407bc23971a08b9fe2a/issues/fogcreek/glitch/1655)

## GIF/Screenshots:

Here is viewing a project on a remix:

![Screen Shot 2019-08-14 at 4 14 00 PM](https://user-images.githubusercontent.com/219964/63052953-8ff07c00-beae-11e9-9a32-6c751dd3d1ac.png)

Here are the local server logs of it being loaded:

![Screen Shot 2019-08-14 at 4 13 27 PM](https://user-images.githubusercontent.com/219964/63052981-a39be280-beae-11e9-99f6-637d9941c3b9.png)

## Changes:
* Add a "local" value for the `RUNNING_ON` environment variable. It tells the server and client to use the API URL that will be generated by the SSH tunnel on the infrastructure project side.
* Default to the project name, if it's not there (maybe we are running community locally too) then use the machine username (the infra project end also falls back to this). 
* `FWD_SUBDOMAIN_PREFIX` can also be set directly in `.env`.

## How To Test:
* Remix this project
* Set `RUNNING_ON` to "local"
* Clone the infrastructure repo
* Checkout the "forward" branch if it hasn't been merged yet
* Do
  * `cd api`
  * `sh/compile`
  * `bundle install`
  * (ask Daniel about getting Postgres and Redis set up)
  * `npm run local -- remix-name`
  * Verify the remix pulls data from the local API instance

## Feedback I'm looking for:
* The was this gets inserted into the constants feels weird, particularly having to do something slightly different for the server and client when the goal seems to be to keep them consistent. Maybe there is a better way?

## Things left to do before deploying:
* Once this and the other half are out we will verify that the connection between them works.
* There's plenty to do to improve the developer experience of actually using this, so there will definitely be followups.