### PR TITLE
User Options Pop Button Wrap & Top Search Result Vertical Alignment

### DIFF
--- a/src/components/images/avatar.styl
+++ b/src/components/images/avatar.styl
@@ -10,7 +10,7 @@ img.avatar
   height: 32px
 img.tiny
   vertical-align: bottom
-  width: 16px
-  hx
-  min-width: 15px
-  margin-top: -2pxisplay: inline-block
+  width: 15px
+  height: 15px  
+  margin-top: -2px
+  display: inline-block

--- a/src/components/images/avatar.styl
+++ b/src/components/images/avatar.styl
@@ -11,5 +11,6 @@ img.avatar
 img.tiny
   vertical-align: bottom
   width: 16px
-  height: 16px
-  display: inline-block
+  hx
+  min-width: 15px
+  margin-top: -2pxisplay: inline-block

--- a/src/components/images/avatar.styl
+++ b/src/components/images/avatar.styl
@@ -1,5 +1,6 @@
 .team, .project
   &.tiny
+    margin-left: 2px
     border-radius: 3px
 .bookmark
   top: -25%

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -92,7 +92,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
   const ready = searchResults.status === 'ready';
   const noResults = ready && searchResults.totalHits === 0;
   const showTopResults = ready && searchResults.starterKit.length + searchResults.topResults.length > 0 && activeFilter === 'all';
-  const topResultsIncludesUser = showTopResults && values(mapValues(searchResults.topResults, result => result.type), 'user');
+  const topResultsIncludesProject = showTopResults && values(mapValues(searchResults.topResults, (result) => result.type), 'project');
 
   const filters = [
     { id: 'all', label: 'All' },
@@ -127,7 +127,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
           <Grid items={searchResults.starterKit} className={styles.starterKitResultsContainer}>
             {(result) => <StarterKitItem result={result} />}
           </Grid>
-          <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, topResultsIncludesUser && styles.includesUser)}>
+          <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, topResultsIncludesProject && styles.includesProject)}>
             {(result) => (
               <div className={classnames(styles.resultWrap, result.type === 'project' && styles.project)}>
                 <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -124,7 +124,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
           <Grid items={searchResults.starterKit} className={styles.starterKitResultsContainer}>
             {(result) => <StarterKitItem result={result} />}
           </Grid>
-          <Grid items={searchResults.topResults} className={styles.resultsContainer}>
+          <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, searchResults.topResults)}>
             {(result) => <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />}
           </Grid>
         </article>

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -129,7 +129,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
           </Grid>
           <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, topResultsIncludesUser && styles.includesUser)}>
             {(result) => (
-              <div className={classnames(styles.resultWrap, `${result.type}`)}>
+              <div className={classnames(styles.resultWrap, result.type === 'project' && styles.project)}>
                 <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />
               </div>
             )}

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -92,7 +92,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
   const ready = searchResults.status === 'ready';
   const noResults = ready && searchResults.totalHits === 0;
   const showTopResults = ready && searchResults.starterKit.length + searchResults.topResults.length > 0 && activeFilter === 'all';
-  const topResultsIncludesProject = showTopResults && values(mapValues(searchResults.topResults, (result) => result.type), 'project');
+  const topResultsIncludesProject = showTopResults && values(mapValues(searchResults.topResults, (result) => result.type)).includes('project');
 
   const filters = [
     { id: 'all', label: 'All' },

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { mapValues, values } from 'lodash';
 import { Badge, Button, Loader, SegmentedButton } from '@fogcreek/shared-components';
 
 import { createAPIHook } from 'State/api';
+
 
 import Heading from 'Components/text/heading';
 import UserItem from 'Components/user/user-item';
@@ -90,6 +92,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
   const ready = searchResults.status === 'ready';
   const noResults = ready && searchResults.totalHits === 0;
   const showTopResults = ready && searchResults.starterKit.length + searchResults.topResults.length > 0 && activeFilter === 'all';
+  const topResultsIncludesUser = showTopResults && values(mapValues(searchResults.topResults, result => result.type), 'user');
 
   const filters = [
     { id: 'all', label: 'All' },
@@ -124,8 +127,12 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
           <Grid items={searchResults.starterKit} className={styles.starterKitResultsContainer}>
             {(result) => <StarterKitItem result={result} />}
           </Grid>
-          <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, searchResults.topResults)}>
-            {(result) => <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />}
+          <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, topResultsIncludesUser && styles.includesUser)}>
+            {(result) => (
+              <div className={`resultWrap-${result.type}`}>
+                <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />
+              </div>
+            )}
           </Grid>
         </article>
       )}

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -129,7 +129,7 @@ function SearchResults({ query, searchResults, activeFilter, setActiveFilter }) 
           </Grid>
           <Grid items={searchResults.topResults} className={classnames(styles.resultsContainer, topResultsIncludesUser && styles.includesUser)}>
             {(result) => (
-              <div className={`resultWrap-${result.type}`}>
+              <div className={classnames(styles.resultWrap, `${result.type}`)}>
                 <ResultComponent result={result} projectsWithUserData={projectsWithUserData} />
               </div>
             )}

