### PR TITLE
Fix tooltip overlap

### DIFF
--- a/src/components/tooltips/tooltip-container.js
+++ b/src/components/tooltips/tooltip-container.js
@@ -27,6 +27,7 @@ function TooltipContainer({ type, tooltip, target, align, persistent, children, 
   );
 
   const id = useUniqueId();
+  const shouldShowTooltip = tooltip && (tooltipIsActive || persistent);
 
   const tooltipClassName = cx({
     tooltip: true,
@@ -36,6 +37,7 @@ function TooltipContainer({ type, tooltip, target, align, persistent, children, 
     newStuff,
     persistent,
     fallback,
+    hideTooltipNode: !shouldShowTooltip,
   });
   const tooltipFallbackClassName = fallback ? styles.fallback : '';
 
@@ -68,8 +70,6 @@ function TooltipContainer({ type, tooltip, target, align, persistent, children, 
     });
   }
 
-  const shouldShowTooltip = tooltip && (tooltipIsActive || persistent);
-
   function cancelClick(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -85,7 +85,7 @@ function TooltipContainer({ type, tooltip, target, align, persistent, children, 
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   if (!fallback) {
     tooltipNode = (
-      <div role={role} id={id} className={tooltipClassName} style={{ opacity: shouldShowTooltip ? 1 : 0 }} onClick={cancelClick}>
+      <div role={role} id={id} className={tooltipClassName} onClick={cancelClick}>
         {type === 'info' || shouldShowTooltip ? tooltip : null}
       </div>
     );

--- a/src/components/tooltips/tooltip.styl
+++ b/src/components/tooltips/tooltip.styl
@@ -201,3 +201,6 @@ tooltip-background = rgba(0,0,0,0.95)
     top: 0px
   &.persistent
     display: none
+
+.hideTooltipNode
+  display: none


### PR DESCRIPTION
## Links
* tooltip-hover.glitch.me
* https://github.com/FogCreek/Glitch-Community-Work/issues/341

## Changes
* if the tooltip isn't showing, make it `display: none` so that the hover target doesn't obscure other elements on the page. (When the tooltip is showing, you should be able to hover over the tooltip without it disappearing)

## How To Test:
1. Go to a project page for a project that's part of a team, on both glitch.com and tooltip-hover.glitch.me. 
  - Examples: [https://glitch.com/~lipstick-robot](https://glitch.com/~lipstick-robot) and [https://tooltip-hover.glitch.me/~lipstick-robot](https://tooltip-hover.glitch.me/~lipstick-robot). 
2. Try to hover over the avatars for the team and user, view the tooltip, click the avatars to go to the profile page, etc.
3. It should be easier in tooltip-hover. 

## Feedback I'm looking for:
- does this break other tooltips anywhere? I can't find any place where it does but you never know with these tooltips. 

