### PR TITLE
jazzy-packet: fix source maps in development mode

### DIFF
--- a/src/components/profile-list/index.js
+++ b/src/components/profile-list/index.js
@@ -34,31 +34,34 @@ const TeamItem = ({ team }) => {
 const useResizeObserver = () => {
   const ref = useRef();
   const [width, setWidth] = useState(0);
-  useEffect(() => {
-    const setWidthOfRef = () => {
-      if (ref.current) {
-        const boundingClientRect = ref.current.getBoundingClientRect();
-        if (boundingClientRect) {
-          setWidth(boundingClientRect.width);
+  useEffect(
+    () => {
+      const setWidthOfRef = () => {
+        if (ref.current) {
+          const boundingClientRect = ref.current.getBoundingClientRect();
+          if (boundingClientRect) {
+            setWidth(boundingClientRect.width);
+          }
         }
-      }
-    };
-    const debouncedSetWidth = debounce(setWidthOfRef, 100);
-    setWidthOfRef();
-
-    if (window.ResizeObserver) {
-      const observer = new ResizeObserver(debouncedSetWidth);
-      observer.observe(ref.current);
-
-      return () => {
-        observer.unobserve(ref.current);
       };
-    }
-    window.addEventListener('resize', debouncedSetWidth);
-    return () => {
-      window.removeEventListener('resize', debouncedSetWidth);
-    };
-  }, [ref, setWidth]);
+      const debouncedSetWidth = debounce(setWidthOfRef, 100);
+      setWidthOfRef();
+
+      if (window.ResizeObserver) {
+        const observer = new ResizeObserver(debouncedSetWidth);
+        observer.observe(ref.current);
+
+        return () => {
+          observer.unobserve(ref.current);
+        };
+      }
+      window.addEventListener('resize', debouncedSetWidth);
+      return () => {
+        window.removeEventListener('resize', debouncedSetWidth);
+      };
+    },
+    [ref, setWidth],
+  );
   return { ref, width };
 };
 
@@ -125,7 +128,11 @@ const GLITCH_TEAM_AVATAR = 'https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-20439
 const GLITCH_TEAM_URL = 'glitch';
 
 const GlitchTeamList = ({ size }) => {
-  const tooltipTarget = <TeamLink team={{url: GLITCH_TEAM_URL }} draggable={false}><Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip /></TeamLink>;
+  const tooltipTarget = (
+    <TeamLink team={{ url: GLITCH_TEAM_URL }} draggable={false}>
+      <Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip />
+    </TeamLink>
+  );
   return (
     <ul className={classnames(styles.container, styles[size])}>
       <li className={styles.teamItem}>

--- a/src/components/profile-list/index.js
+++ b/src/components/profile-list/index.js
@@ -34,34 +34,31 @@ const TeamItem = ({ team }) => {
 const useResizeObserver = () => {
   const ref = useRef();
   const [width, setWidth] = useState(0);
-  useEffect(
-    () => {
-      const setWidthOfRef = () => {
-        if (ref.current) {
-          const boundingClientRect = ref.current.getBoundingClientRect();
-          if (boundingClientRect) {
-            setWidth(boundingClientRect.width);
-          }
+  useEffect(() => {
+    const setWidthOfRef = () => {
+      if (ref.current) {
+        const boundingClientRect = ref.current.getBoundingClientRect();
+        if (boundingClientRect) {
+          setWidth(boundingClientRect.width);
         }
-      };
-      const debouncedSetWidth = debounce(setWidthOfRef, 100);
-      setWidthOfRef();
-
-      if (window.ResizeObserver) {
-        const observer = new ResizeObserver(debouncedSetWidth);
-        observer.observe(ref.current);
-
-        return () => {
-          observer.unobserve(ref.current);
-        };
       }
-      window.addEventListener('resize', debouncedSetWidth);
+    };
+    const debouncedSetWidth = debounce(setWidthOfRef, 100);
+    setWidthOfRef();
+
+    if (window.ResizeObserver) {
+      const observer = new ResizeObserver(debouncedSetWidth);
+      observer.observe(ref.current);
+
       return () => {
-        window.removeEventListener('resize', debouncedSetWidth);
+        observer.unobserve(ref.current);
       };
-    },
-    [ref, setWidth],
-  );
+    }
+    window.addEventListener('resize', debouncedSetWidth);
+    return () => {
+      window.removeEventListener('resize', debouncedSetWidth);
+    };
+  }, [ref, setWidth]);
   return { ref, width };
 };
 
@@ -128,11 +125,7 @@ const GLITCH_TEAM_AVATAR = 'https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-20439
 const GLITCH_TEAM_URL = 'glitch';
 
 const GlitchTeamList = ({ size }) => {
-  const tooltipTarget = (
-    <TeamLink team={{ url: GLITCH_TEAM_URL }} draggable={false}>
-      <Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip />
-    </TeamLink>
-  );
+  const tooltipTarget = <TeamLink team={{url: GLITCH_TEAM_URL }} draggable={false}><Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip /></TeamLink>;
   return (
     <ul className={classnames(styles.container, styles[size])}>
       <li className={styles.teamItem}>

--- a/src/components/profile-list/index.js
+++ b/src/components/profile-list/index.js
@@ -34,34 +34,31 @@ const TeamItem = ({ team }) => {
 const useResizeObserver = () => {
   const ref = useRef();
   const [width, setWidth] = useState(0);
-  useEffect(
-    () => {
-      const setWidthOfRef = () => {
-        if (ref.current) {
-          const boundingClientRect = ref.current.getBoundingClientRect();
-          if (boundingClientRect) {
-            setWidth(boundingClientRect.width);
-          }
+  useEffect(() => {
+    const setWidthOfRef = () => {
+      if (ref.current) {
+        const boundingClientRect = ref.current.getBoundingClientRect();
+        if (boundingClientRect) {
+          setWidth(boundingClientRect.width);
         }
-      };
-      const debouncedSetWidth = debounce(setWidthOfRef, 100);
-      setWidthOfRef();
-
-      if (window.ResizeObserver) {
-        const observer = new ResizeObserver(debouncedSetWidth);
-        observer.observe(ref.current);
-
-        return () => {
-          observer.unobserve(ref.current);
-        };
       }
-      window.addEventListener('resize', debouncedSetWidth);
+    };
+    const debouncedSetWidth = debounce(setWidthOfRef, 100);
+    setWidthOfRef();
+
+    if (window.ResizeObserver) {
+      const observer = new ResizeObserver(debouncedSetWidth);
+      observer.observe(ref.current);
+
       return () => {
-        window.removeEventListener('resize', debouncedSetWidth);
+        observer.unobserve(ref.current);
       };
-    },
-    [ref, setWidth],
-  );
+    }
+    window.addEventListener('resize', debouncedSetWidth);
+    return () => {
+      window.removeEventListener('resize', debouncedSetWidth);
+    };
+  }, [ref, setWidth]);
   return { ref, width };
 };
 
@@ -128,11 +125,7 @@ const GLITCH_TEAM_AVATAR = 'https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-20439
 const GLITCH_TEAM_URL = 'glitch';
 
 const GlitchTeamList = ({ size }) => {
-  const tooltipTarget = (
-    <TeamLink team={{ url: GLITCH_TEAM_URL }} draggable={false}>
-      <Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip />
-    </TeamLink>
-  );
+  const tooltipTarget = <TeamLink team={{ url: GLITCH_TEAM_URL }} draggable={false}><Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip /></TeamLink>;
   return (
     <ul className={classnames(styles.container, styles[size])}>
       <li className={styles.teamItem}>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = smp.wrap({
     path: BUILD,
     publicPath: '/',
   },
-  devtool: mode === 'production' ? 'source-map' : 'cheap-module-source-map',
+  devtool: mode === 'production' ? 'source-map' : 'eval-source-map',
   optimization: {
     splitChunks: {
       chunks: 'initial',


### PR DESCRIPTION
## Links
* [jazzy-packet.glitch.me](https://spiny-wire.glitch.me)

lol
![Screen Shot 2019-08-16 at 2 22 58 PM](https://user-images.githubusercontent.com/7584833/63191267-15eaff00-c036-11e9-9c57-87c57f1f92de.png)

## GIF/Screenshots:
🔢 Look! The line numbers aren't grayed out! You can set breakpoints again!

<img width="550" alt="Screen Shot 2019-08-16 at 2 43 48 PM" src="https://user-images.githubusercontent.com/7584833/63190919-48482c80-c035-11e9-9155-1b300501d9cb.png">

## Changes:
Use `eval-source-map` in dev mode instead of `cheap-module-source-map` because `cheap-module-source-map` is broken af when used with babel. I don't have time to fully understand why, but if you're interested to learn more, see [create-react-app/pull/4930](https://github.com/facebook/create-react-app/pull/4930) or [fusion-cli/pull/758](https://github.com/fusionjs/fusion-cli/pull/758) or [webpack/issues/8302](https://github.com/webpack/webpack/issues/8302)

Using `eval-source-map` will make initial builds slower, but not by much (2-3 min total), and should make rebuilds a bit faster.

## How To Test:
* Open the debugger, use `CMD-p`/`Ctrl-p` to open a file like `button/button.js`, you should be able to set breakpoints.

## Feedback I'm looking for:
- Are we cool with slowing down initial builds a bit in devolpment mode?