### PR TITLE
Quixotic rocket: Fix leaving team projects, fix joining teams via email whitelist

### DIFF
--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -11,6 +11,7 @@ import { useCurrentUser } from 'State/current-user';
 import { AddProjectToCollectionBase } from './add-project-to-collection-pop';
 
 const isTeamProject = ({ currentUser, project }) => currentUser.teams.some((team) => project.teamIds.includes(team.id));
+const useTrackedLeaveProject = (leaveProject) => useTrackedFunc(leaveProject, 'Leave Project clicked');
 
 /* eslint-disable react/no-array-index-key */
 const PopoverMenuItems = ({ children }) =>
@@ -24,13 +25,8 @@ const PopoverMenuItems = ({ children }) =>
   );
 
 const LeaveProjectPopover = ({ project, leaveProject, togglePopover }) => {
-  const { currentUser } = useCurrentUser();
   const illustration = 'https://cdn.glitch.com/55f8497b-3334-43ca-851e-6c9780082244%2Fwave.png?v=1502123444938';
-  const trackLeaveProject = useTrackedFunc(leaveProject, 'Leave Project clicked');
-  if (isTeamProject({ currentUser, project })) {
-    trackLeaveProject(project);
-    return null;
-  }
+  const trackLeaveProject = useTrackedLeaveProject(leaveProject);
 
   return (
     <PopoverDialog wide focusOnDialog align="right">
@@ -50,8 +46,11 @@ const LeaveProjectPopover = ({ project, leaveProject, togglePopover }) => {
   );
 };
 
-const ProjectOptionsContent = ({ projectOptions, addToCollectionPopover, leaveProjectPopover }) => {
+const ProjectOptionsContent = ({ project, projectOptions, addToCollectionPopover, leaveProjectPopover, leaveProjectDirect }) => {
+  const { currentUser } = useCurrentUser();
   const onClickDeleteProject = useTrackedFunc(projectOptions.deleteProject, 'Delete Project clicked');
+  const trackedLeaveProjectDirect = useTrackedLeaveProject(leaveProjectDirect);
+  const onClickLeaveProject = isTeamProject({ currentUser, project }) ? trackedLeaveProjectDirect : leaveProjectPopover;
 
   return (
     <PopoverDialog align="right">
@@ -66,7 +65,7 @@ const ProjectOptionsContent = ({ projectOptions, addToCollectionPopover, leavePr
           [{ onClick: addToCollectionPopover, label: 'Add to Collection', emoji: 'framedPicture' }],
           [{ onClick: projectOptions.joinTeamProject, label: 'Join Project', emoji: 'rainbow' }],
           [
-            { onClick: leaveProjectPopover, label: 'Leave Project', emoji: 'wave' },
+            { onClick: leaveProjectDirect && onClickLeaveProject, label: 'Leave Project', emoji: 'wave' },
           ],
           [
             { onClick: projectOptions.removeProjectFromTeam, label: 'Remove Project', emoji: 'thumbsDown', dangerZone: true },
@@ -115,9 +114,11 @@ export default function ProjectOptionsPop({ project, projectOptions }) {
         >
           {({ addToCollection, leaveProject }) => (
             <ProjectOptionsContent
+              project={project}
               projectOptions={toggleBeforeAction(togglePopover)}
               addToCollectionPopover={addToCollection}
-              leaveProjectPopover={projectOptions.leaveProject && leaveProject}
+              leaveProjectPopover={leaveProject}
+              leaveProjectDirect={projectOptions.leaveProject}
             />
           )}
         </MultiPopover>

--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -83,16 +83,11 @@ export default function ProjectOptionsPop({ project, projectOptions }) {
 
   if (noProjectOptions) return null;
 
-  const toggleBeforeAction = (togglePopover) =>
-    mapValues(
-      projectOptions,
-      (action) =>
-        action &&
-        ((...args) => {
-          togglePopover();
-          action(...args);
-        }),
-    );
+  const toggleBeforeAction = (togglePopover, action) => action && ((...args) => {
+    togglePopover();
+    action(...args);
+  });
+  const toggleBeforeActions = (togglePopover) => mapValues(projectOptions, (action) => toggleBeforeAction(togglePopover, action));
 
   return (
     <PopoverMenu label={`Project Options for ${project.domain}`}>
@@ -115,10 +110,10 @@ export default function ProjectOptionsPop({ project, projectOptions }) {
           {({ addToCollection, leaveProject }) => (
             <ProjectOptionsContent
               project={project}
-              projectOptions={toggleBeforeAction(togglePopover)}
+              projectOptions={toggleBeforeActions(togglePopover)}
               addToCollectionPopover={addToCollection}
               leaveProjectPopover={leaveProject}
-              leaveProjectDirect={projectOptions.leaveProject}
+              leaveProjectDirect={toggleBeforeAction(togglePopover, projectOptions.leaveProject)}
             />
           )}
         </MultiPopover>

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -96,6 +96,7 @@ export function useTeamEditor(initialTeam) {
       await joinTeam({ team });
       setTeam((prev) => ({
         ...prev,
+        teamPermissions: [...prev.teamPermissions, { accessLevel: MEMBER_ACCESS_LEVEL, userId: currentUser.id }],
         users: [...prev.users, currentUser],
       }));
       if (currentUser) {
@@ -113,6 +114,7 @@ export function useTeamEditor(initialTeam) {
       removeUserAdmin(user);
       setTeam((prev) => ({
         ...prev,
+        teamPermissions: prev.teamPermissions.filter((p) => p.userId !== user.id),
         users: prev.users.filter((u) => u.id !== user.id),
       }));
       if (currentUser && currentUser.id === user.id) {


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/
https://github.com/FogCreek/Glitch-Community-Work/issues/330

## Changes:
- When leaving a project, do the thing in the onclick rather than in the popover render function
- Update teamPermissions when joining/leaving a team so that the join team button appears/goes away

## How To Test:
- Try leaving a project on a team page, it should remove you from the user list without blanking out the whole page
- Try leaving and joining a team via email whitelist. The join team button should get replaced with an invite button (note that leaving teams is broken right now https://github.com/FogCreek/Glitch/issues/1733)