### PR TITLE
Acidic-tomate: standardize error handling on image upload failures

### DIFF
--- a/src/components/team-analytics/team-analytics-activity.js
+++ b/src/components/team-analytics/team-analytics-activity.js
@@ -74,7 +74,6 @@ const dateFormat = (currentTimeFrame) => {
 };
 
 const renderChart = (activeFilter, c3, analytics, currentTimeFrame) => {
-  console.log(analytics);
   let columns = [];
   if (!isEmpty(analytics)) {
     columns = chartColumns(analytics, currentTimeFrame);

--- a/src/state/error-handlers.js
+++ b/src/state/error-handlers.js
@@ -21,12 +21,20 @@ function handleCustomError(notify, error) {
   return Promise.reject(error);
 }
 
+function handleImageUploadError(notify, error) {
+  console.error(error);
+  notify('Unable to process image. Please try another image.');
+  // swallow the error
+  return false;
+}
+
 const useErrorHandlers = () => {
   const { createErrorNotification } = useNotifications();
   return {
     handleError: (error) => handleError(createErrorNotification, error),
     handleErrorForInput: (error) => handleErrorForInput(createErrorNotification, error),
     handleCustomError: (error) => handleCustomError(createErrorNotification, error),
+    handleImageUploadError: (error) => handleImageUploadError(createErrorNotification, error),
   };
 };
 

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -90,7 +90,7 @@ export function useProjectReload() {
 export function useProjectEditor(initialProject) {
   const [project, setProject] = useState(initialProject);
   const { uploadAsset } = useUploader();
-  const { handleError, handleErrorForInput } = useErrorHandlers();
+  const { handleError, handleErrorForInput, handleImageUploadError } = useErrorHandlers();
   const { getAvatarImagePolicy } = assets.useAssetPolicy();
   const { updateItem, deleteItem, updateProjectDomain } = useAPIHandlers();
   useEffect(() => setProject(initialProject), [initialProject]);
@@ -118,12 +118,16 @@ export function useProjectEditor(initialProject) {
       assets.requestFile(
         withErrorHandler(async (blob) => {
           const { data: policy } = await getAvatarImagePolicy({ project });
-          await uploadAsset(blob, policy, '', { cacheControl: 60 });
+          const url = await uploadAsset(blob, policy, '', { cacheControl: 60 });
+          if (!url) {
+            return;
+          }
+
           setProject((prev) => ({
             ...prev,
             avatarUpdatedAt: Date.now(),
           }));
-        }, handleError),
+        }, handleImageUploadError),
       ),
   };
   return [project, funcs];

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -17,7 +17,7 @@ export function useTeamEditor(initialTeam) {
   const { currentUser, update: updateCurrentUser } = useCurrentUser();
   const { uploadAssetSizes } = useUploader();
   const { createNotification } = useNotifications();
-  const { handleError, handleErrorForInput } = useErrorHandlers();
+  const { handleError, handleErrorForInput, handleImageUploadError } = useErrorHandlers();
   const { getAvatarImagePolicy, getCoverImagePolicy } = assets.useAssetPolicy();
   const reloadProjectMembers = useProjectReload();
   const {
@@ -129,7 +129,10 @@ export function useTeamEditor(initialTeam) {
       assets.requestFile(
         withErrorHandler(async (blob) => {
           const { data: policy } = await getAvatarImagePolicy({ team });
-          await uploadAssetSizes(blob, policy, assets.AVATAR_SIZES);
+          const success = await uploadAssetSizes(blob, policy, assets.AVATAR_SIZES);
+          if (!success) {
+            return;
+          }
 
           const image = await assets.blobToImage(blob);
           const color = assets.getDominantColor(image);
@@ -138,13 +141,16 @@ export function useTeamEditor(initialTeam) {
             backgroundColor: color,
           });
           setTeam((prev) => ({ ...prev, updatedAt: Date.now() }));
-        }, handleError),
+        }, handleImageUploadError),
       ),
     uploadCover: () =>
       assets.requestFile(
         withErrorHandler(async (blob) => {
           const { data: policy } = await getCoverImagePolicy({ team });
-          await uploadAssetSizes(blob, policy, assets.COVER_SIZES);
+          const success = await uploadAssetSizes(blob, policy, assets.COVER_SIZES);
+          if (!success) {
+            return;
+          }
 
           const image = await assets.blobToImage(blob);
           const color = assets.getDominantColor(image);
@@ -153,7 +159,7 @@ export function useTeamEditor(initialTeam) {
             coverColor: color,
           });
           setTeam((prev) => ({ ...prev, updatedAt: Date.now() }));
-        }, handleError),
+        }, handleImageUploadError),
       ),
     clearCover: () => updateFields({ hasCoverImage: false }).catch(handleError),
     addProject: withErrorHandler(async (project) => {

--- a/src/state/uploader.js
+++ b/src/state/uploader.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Progress } from '@fogcreek/shared-components';
 
 import { uploadAsset, uploadAssetSizes } from 'Utils/assets';
-import { captureException } from 'Utils/sentry';
 import { useNotifications } from 'State/notifications';
 import Text from 'Components/text/text';
 
@@ -35,10 +34,9 @@ async function uploadWrapper(notifications, upload) {
       updateNotification(<NotifyUploading progress={progress} />);
     });
   } catch (error) {
-    captureException(error);
-    notifications.createErrorNotification(<NotifyError error={error} />);
     removeNotification();
-    return result;
+    notifications.createErrorNotification(<NotifyError error={error} />);
+    return false;
   }
 
   removeNotification();

