### PR TITLE
Quixotic-rocket: Fix the analytics identify call

### DIFF
--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -29,8 +29,7 @@ const defaultUser = {
 };
 
 function identifyUser(user) {
-  const analytics = { window };
-  document.cookie = `hasLogin=; expires=${new Date().toUTCString()}`;
+  document.cookie = `hasLogin=; expires=${new Date()}`;
   if (user) {
     addBreadcrumb({
       level: 'info',
@@ -48,10 +47,10 @@ function identifyUser(user) {
     });
   }
   try {
-    if (analytics && analytics.identify && user && user.login) {
+    if (window.analytics && user && user.login) {
       const emailObj = Array.isArray(user.emails) && user.emails.find((email) => email.primary);
       const email = emailObj && emailObj.email;
-      analytics.identify(
+      window.analytics.identify(
         user.id,
         {
           name: user.name,


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me
https://github.com/FogCreek/Glitch-Community-Work/issues/346

## Changes:
- Get rid of the attempted analytics destructure so identify gets called
- Small simplification to hasLogin cookie setting

## How To Test:
Check the network panel for a request to api.segment.io/v1/i, there should be a request made on page load