### PR TITLE
Auto focus the pause button when wistia component appears on homepage

### DIFF
--- a/src/components/wistia-video/index.js
+++ b/src/components/wistia-video/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-const WistiaVideo = ({ videoId }) => {
+const WistiaVideo = React.forwardRef(({ videoId }, ref) => {
   useEffect(() => {
     const loadedScripts = new Set();
     const scriptTags = document.querySelectorAll('script');
@@ -31,10 +31,10 @@ const WistiaVideo = ({ videoId }) => {
   return (
     <div className="wistia_responsive_padding">
       <div className="wistia_responsive_wrapper">
-        <div className={`wistia_embed wistia_async_${videoId}`} videofoam="true" />
+        <div ref={ref} className={`wistia_embed wistia_async_${videoId}`} videofoam="true" />
       </div>
     </div>
   );
-};
+});
 
 export default WistiaVideo;

--- a/src/presenters/pages/home-v2/banner.js
+++ b/src/presenters/pages/home-v2/banner.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 
 import Button from 'Components/buttons/button';
@@ -48,16 +48,28 @@ const OverlayVideo = () => {
 const InlineVideo = () => {
   const [showVideo, setShowVideo] = useState(false);
   const track = useTracker();
+  const wistiaRef = React.createRef();
 
   const onClick = () => {
     track('Watch Video clicked');
     setShowVideo(true);
   };
 
+  useEffect(() => {
+    if (showVideo && wistiaRef.current) {
+      setTimeout(() => {
+        const pauseButton = wistiaRef.current.querySelector('[aria-label="Pause"]');
+        if (pauseButton) {
+          pauseButton.focus();
+        }
+      }, 500);
+    }
+  }, [showVideo]);
+
   return (
     <div className={classnames(styles.bannerVideo)}>
       {showVideo ? (
-        <WistiaVideo videoId="z2ksbcs34d" />
+        <WistiaVideo ref={wistiaRef} videoId="z2ksbcs34d" />
       ) : (
         <>
           <div className={styles.bannerVideoPoster} onClick={onClick} aria-hidden="true" />


### PR DESCRIPTION
## Links
* arrow-ankylosaurus.glitch.me
* https://github.com/FogCreek/Glitch-Community-Work/issues/63

## Changes:
* When you click the button to 'watch video' on the homepage, a click on the spacebar should pause the video for consistency with other video players/how it would be if the video player was actually on screen the whole time.

## Things to think about
* We're relying on Wistia's control to stay the same - or at least have a pause button with aria-label='Pause'
* If the player doesn't appear in time or the pause button can't be found, we fall back silently to the old behavior of focus going to the `body` element

## How To Test:
* Start the video on the homepage by clicking the button; start the video on the homepage by tabbing to the button and pressing space

## Feedback I'm looking for:
Is this an okay solution? 
