### PR TITLE
Slash second: more my stuff bugs

### DIFF
--- a/src/components/buttons/bookmark-button.styl
+++ b/src/components/buttons/bookmark-button.styl
@@ -28,7 +28,7 @@
   }
 }  
 
-@media (max-width: mediumSmallViewport) {
+@media (hover: none) {
   .bookmarkButton {
     transform: translateY(0px)
     opacity: 1

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -13,6 +13,7 @@ import { useCurrentUser } from 'State/current-user';
 import { useNotifications } from 'State/notifications';
 import { toggleBookmark, useCollectionReload } from 'State/collection';
 import useDevToggle from 'State/dev-toggles';
+import { useTrackedFunc } from 'State/segment-analytics';
 
 import FeaturedProjectOptionsPop from './featured-project-options-pop';
 import styles from './featured-project.styl';
@@ -80,19 +81,28 @@ const FeaturedProject = ({
     setHasBookmarked(featuredProject.authUserHasBookmarked);
   }, [featuredProject.authUserHasBookmarked]);
 
-  const bookmarkAction = () =>
-    toggleBookmark({
-      api,
-      project: featuredProject,
-      currentUser,
-      createNotification,
-      myStuffEnabled,
-      addProjectToCollection: addProjectToCollectionAPI,
-      removeProjectFromCollection,
-      setHasBookmarked,
-      hasBookmarked,
-      reloadCollectionProjects,
-    });
+  const bookmarkAction = useTrackedFunc(
+    () =>
+      toggleBookmark({
+        api,
+        project: featuredProject,
+        currentUser,
+        createNotification,
+        myStuffEnabled,
+        addProjectToCollection: addProjectToCollectionAPI,
+        removeProjectFromCollection,
+        setHasBookmarked,
+        hasBookmarked,
+        reloadCollectionProjects,
+      }),
+    `Project ${hasBookmarked ? 'removed from my stuff' : 'added to my stuff'}`,
+    (inherited) => ({
+      ...inherited,
+      projectName: featuredProject.domain,
+      baseProjectId: featuredProject.baseId || featuredProject.baseProject,
+      userId: currentUser.id,
+    }),
+  );
 
   return (
     <div data-cy="featured-project">

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -101,6 +101,7 @@ const FeaturedProject = ({
       projectName: featuredProject.domain,
       baseProjectId: featuredProject.baseId || featuredProject.baseProject,
       userId: currentUser.id,
+      origin: `${inherited.origin}-featured-project`,
     }),
   );
 


### PR DESCRIPTION
## Links
* Remix link: https://slash-second.glitch.me 🔪 🕐 
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/329

## Changes:
* always show bookmark button on devices that don't have a hover (phones/ipads, etc) rather than based on screen width, realized in a11y testing that putting my phone on landscape mode makes the bookmark buttons undiscoverable lol. I'm curious if there's anywhere else we might want to consider doing this, couldn't think of any of the top of my head. 
* added a tracker around the bookmark button from the featured project embed, realized that got lost in the shuffle somehow. Added a modified origins so it'll show it's come from the user or collection page, but specifically from the featured project section and not from the project items. Not sure if that matters but i figure the more data the better. 

## How To Test:
* enable my stuff
* login
* notice the bookmark buttons are always visible on a phone, even on landscape. Or if you have some kind of tablet device that would be even better [I'm just sort of assuming this works](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover).

## Feedback I'm looking for:
any bugs or things I'm not thinking about
