### PR TITLE
repeated-snapper: add Norton SafeWeb verification

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -25,6 +25,9 @@
     <meta name="twitter:image" content="<%= image %>">
     <meta name="twitter:url" content="<%= canonicalUrl %>">
     
+    <!-- norton safeweb verification, can be removed once verification is complete -->
+    <meta name="norton-safeweb-site-verification" content="p2ou8wp-rqphby6friirgu674v4mdl63bldktot1arf8x-02sknirce1ybskl3oca6c6845btybnr4r8pmf841sqg5yeyl759tq0br2n3f3dcxrv7f48bn0pnqopptmw" />
+    
     <link rel="stylesheet" href="https://cloud.webtype.com/css/3a8e55c6-b1f3-4659-99eb-125ae72bd084.css">
     <% for (let i = 0; i < styles.length; ++i) { %>
     <link rel="stylesheet" type="text/css" href="<%= styles[i] %>">


### PR DESCRIPTION
## Links
* [repeated-snapper.glitch.me](https://repeated-snapper.glitch.me/)
* [#415](https://github.com/FogCreek/Glitch-Community-Work/issues/415)

## Changes:
Adds a `<meta>` tag for Norton SafeWeb verification. We can remove it once verification is complete.

## How To Test:
This meta tag should be in the head:

```
<meta name="norton-safeweb-site-verification" content="p2ou8wp-rqphby6friirgu674v4mdl63bldktot1arf8x-02sknirce1ybskl3oca6c6845btybnr4r8pmf841sqg5yeyl759tq0br2n3f3dcxrv7f48bn0pnqopptmw" />
```

