### PR TITLE
Successful geology: debounce search results from search input

### DIFF
--- a/src/components/profile-list/index.js
+++ b/src/components/profile-list/index.js
@@ -125,7 +125,7 @@ const GLITCH_TEAM_AVATAR = 'https://cdn.glitch.com/2bdfb3f8-05ef-4035-a06e-20439
 const GLITCH_TEAM_URL = 'glitch';
 
 const GlitchTeamList = ({ size }) => {
-  const tooltipTarget = <TeamLink team={{url: GLITCH_TEAM_URL }} draggable={false}><Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip /></TeamLink>;
+  const tooltipTarget = <TeamLink team={{ url: GLITCH_TEAM_URL }} draggable={false}><Avatar name="Glitch Team" src={GLITCH_TEAM_AVATAR} color="#74ecfc" type="team" hideTooltip /></TeamLink>;
   return (
     <ul className={classnames(styles.container, styles[size])}>
       <li className={styles.teamItem}>

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -8,6 +8,7 @@ import { getProjectLink } from 'Models/project';
 import { getUserLink } from 'Models/user';
 import { getTeamLink } from 'Models/team';
 import { useAlgoliaSearch } from 'State/search';
+import useDebouncedValue from 'Hooks/use-debounced-value';
 
 import TextInput from '../inputs/text-input';
 import AutocompleteSearch from './autocomplete';
@@ -104,7 +105,8 @@ const AlgoliaSearchController = withRouter(({ history, visible, openPopover, def
     results: [],
   };
   const [{ query, results, selectedResult }, dispatch] = useReducer(reducer, initialState);
-  const algoliaResults = useAlgoliaSearch(query);
+  const debouncedQuery = useDebouncedValue(query, 500);
+  const algoliaResults = useAlgoliaSearch(debouncedQuery);
 
   useEffect(
     () => {

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -138,6 +138,7 @@ const AlgoliaSearchController = withRouter(({ history, visible, openPopover, def
   };
 
   const onChange = (value) => dispatch(actions.queryChanged(value));
+  console.log('paint')
 
   return (
     <form className={styles.container} role="search" onSubmit={onSubmit} autoComplete="off" autoCapitalize="off" action="/search" method="get">

--- a/src/components/search-form/index.js
+++ b/src/components/search-form/index.js
@@ -138,7 +138,6 @@ const AlgoliaSearchController = withRouter(({ history, visible, openPopover, def
   };
 
   const onChange = (value) => dispatch(actions.queryChanged(value));
-  console.log('paint')
 
   return (
     <form className={styles.container} role="search" onSubmit={onSubmit} autoComplete="off" autoCapitalize="off" action="/search" method="get">


### PR DESCRIPTION
## Links
* Remix link: https://successful-geology.glitch.me/

## Changes:
* add a 500ms debounce before making algolia searches
* fix lint error

## How To Test:
* visit https://successful-geology.glitch.me/
* throttle your bandwidth to "Fast 3G" in the "Network" tab of the inspector
* use the search autocomplete
* typing in the search box should have no noticeable latency
* the search results should update only after you have stopped typing
