### PR TITLE
Search results styling

### DIFF
--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -26,7 +26,7 @@ const FilterContainer = ({ filters, activeFilter, setFilter }) => {
     ),
   }));
 
-  return <SegmentedButton value={activeFilter} options={buttons} onChange={setFilter} />;
+  return <SegmentedButton variant="secondary" value={activeFilter} options={buttons} onChange={setFilter} />;
 };
 
 const groups = [

--- a/src/components/search-results/search-results.styl
+++ b/src/components/search-results/search-results.styl
@@ -26,3 +26,6 @@
   margin-bottom: 2rem
   .resultsContainer
     align-items: end
+    
+span[data-module="Badge"]
+  margin-left: 5px


### PR DESCRIPTION
## Links
* https://historical-salesman.glitch.me
* https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/422

## GIF/Screenshots:
![Screen Shot 2019-09-11 at 10 57 17 AM](https://user-images.githubusercontent.com/3011231/64708661-f1424580-d482-11e9-8fdc-42cbc9a598fe.png)

## Changes:
* Updated styling on search results to better match previous (and not be so squished)

## How To Test:
* Search for a thing, specifically one with lots of results
