### PR TITLE
Fallacious slice: Remove the feature switch in front of email invites

### DIFF
--- a/src/components/team-users/add-team-user.js
+++ b/src/components/team-users/add-team-user.js
@@ -38,7 +38,7 @@ const InviteByEmail = ({ result: email, active, onClick }) => {
   const { current: color } = useRef(randomColor({ luminosity: 'light' }));
   return (
     <ResultItem onClick={onClick} active={active}>
-      <UserAvatar user={{ color }} hideTooltip />
+      <UserAvatar user={{ id: 0, color }} hideTooltip />
       <ResultInfo>
         <ResultName>Invite {email}</ResultName>
       </ResultInfo>

--- a/src/components/team-users/add-team-user.js
+++ b/src/components/team-users/add-team-user.js
@@ -61,6 +61,7 @@ function useCheckedDomains(query) {
     const domain = getDomain(query);
     if (!domain || domain in checkedDomains) return;
 
+    setCheckedDomains((domains) => ({ ...domains, [domain]: null }));
     axios.get(`https://freemail.glitch.me/${domain}`).then(({ data }) => {
       setCheckedDomains((domains) => ({ ...domains, [domain]: !data.free }));
     }, captureException);

--- a/src/components/team-users/add-team-user.js
+++ b/src/components/team-users/add-team-user.js
@@ -12,7 +12,6 @@ import { ResultItem, ResultInfo, ResultName, ResultDescription } from 'Component
 import { getDisplayName } from 'Models/user';
 import { captureException } from 'Utils/sentry';
 import { useTracker } from 'State/segment-analytics';
-import useDevToggle from 'State/dev-toggles';
 import { useAlgoliaSearch } from 'State/search';
 
 import useDebouncedValue from '../../hooks/use-debounced-value';
@@ -79,7 +78,6 @@ function AddTeamUserPop({ members, inviteEmail, inviteUser, setWhitelistedDomain
   const [value, onChange] = useState('');
   const debouncedValue = useDebouncedValue(value, 200);
   const checkedDomains = useCheckedDomains(debouncedValue);
-  const allowEmailInvites = useDevToggle('Email Invites');
 
   const { user: retrievedUsers, status } = useAlgoliaSearch(
     debouncedValue,
@@ -95,7 +93,7 @@ function AddTeamUserPop({ members, inviteEmail, inviteUser, setWhitelistedDomain
     const out = [];
 
     const email = parseOneAddress(debouncedValue);
-    if (email && allowEmailInvites) {
+    if (email) {
       out.push({
         id: 'invite-by-email',
         result: email.address,

--- a/src/components/team-users/add-team-user.js
+++ b/src/components/team-users/add-team-user.js
@@ -59,17 +59,11 @@ function useCheckedDomains(query) {
   const [checkedDomains, setCheckedDomains] = useState({ 'gmail.com': false, 'yahoo.com': false });
   useEffect(() => {
     const domain = getDomain(query);
-    if (!domain || domain in checkedDomains) return undefined;
+    if (!domain || domain in checkedDomains) return;
 
-    let isCurrentRequest = true;
     axios.get(`https://freemail.glitch.me/${domain}`).then(({ data }) => {
-      if (!isCurrentRequest) return;
       setCheckedDomains((domains) => ({ ...domains, [domain]: !data.free }));
     }, captureException);
-
-    return () => {
-      isCurrentRequest = false;
-    };
   }, [query, checkedDomains]);
   return checkedDomains;
 }
@@ -125,7 +119,7 @@ function AddTeamUserPop({ members, inviteEmail, inviteUser, setWhitelistedDomain
     );
 
     return out;
-  }, [debouncedValue, retrievedUsers, members, whitelistedDomain]);
+  }, [debouncedValue, retrievedUsers, members, whitelistedDomain, checkedDomains]);
 
   return (
     <PopoverDialog align="left">

--- a/src/state/dev-toggles.js
+++ b/src/state/dev-toggles.js
@@ -12,10 +12,6 @@ import useUserPref from './user-prefs';
 // Users can enable them with the /secret page.
 const toggleData = [
   {
-    name: 'Email Invites',
-    description: 'Enables invite-by-email behavior on the team page.',
-  },
-  {
     name: 'Slack Auth',
     description: 'Sign in with your Slack account!',
   },


### PR DESCRIPTION
## Links
https://fallacious-slice.glitch.me
https://github.com/FogCreek/Glitch-Community-Work/issues/381

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/64281944-4978c500-cf22-11e9-8bfb-93a76b539913.png)

## Changes:
- Removed the email invites dev toggle
- Fixed a proptypes error with the invite by email button
- Some changes to useCheckedDomains to prevent duplicate requests
- Added a missing param to the memo so it consistently shows the whitelist option

## How To Test:
Try inviting yourself to a team via email