--- a/src/components/search-results/search-results.styl
+++ b/src/components/search-results/search-results.styl
@@ -26,9 +26,8 @@
   margin-bottom: 2rem
   .resultsContainer
     align-items: type
-    &.includesUser
+    &.includesProject
       .resultWrap
-        display: inline
         margin-top: 40px
         &.project
           margin-top: 0

--- a/src/components/search-results/search-results.styl
+++ b/src/components/search-results/search-results.styl
@@ -27,7 +27,11 @@
   .resultsContainer
     align-items: type
     &.includesUser
-      background: black
+      background: red
+      .resultsWrap
+        &:not(.user)
+          
+
     
 span[data-module="Badge"]
   margin-left: 5px

--- a/src/components/search-results/search-results.styl
+++ b/src/components/search-results/search-results.styl
@@ -25,7 +25,9 @@
   padding-bottom: 2rem
   margin-bottom: 2rem
   .resultsContainer
-    align-items: end
+    align-items: type
+    &.includesUser
+      background: black
     
 span[data-module="Badge"]
   margin-left: 5px

--- a/src/components/search-results/search-results.styl
+++ b/src/components/search-results/search-results.styl
@@ -27,11 +27,11 @@
   .resultsContainer
     align-items: type
     &.includesUser
-      background: red
-      .resultsWrap
-        &:not(.user)
-          
-
+      .resultWrap
+        display: inline
+        margin-top: 40px
+        &.project
+          margin-top: 0
     
 span[data-module="Badge"]
   margin-left: 5px

--- a/src/components/user-options-pop/styles.styl
+++ b/src/components/user-options-pop/styles.styl
@@ -28,9 +28,10 @@
 .checkbox
   margin-bottom: 10px
 .buttonWrap
+  width: min-content
   margin-bottom: 10px
   a
-    white-space: nowrap
+    display: flex
 a:hover
   text-decoration: none
   

--- a/src/components/user-options-pop/styles.styl
+++ b/src/components/user-options-pop/styles.styl
@@ -28,7 +28,7 @@
 .checkbox
   margin-bottom: 10px
 .buttonWrap
-  width: min-content
+  width: fit-content
   margin-bottom: 10px
   a
     display: flex


### PR DESCRIPTION
## Links
* Remix link: https://vaulted-mirror.glitch.me/search?q=space
* Issue-tracker link: 
https://github.com/FogCreek/Glitch-Community-Work/issues/351
https://github.com/FogCreek/Glitch-Community-Work/issues/399

## GIF/Screenshots:
Original on left, changes on right
![image](https://user-images.githubusercontent.com/519336/64880605-96e1ea00-d626-11e9-9424-0044bc1f75e0.png)

## Changes:
* Top search results that include projects will be vertically aligned to the top of the project-item-container
* Also changed the buttonWrap of the user-options-pop to account for long team names.

## How To Test:
* Search for terms that give multiple top results ("space", "react") - the items should be vertically aligned
* Search for terms that give top results that don't include a project - there shouldn't be any extra margins applied (e.g. "scientiffic")
* Check that long names wrap well in the user options pop

## Feedback I'm looking for:
Is there a better way to determine if the top results include a project? 
```
  const topResultsIncludesProject = showTopResults && values(mapValues(searchResults.topResults, (result) => result.type)).includes('project');
```