### PR TITLE
Quixotic rocket: Improve color contrast on help requests

### DIFF
--- a/src/components/questions/index.js
+++ b/src/components/questions/index.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import randomColor from 'randomcolor';
 import { sample } from 'lodash';
 
 import Heading from 'Components/text/heading';
@@ -9,6 +8,7 @@ import Grid from 'Components/containers/grid';
 import ErrorBoundary from 'Components/error-boundary';
 import Arrow from 'Components/arrow';
 
+import { pickRandomColors } from 'Utils/color';
 import { captureException } from 'Utils/sentry';
 import { useAPI } from 'State/api';
 
@@ -26,10 +26,7 @@ async function load(api, max) {
       .filter((q) => !!q)
       .slice(0, max)
       .map((question) => {
-        const [colorInner, colorOuter] = randomColor({
-          luminosity: 'light',
-          count: 2,
-        });
+        const [colorInner, colorOuter] = pickRandomColors(2);
         return { colorInner, colorOuter, id: question.questionId, ...question };
       });
     return { kaomoji, questions };

--- a/src/components/questions/index.js
+++ b/src/components/questions/index.js
@@ -56,7 +56,7 @@ function Questions({ max }) {
   });
   useRepeatingEffect(() => {
     load(api, max).then(setState);
-  }, 10000, []);
+  }, 10000, [api.persistentToken, max]);
 
   return (
     <section className={styles.container}>

--- a/src/components/questions/item.js
+++ b/src/components/questions/item.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Image from 'Components/images/image';
 import Button from 'Components/buttons/button';
 import { getEditorUrl } from 'Models/project';
 import Link from 'Components/link';
+import { isDarkColor } from 'Utils/color';
 import styles from './questions.styl';
 
 const iconHelp = 'https://cdn.glitch.com/f7224274-1330-4022-a8f2-8ae09dbd68a8%2Fask-for-help.svg?1494954687906';
@@ -38,7 +40,7 @@ const QuestionItem = ({ colorOuter, colorInner, domain, question, tags, userAvat
           <Button decorative>Help {userLogin}</Button>
         </div>
 
-        <div className={styles.questionText} title={question}>
+        <div className={classNames(styles.questionText, { [styles.dark]: isDarkColor(colorInner) })} title={question}>
           {truncateQuestion(question)}
         </div>
         <div className={styles.questionTags}>

--- a/src/components/questions/questions.styl
+++ b/src/components/questions/questions.styl
@@ -10,7 +10,7 @@
 .link
   color: link !important
 
-  
+
 // question-item
 .helpIcon
   vertical-align: middle
@@ -23,30 +23,33 @@
   background-color: secondary-background-active
   padding: 8px
   border-radius: 5px
-    
+
 .questionAsker
   display: flex
   flex-direction: row
   align-items: center
-  
+
 .questionInner
   padding: 8px
   background-color: secondary-background
-  border-radius: 3px  
-  
+  border-radius: 3px
+
+.dark
+  color: white
+
 .avatar
   border-radius: 50%
   width: 32px
   margin-right: 4px
-  
+
 .questionText
   margin: 8px 0
   font-size: 14px
-  
+
 .questionTags
   margin-bottom: -6px
   font-size: 14px
-  
+
 .tag
   background-color: help-tag
   border-radius: 5px

--- a/src/state/globals.js
+++ b/src/state/globals.js
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
-const Context = createContext({});
+export const Context = createContext({});
 
 export const GlobalsProvider = withRouter(({ children, history, location, origin, SSR_SIGNED_IN, ZINE_POSTS, HOME_CONTENT, EXTERNAL_ROUTES }) => {
   const value = useMemo(() => {

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -28,10 +28,15 @@ export const hexToRgbA = (hex) => {
 
 export const isGoodColorContrast = (hex) => getContrastWithDarkText(hex) >= 4.5 || getContrastWithLightText(hex) >= 4.5;
 
-export function pickRandomColor() {
-  const newColor = randomColor({ luminosity: 'light' });
-  if (isGoodColorContrast(newColor)) {
-    return newColor;
+export function pickRandomColors(count) {
+  const newColors = randomColor({ luminosity: 'light', count });
+  if (newColors.every((color) => isGoodColorContrast(color))) {
+    return newColors;
   }
-  return pickRandomColor();
+  return pickRandomColors();
+}
+
+export function pickRandomColor() {
+  const [newColor] = pickRandomColors(1);
+  return newColor;
 }

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -33,7 +33,7 @@ export function pickRandomColors(count) {
   if (newColors.every((color) => isGoodColorContrast(color))) {
     return newColors;
   }
-  return pickRandomColors();
+  return pickRandomColors(count);
 }
 
 export function pickRandomColor() {

--- a/stories/util.js
+++ b/stories/util.js
@@ -1,3 +1,4 @@
+import { Context as GlobalsContext } from 'State/globals';
 import { Context as CurrentUserContext } from 'State/current-user';
 import { Context as APIContext } from 'State/api';
 
@@ -17,9 +18,11 @@ export const provideContext = (
   { currentUser = {}, currentUserFetched = true, api = {} } = {},
   Component,
 ) => () => (
-  <CurrentUserContext.Provider value={{ currentUser, fetched: currentUserFetched }}>
-    <APIContext.Provider value={api}>
-      <Component />
-    </APIContext.Provider>
-  </CurrentUserContext.Provider>
+  <GlobalsContext.Provider value={{ location: new URL(window.location.origin) }}>
+    <CurrentUserContext.Provider value={{ currentUser, fetched: currentUserFetched }}>
+      <APIContext.Provider value={api}>
+        <Component />
+      </APIContext.Provider>
+    </CurrentUserContext.Provider>
+  </GlobalsContext.Provider>
 );

--- a/stories/util.js
+++ b/stories/util.js
@@ -18,7 +18,14 @@ export const provideContext = (
   { currentUser = {}, currentUserFetched = true, api = {} } = {},
   Component,
 ) => () => (
-  <GlobalsContext.Provider value={{ location: new URL(window.location.origin) }}>
+  <GlobalsContext.Provider value={{
+    location: new URL(window.location.origin),
+    origin: window.location.origin,
+    EXTERNAL_ROUTES: [],
+    HOME_CONTENT: {},
+    SSR_SIGNED_IN: false,
+    ZINE_POSTS: [],
+  }}>
     <CurrentUserContext.Provider value={{ currentUser, fetched: currentUserFetched }}>
       <APIContext.Provider value={api}>
         <Component />


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me
https://github.com/FogCreek/Glitch-Community-Work/issues/334

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/63618154-5f4cc880-c5b9-11e9-9e64-3b9725c424e2.png)

## Changes:
- Question items will switch to white text if they are using dark colors, like collections do
- Only use colors with high enough contrast values for question items
- Fixed the storybook entry for question items

## How To Test:
https://quixotic-rocket.glitch.me/storybook/index.html?path=/story/questions--has-questions
Check out the storybook and see if any of them are hard to read. Switch between 'has questions' and 'has many questions' to refresh the colors. It prefers light colors so getting one with white text is very rare.