### PR TITLE
Nova chance: cta edit project button, fix anon user avatars

### DIFF
--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -19,7 +19,7 @@ import styles from './avatar.styl';
 // UserAvatar
 export const AvatarBase = ({ name, src, color, srcFallback, variant, type, tiny, hideTooltip, withinButton }) => {
   const className = classNames(styles.avatar, styles[type], { [styles.tiny]: tiny });
-  const contents = <Avatar src={src} defaultSrc={srcFallback} alt={name} backgroundcolor={color} variant={variant} className={className} />;
+  const contents = <Avatar src={src} defaultSrc={srcFallback} alt={name} style={{ backgroundColor: color }} variant={variant} className={className} />;
 
   if (!hideTooltip) {
     return <TooltipContainer tooltip={name} target={contents} type="action" align={['left']} fallback={withinButton} />;

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -19,7 +19,7 @@ import styles from './avatar.styl';
 // UserAvatar
 export const AvatarBase = ({ name, src, color, srcFallback, variant, type, tiny, hideTooltip, withinButton }) => {
   const className = classNames(styles.avatar, styles[type], { [styles.tiny]: tiny });
-  const style = { backgroundColor: color };
+  const style = color && { backgroundColor: color };
   const contents = <Avatar src={src} defaultSrc={srcFallback} alt={name} style={style} variant={variant} className={className} />;
 
   if (!hideTooltip) {

--- a/src/components/images/avatar.js
+++ b/src/components/images/avatar.js
@@ -19,7 +19,8 @@ import styles from './avatar.styl';
 // UserAvatar
 export const AvatarBase = ({ name, src, color, srcFallback, variant, type, tiny, hideTooltip, withinButton }) => {
   const className = classNames(styles.avatar, styles[type], { [styles.tiny]: tiny });
-  const contents = <Avatar src={src} defaultSrc={srcFallback} alt={name} style={{ backgroundColor: color }} variant={variant} className={className} />;
+  const style = { backgroundColor: color };
+  const contents = <Avatar src={src} defaultSrc={srcFallback} alt={name} style={style} variant={variant} className={className} />;
 
   if (!hideTooltip) {
     return <TooltipContainer tooltip={name} target={contents} type="action" align={['left']} fallback={withinButton} />;

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -21,6 +21,7 @@ export const EditButton = ({ name, isMember, size }) => (
     {isMember ? 'Edit Project' : 'View Source'}
   </Button>
 );
+
 EditButton.propTypes = {
   name: PropTypes.string.isRequired,
   isMember: PropTypes.bool,
@@ -35,6 +36,7 @@ export const RemixButton = ({ name, isMember }) => (
     {isMember ? 'Remix This' : 'Remix your own'} <Icon className={emoji} icon="microphone" />
   </Button>
 );
+
 RemixButton.propTypes = {
   name: PropTypes.string.isRequired,
   isMember: PropTypes.bool,

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -17,7 +17,7 @@ ShowButton.propTypes = {
 };
 
 export const EditButton = ({ name, isMember, size }) => (
-  <Button as="a" href={getEditorUrl(name)} size={size}>
+  <Button as="a" href={getEditorUrl(name)} size={size} variant={isMember ? 'cta' : undefined}>
     {isMember ? 'Edit Project' : 'View Source'}
   </Button>
 );


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me
- https://github.com/FogCreek/Glitch-Community-Work/issues/396
- https://github.com/FogCreek/Glitch-Community-Work/issues/418

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/64880587-8762a100-d626-11e9-93af-55a964f76a47.png)
![image](https://user-images.githubusercontent.com/8932174/64880549-731ea400-d626-11e9-87c2-312508743ea1.png)

## Changes:
- Use cta styling on edit project buttons if you are a member
- Properly apply the background color styling to avatars

## How To Test:
- Take a look at some project pages you are and are not a member of
- Look at some projects owned by anon users and verify their avatars show up

## Feedback I'm looking for:
Avatar background colors are not supported by the shared components library as a prop, should they be?