### PR TITLE
Well iodine: disable horizontal scrolling

### DIFF
--- a/styles/globals.styl
+++ b/styles/globals.styl
@@ -54,7 +54,7 @@ body
   font-family: sansserif
   color: primary
   margin: 0
-  //overflow-x: hidden
+  overflow-x: hidden
 
 h1
   font-weight: bold

--- a/styles/globals.styl
+++ b/styles/globals.styl
@@ -54,6 +54,7 @@ body
   font-family: sansserif
   color: primary
   margin: 0
+  //overflow-x: hidden
 
 h1
   font-weight: bold


### PR DESCRIPTION
## Links
* Remix link: https://well-iodine.glitch.me/
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/287

## Changes:
* add `overflow-x: hidden` to body

## How To Test:
* visit https://well-iodine.glitch.me/
* enable "Show scroll bars: always" if you are on a mac laptop
![Screen Shot 2019-08-19 at 3 16 50 PM](https://user-images.githubusercontent.com/938722/63292770-6f506980-c294-11e9-98d9-4649556e8d9a.png)
* there should be no horizontal scroll bar

## Feedback I'm looking for:
Is there any platform on which this breaks _vertical_ scrolling? I tested on iOS safari, Mac chrome, mac Safari, mac Firefox