### PR TITLE
shadowed-wave: populate collection name input with collection filter query

### DIFF
--- a/src/components/collection/create-collection-pop.js
+++ b/src/components/collection/create-collection-pop.js
@@ -77,14 +77,13 @@ const useCollections = createAPIHook((api, teamId, currentUser) => {
   return getAllPages(api, `/v1/users/by/id/collections?id=${currentUser.id}&limit=100`);
 });
 
-function CreateCollectionPopBase({ align, title, onSubmit, options }) {
+function CreateCollectionPopBase({ align, title, onSubmit, options, initialCollectionName }) {
   const api = useAPI();
   const { createNotification } = useNotifications();
   const { currentUser } = useCurrentUser();
 
   const [loading, setLoading] = useState(false);
-  // TODO: should this be pre-populated with a friendly name?
-  const [collectionName, setCollectionName] = useState('');
+  const [collectionName, setCollectionName] = useState(initialCollectionName);
 
   const [selection, setSelection] = useState(options[0]);
 
@@ -153,7 +152,16 @@ function CreateCollectionPopBase({ align, title, onSubmit, options }) {
   );
 }
 
-export function CreateCollectionWithProject({ project, addProjectToCollection }) {
+CreateCollectionPopBase.propTypes = {
+  team: PropTypes.object,
+  initialCollectionName: PropTypes.string,
+};
+CreateCollectionPopBase.defaultProps = {
+  team: null,
+  initialCollectionName: '',
+};
+
+export function CreateCollectionWithProject({ project, addProjectToCollection, initialCollectionName }) {
   const { createNotification } = useNotifications();
   const { currentUser } = useCurrentUser();
   const options = getOptions(currentUser);
@@ -176,7 +184,7 @@ export function CreateCollectionWithProject({ project, addProjectToCollection })
   };
   const title = <MultiPopoverTitle>{`Add ${project.domain} to a new collection`}</MultiPopoverTitle>;
 
-  return <CreateCollectionPopBase align="right" title={title} options={options} onSubmit={onSubmit} />;
+  return <CreateCollectionPopBase align="right" title={title} options={options} onSubmit={onSubmit} initialCollectionName={initialCollectionName} />;
 }
 
 CreateCollectionWithProject.propTypes = {
@@ -184,7 +192,7 @@ CreateCollectionWithProject.propTypes = {
   addProjectToCollection: PropTypes.func.isRequired,
 };
 
-const CreateCollectionPop = withRouter(({ team, history }) => {
+const CreateCollectionPop = withRouter(({ team, history, initialCollectionName }) => {
   const { currentUser } = useCurrentUser();
   const options = team ? [getTeamOption(team)] : [getUserOption(currentUser)];
   const track = useTracker('Create Collection clicked');
@@ -197,7 +205,7 @@ const CreateCollectionPop = withRouter(({ team, history }) => {
 
   return (
     <PopoverWithButton buttonText="Create Collection">
-      {() => <CreateCollectionPopBase align="left" options={options} onSubmit={onSubmit} />}
+      {() => <CreateCollectionPopBase align="left" options={options} onSubmit={onSubmit} initialCollectionName={initialCollectionName} />}
     </PopoverWithButton>
   );
 });
@@ -207,6 +215,7 @@ CreateCollectionPop.propTypes = {
 };
 CreateCollectionPop.defaultProps = {
   team: null,
+  initialCollectionName: '',
 };
 
 export default CreateCollectionPop;

--- a/src/components/collection/create-collection-pop.js
+++ b/src/components/collection/create-collection-pop.js
@@ -129,6 +129,7 @@ function CreateCollectionPopBase({ align, title, onSubmit, options, initialColle
               error={error}
               placeholder="New Collection Name"
               labelText="New Collection Name"
+              autoFocus
             />
           </div>
 
@@ -151,13 +152,10 @@ function CreateCollectionPopBase({ align, title, onSubmit, options, initialColle
     </PopoverDialog>
   );
 }
-
 CreateCollectionPopBase.propTypes = {
-  team: PropTypes.object,
   initialCollectionName: PropTypes.string,
 };
 CreateCollectionPopBase.defaultProps = {
-  team: null,
   initialCollectionName: '',
 };
 
@@ -192,7 +190,7 @@ CreateCollectionWithProject.propTypes = {
   addProjectToCollection: PropTypes.func.isRequired,
 };
 
-const CreateCollectionPop = withRouter(({ team, history, initialCollectionName }) => {
+const CreateCollectionPop = withRouter(({ team, history }) => {
   const { currentUser } = useCurrentUser();
   const options = team ? [getTeamOption(team)] : [getUserOption(currentUser)];
   const track = useTracker('Create Collection clicked');
@@ -205,7 +203,7 @@ const CreateCollectionPop = withRouter(({ team, history, initialCollectionName }
 
   return (
     <PopoverWithButton buttonText="Create Collection">
-      {() => <CreateCollectionPopBase align="left" options={options} onSubmit={onSubmit} initialCollectionName={initialCollectionName} />}
+      {() => <CreateCollectionPopBase align="left" options={options} onSubmit={onSubmit} />}
     </PopoverWithButton>
   );
 });
@@ -215,7 +213,6 @@ CreateCollectionPop.propTypes = {
 };
 CreateCollectionPop.defaultProps = {
   team: null,
-  initialCollectionName: '',
 };
 
 export default CreateCollectionPop;

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -126,12 +126,22 @@ function useCollectionSearch(query, project, collectionType) {
   return { status: searchResults.status, collections, collectionsWithProject };
 }
 
-export const AddProjectToCollectionBase = ({ project, fromProject, addProjectToCollection, togglePopover, createCollectionPopover, setInitialCollectionName }) => {
+export const AddProjectToCollectionBase = ({
+  project,
+  fromProject,
+  addProjectToCollection,
+  togglePopover,
+  createCollectionPopover,
+  setInitialCollectionName,
+}) => {
   const [collectionType, setCollectionType] = useState('user');
   const [query, setQuery] = useState('');
-  useEffect(() => {
-    setInitialCollectionName(query);
-  }, [query]);
+  useEffect(
+    () => {
+      setInitialCollectionName(query);
+    },
+    [query],
+  );
   const { status, collections, collectionsWithProject } = useCollectionSearch(query, project, collectionType);
   const { currentUser } = useCurrentUser();
   const { createNotification } = useNotifications();

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -186,6 +186,12 @@ export const AddProjectToCollectionBase = ({
         renderItem={({ item: collection, active }) => (
           <AddProjectToCollectionResultItem active={active} onClick={() => addProjectTo(collection)} collection={collection} />
         )}
+        renderMessage={() => {
+          if (collectionsWithProject.length) {
+            return <PopoverInfo><AlreadyInCollection project={project} collections={collectionsWithProject} /></PopoverInfo>;
+          }
+          return null;
+        }}
         renderNoResults={() => (
           <PopoverInfo>
             <NoResults project={project} collectionsWithProject={collectionsWithProject} query={query} />

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -194,7 +194,7 @@ export const AddProjectToCollectionBase = ({
       />
 
       <PopoverActions>
-        <Button size="small" type="tertiary" onClick={() => createCollectionPopover()}>
+        <Button size="small" type="tertiary" onClick={createCollectionPopover}>
           Add to a new collection
         </Button>
       </PopoverActions>

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -183,15 +183,15 @@ export const AddProjectToCollectionBase = ({
         onSubmit={addProjectTo}
         placeholder="Filter collections"
         labelText="Filter collections"
-        renderItem={({ item: collection, active }) => (
-          <AddProjectToCollectionResultItem active={active} onClick={() => addProjectTo(collection)} collection={collection} />
-        )}
         renderMessage={() => {
           if (collectionsWithProject.length) {
             return <PopoverInfo><AlreadyInCollection project={project} collections={collectionsWithProject} /></PopoverInfo>;
           }
           return null;
         }}
+        renderItem={({ item: collection, active }) => (
+          <AddProjectToCollectionResultItem active={active} onClick={() => addProjectTo(collection)} collection={collection} />
+        )}
         renderNoResults={() => (
           <PopoverInfo>
             <NoResults project={project} collectionsWithProject={collectionsWithProject} query={query} />


### PR DESCRIPTION
## Links
* [shadowed-wave.glitch.me](https://shadowed-wave.glitch.me)
* [#337](https://github.com/FogCreek/Glitch-Community-Work/issues/337)

## GIF/Screenshots:

<img width="300" src="https://user-images.githubusercontent.com/7584833/63976938-793a4f80-ca80-11e9-83f5-8a7b1a227fe5.gif" />

## Changes:
Auto-populate the collection name input with the filter query when creating a new collection from a project page.

I also autofocused the collection name input because that just feels like a better experience to me. @clottman is that an a11y issue?

## How To Test:
On a project page, click the "Add to collection" button:

1. Search the collection list for a non-existent collection. Click "Add to a new collection". The collection name input should be populated with your query.
2. Click "Add to a new collection" without entering a query. The collection name input should be empty.