### PR TITLE
Probable castanet: Use larger font on touch devices to prevent strange zoom behavior

### DIFF
--- a/src/components/inputs/text-input.styl
+++ b/src/components/inputs/text-input.styl
@@ -44,7 +44,8 @@
     background-image: url(search)
     background-repeat: no-repeat
     background-position: right 5px center
-
+    font-size: 16px
+    
 .inputBorder, .input
   transition: box-shadow .1s
 .inputBorder:focus-within, .input:focus

--- a/src/components/inputs/text-input.styl
+++ b/src/components/inputs/text-input.styl
@@ -44,7 +44,8 @@
     background-image: url(search)
     background-repeat: no-repeat
     background-position: right 5px center
-    font-size: 16px
+    @media (hover: none)
+      font-size: 16px
     
 .inputBorder, .input
   transition: box-shadow .1s


### PR DESCRIPTION
## Links
* Remix link: https://probable-castanet.glitch.me/

## GIF/Screenshots:
![Screen Shot 2019-08-28 at 10 47 37 AM](https://user-images.githubusercontent.com/6620164/63866519-5117f700-c981-11e9-987e-61054494f9aa.png)
![Screen Shot 2019-08-28 at 10 47 49 AM](https://user-images.githubusercontent.com/6620164/63866521-5117f700-c981-11e9-955e-2094b56e8198.png)

## Changes:
* If you try searching for something on the glitch site on an iphone (and potentially other devices as well?) it will zoom in to the input field (which makes sense) unfortunately when you hit enter, there's no zoom out behavior. There seem to be [2 main ways of handling this](https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone) that I could find, one is to set the fontsize to 16px (as apparently that's the size iphones don't zoom for) and the other is to prevent zooming all together (which sounds terrible from an accessibility standpoint). I guess the 3rd option would be to just let it go and embrace the weird zoom behavior.

## How To Test:
* get an iphone and type in the search field, notice it should not zoom in when you type and thus you have no need for it to zoom out

## Feedback I'm looking for:
- does this look terrible? does this look strange on other devices besides iphone? do you see alternative solutions? am I concerned over something I shouldn't be concerned about?

## Things left to do before deploying:
- [x] feels worth running by tiff when she gets back