--- a/src/state/user.js
+++ b/src/state/user.js
@@ -23,7 +23,7 @@ export function useUserEditor(initialUser) {
   });
   const { currentUser, update: updateCurrentUser } = useCurrentUser();
   const { uploadAsset, uploadAssetSizes } = useUploader();
-  const { handleError, handleErrorForInput } = useErrorHandlers();
+  const { handleError, handleErrorForInput, handleImageUploadError } = useErrorHandlers();
   const { getCoverImagePolicy } = assets.useAssetPolicy();
   const {
     updateItem,
@@ -55,20 +55,25 @@ export function useUserEditor(initialUser) {
         withErrorHandler(async (blob) => {
           const { data: policy } = await getCoverImagePolicy({ user }); // TODO: why not 'getAvatarImagePolicy' here?
           const url = await uploadAsset(blob, policy, 'temporary-user-avatar');
-
+          if (!url) {
+            return;
+          }
           const image = await assets.blobToImage(blob);
           const color = assets.getDominantColor(image);
           await updateFields({
             avatarUrl: url,
             color,
           });
-        }, handleError),
+        }, handleImageUploadError),
       ),
     uploadCover: () =>
       assets.requestFile(
         withErrorHandler(async (blob) => {
           const { data: policy } = await getCoverImagePolicy({ user });
-          await uploadAssetSizes(blob, policy, assets.COVER_SIZES);
+          const success = await uploadAssetSizes(blob, policy, assets.COVER_SIZES);
+          if (!success) {
+            return;
+          }
 
           const image = await assets.blobToImage(blob);
           const color = assets.getDominantColor(image);
@@ -77,7 +82,7 @@ export function useUserEditor(initialUser) {
             coverColor: color,
           });
           setUser((prev) => ({ ...prev, updatedAt: Date.now() }));
-        }, handleError),
+        }, handleImageUploadError),
       ),
     clearCover: () => updateFields({ hasCoverImage: false }).catch(handleError),
     addPin: withErrorHandler(async (project) => {


### PR DESCRIPTION
## Links
* acidic-tomate.glitch.me
* https://github.com/FogCreek/Glitch-Community-Work/issues/344

## GIF/Screenshots:
if the upload itself failed: 
![image](https://user-images.githubusercontent.com/4480480/64047204-c6c3c480-cb33-11e9-8a19-b433d23402b3.png)
If the upload succeeded but we can't process the image: 
![image](https://user-images.githubusercontent.com/4480480/64047249-de02b200-cb33-11e9-9090-ed3a502ceb71.png)

## Changes:
* Only one error notification ever shows up on file upload failures. Before, you might have got an 'upload failed' notification followed immediately by a 'something went wrong, try refreshing?' notification because we kept acting as if the upload succeeded when it failed
* We don't let errors bubble up to sentry if they're just file upload errors - more than likely it's the user's problem, not ours
* removes a console.log that got left in when I was working on the team analytics section

## How To Test:
* Try uploading [the image in this zip file](https://fogcreek.slack.com/archives/CJS8MABLZ/p1567098131017400?thread_ts=1567097911.016700&cid=CJS8MABLZ) as your cover photo for a team or user, or your avatar. 
  * this still fails silently on project avatar uploads, but I don't know enough about image processing/ how our uploads work to figure out why

## Feedback I'm looking for:
anything really
