### PR TITLE
[WIP] Sun culotte: notifications page

### DIFF
--- a/src/presenters/pages/notifications.js
+++ b/src/presenters/pages/notifications.js
@@ -1,0 +1,376 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { useDispatch } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import dayjs from 'dayjs';
+import { IconButton, Button, SegmentedButton, Icon, Popover, Actions, Loader } from '@fogcreek/shared-components';
+import Layout from 'Components/layout';
+import { ProjectAvatar } from 'Components/images/avatar';
+import Link from 'Components/link';
+import { ProfileItem } from 'Components/profile-list';
+import TooltipContainer from 'Components/tooltips/tooltip-container';
+import { useCurrentUser } from 'State/current-user';
+import { actions, useNotifications } from 'State/remote-notifications';
+import { getDisplayName as getUserDisplayName, getUserLink } from 'Models/user';
+import { getProjectLink } from 'Models/project';
+import { getCollectionLink } from 'Models/collection';
+import { getTeamLink } from 'Models/team';
+
+// TODO: 'party' and 'handshake' icons
+
+// TODO: surely this already exists
+const ProjectAvatarLink = ({ project }) => (
+  <TooltipContainer
+    type="info"
+    tooltip={project.domain}
+    target={
+      <Link to={getProjectLink(project)} aria-label={project.domain}>
+        <ProjectAvatar project={project} />
+      </Link>
+    }
+  />
+);
+
+// notification items
+
+const ActionsPopoverContent = styled.div`
+  width: 250px; 
+  > section {
+    margin: 0;
+  }
+  ${Button} {
+    display: block;
+  }
+  ${Button} + ${Button} {
+    margin-top: var(--space-1);
+  }
+`;
+
+// TODO: handle "report abuse" page
+/* eslint-disable react/no-array-index-key */
+const ActionsPopover = ({ options: actionGroups, menuLabel }) => (
+  <Popover align="right" renderLabel={(buttonProps) => <IconButton icon="chevronDown" label={menuLabel} {...buttonProps} />}>
+    {({ onClose, focusedOnMount }) => (
+      <ActionsPopoverContent>
+        {actionGroups.map((group, groupIndex) => (
+          <Actions key={groupIndex}>
+            {group.map((action, actionIndex) => (
+              <Button
+                key={actionIndex}
+                variant="secondary"
+                size="tiny"
+                ref={groupIndex === 0 && actionIndex === 0 ? focusedOnMount : null}
+                onClick={() => {
+                  onClose();
+                  action.onClick();
+                }}
+              >
+                {action.label}
+              </Button>
+            ))}
+          </Actions>
+        ))}
+      </ActionsPopoverContent>
+    )}
+  </Popover>
+);
+
+const TimeAgoText = styled.span`
+  color: var(--colors-secondary);
+  font-size: var(--fontSizes-small);
+  margin-right: var(--space-1);
+`;
+const TimeAgo = ({ value }) => <TimeAgoText>{dayjs(value).fromNow()}</TimeAgoText>;
+
+const NotificationWrap = styled.div`
+  position: relative;
+  display: block;
+  border-radius: var(--rounded);
+  padding: var(--space-1);
+
+  ${({ status }) =>
+    status === 'unread' &&
+    css`
+      background-color: var(--colors-selected-background);
+      color: var(--colors-selected-text);
+    `}
+`;
+
+const BackgroundLink = styled(Link)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: flex-start;
+  & + & {
+    margin-top: var(--space-2);
+  }
+`;
+const AvatarRow = styled.span`
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  > * + * {
+    margin-left: var(--space-1);
+  }
+`;
+const NotificationMessage = styled.p`
+  margin: 0;
+  flex: 1 1 auto;
+`;
+
+const BigIcon = styled(Icon)`
+  font-size: var(--fontSizes-bigger);
+`;
+const BoldLink = styled(Link)`
+  font-weight: bold;
+  color: var(--colors-primary);
+`;
+
+const NotificationBase = ({ href, label, notification, icon, options, avatars, children }) => {
+  React.useEffect(() => {
+    // TODO: mark as read when ... what? mount? mouse over? on screen? focused?
+  }, []);
+
+  return (
+    <NotificationWrap status={notification.status}>
+      <BackgroundLink to={href} aria-label={label} />
+      <Row>
+        <AvatarRow>{avatars}</AvatarRow>
+        <TimeAgo value={notification.createdAt} />
+        <ActionsPopover options={options} menuLabel="Notification options" />
+      </Row>
+      <Row>
+        <NotificationMessage>{children}</NotificationMessage>
+        <BigIcon icon={icon} />
+      </Row>
+    </NotificationWrap>
+  );
+};
+
+const noop = () => {};
+
+const RemixNotification = ({ notification }) => {
+  const { remixUser, originalProject, remixProject } = notification;
+  const options = [
+    [
+      { label: `Mute notifications for ${originalProject.domain}`, onClick: noop },
+      { label: `Mute notifications from ${getUserDisplayName(remixUser)}`, onClick: noop },
+    ],
+    [{ label: 'Mute all remix notifications', onClick: noop }],
+    [{ label: 'Hide notification', onClick: noop }, { label: 'Report abuse', onClick: noop }],
+  ];
+
+  return (
+    <NotificationBase
+      href={getProjectLink(remixProject)}
+      label="visit remix"
+      notification={notification}
+      icon="microphone"
+      options={options}
+      avatars={
+        <>
+          <ProfileItem user={remixUser} />
+          <ProjectAvatarLink project={originalProject} />
+        </>
+      }
+    >
+      <BoldLink to={getUserLink(remixUser)}>{getUserDisplayName(remixUser)}</BoldLink> created a{' '}
+      <BoldLink to={getProjectLink(remixProject)}>remix</BoldLink> of{' '}
+      <BoldLink to={getProjectLink(originalProject)}>{originalProject.domain}</BoldLink>
+    </NotificationBase>
+  );
+};
+
+const CollectionNotification = ({ notification }) => {
+  const { project, collection, collectionUser, collectionTeam } = notification;
+  const options = [
+    [
+      { label: `Mute notifications for ${project.domain}`, onClick: noop },
+      { label: `Mute notifications from ${getUserDisplayName(collectionUser)}`, onClick: noop },
+    ],
+    [{ label: 'Mute all collection notifications', onClick: noop }],
+    [{ label: 'Hide notification', onClick: noop }, { label: 'Report abuse', onClick: noop }],
+  ];
+
+  const collectionPrefix = collectionTeam ? (
+    <>
+      <BoldLink to={getTeamLink(collectionTeam)}>{collectionTeam.name}</BoldLink> collection
+    </>
+  ) : (
+    'collection'
+  );
+
+  return (
+    <NotificationBase
+      href={getCollectionLink(collection)}
+      label="visit collection"
+      notification={notification}
+      icon="framedPicture"
+      options={options}
+      avatars={
+        <>
+          <ProfileItem user={collectionUser} />
+          {collectionTeam && <ProfileItem team={collectionTeam} />}
+          <ProjectAvatarLink project={project} />
+        </>
+      }
+    >
+      <BoldLink to={getUserLink(collectionUser)}>{getUserDisplayName(collectionUser)}</BoldLink> added{' '}
+      <BoldLink to={getProjectLink(project)}>{project.domain}</BoldLink> to the {collectionPrefix}{' '}
+      <BoldLink to={getCollectionLink(collection)}>{collection.name}</BoldLink>
+    </NotificationBase>
+  );
+};
+
+const ProjectUserNotification = ({ notification }) => {
+  const { project, user, team } = notification;
+  const options = [
+    [
+      { label: `Mute notifications for ${project.domain}`, onClick: noop },
+      { label: `Mute notifications from ${getUserDisplayName(user)}`, onClick: noop },
+    ],
+    [{ label: 'Mute all project member notifications', onClick: noop }],
+    [{ label: 'Hide notification', onClick: noop }, { label: 'Report abuse', onClick: noop }],
+  ];
+
+  const memberType = team ? 'team member' : 'member';
+
+  return (
+    <NotificationBase
+      href={getProjectLink(project)}
+      label="visit project"
+      notification={notification}
+      icon="handshake"
+      options={options}
+      avatars={
+        <>
+          <ProfileItem user={user} />
+          <ProjectAvatarLink project={project} />
+        </>
+      }
+    >
+      <BoldLink to={getUserLink(user)}>{getUserDisplayName(user)}</BoldLink> was added as a {memberType} to{' '}
+      <BoldLink to={getProjectLink(project)}>{project.domain}</BoldLink>
+    </NotificationBase>
+  );
+};
+
+const FeaturedProjectNotification = ({ notification }) => {
+  const { project } = notification;
+  const options = [[{ label: 'Hide notification', onClick: noop }, { label: 'Request to remove from featured projects', onClick: noop }]];
+
+  return (
+    <NotificationBase
+      href="/"
+      label="visit home page"
+      notification={notification}
+      icon="party"
+      options={options}
+      avatars={
+        <>
+          <ProjectAvatarLink project={project} />
+        </>
+      }
+    >
+      <BoldLink to={getProjectLink(project)}>{project.domain}</BoldLink> has been featured on the <BoldLink to="/">Glitch homepage</BoldLink>!
+    </NotificationBase>
+  );
+};
+
+const notificationForType = {
+  remixActivity: RemixNotification,
+  collectionActivity: CollectionNotification,
+  projectUserActivity: ProjectUserNotification,
+  featuredProjectActivity: FeaturedProjectNotification,
+};
+
+const filterOptions = [
+  { id: 'all', label: 'All' },
+  { id: 'remixActivity', label: 'Remixes' },
+  { id: 'collectionActivity', label: 'Collections' },
+  { id: 'projectUserActivity', label: 'Users' },
+];
+
+const PAGE_SIZE = 20;
+
+const NotificationList = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  > li {
+    padding: var(--space-1) 0;
+  }
+  > * + * {
+    border-top: 1px solid var(--colors-border);
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const PageTitle = styled.h2`
+  font-size: var(--fontSizes-bigger);
+  flex: 1 1 auto;
+`;
+
+const NotificationsPage = withRouter(({ history, activeFilter }) => {
+  const { status, notifications, nextPage } = useNotifications();
+  const [limit, setLimit] = React.useState(PAGE_SIZE);
+  const dispatch = useDispatch();
+
+  const setActiveFilter = (filter) => {
+    history.push(`/notifications?activeFilter=${filter}`);
+  };
+
+  const filteredNotifications = React.useMemo(() => {
+    const filtered = activeFilter === 'all' ? notifications : notifications.filter((n) => n.type === activeFilter);
+    return filtered.filter((n) => n.status !== 'hidden' && n.type in notificationForType).slice(0, limit);
+  }, [notifications, activeFilter]);
+
+  const hasMoreNotifications = !!nextPage || filteredNotifications.length > limit;
+
+  const requestNextPage = () => {
+    setLimit((prevLimit) => prevLimit + PAGE_SIZE);
+    if (notifications.length <= PAGE_SIZE) {
+      dispatch(actions.requestedMoreNotifications());
+    }
+  };
+
+  return (
+    <section>
+      <header>
+        <HeaderRow>
+          <PageTitle>Notifications</PageTitle>
+          <Button as={Link} size="small" variant="secondary" to="/settings#privacy-and-notifications">
+            Edit notification settings
+          </Button>
+        </HeaderRow>
+        <SegmentedButton variant="secondary" size="small" options={filterOptions} value={activeFilter} onChange={setActiveFilter} />
+      </header>
+
+      <NotificationList>
+        {filteredNotifications.map((n) => (
+          <li key={n.id}>{React.createElement(notificationForType[n.type], { notification: n })}</li>
+        ))}
+      </NotificationList>
+      {status === 'loading' && <Loader />}
+      {status === 'ready' && filteredNotifications.length === 0 && <p>No notifications</p>}
+      {status === 'ready' && hasMoreNotifications && <Button onClick={requestNextPage}>Load More</Button>}
+    </section>
+  );
+});
+
+const NotificationsPageContainer = ({ activeFilter }) => {
+  const { currentUser } = useCurrentUser();
+  return <Layout>{currentUser.login ? <NotificationsPage activeFilter={activeFilter} /> : <div />}</Layout>;
+};
+
+export default NotificationsPageContainer;

--- a/src/presenters/pages/notifications.js
+++ b/src/presenters/pages/notifications.js
@@ -16,8 +16,6 @@ import { getProjectLink } from 'Models/project';
 import { getCollectionLink } from 'Models/collection';
 import { getTeamLink } from 'Models/team';
 
-// TODO: 'party' and 'handshake' icons
-
 // TODO: surely this already exists
 const ProjectAvatarLink = ({ project }) => (
   <TooltipContainer

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -26,6 +26,7 @@ import SearchPage from './search';
 import SecretPage from './secret';
 import NewHomePage, { HomePreview as NewHomePagePreview } from './home-v2';
 import VSCodeAuth from './vscode-auth';
+import NotificationsPage from './notifications';
 
 const parse = (search, name) => {
   const params = new URLSearchParams(search);
@@ -174,6 +175,12 @@ const Router = () => {
         <Route path="/secret" exact render={({ location }) => <SecretPage key={location.key} />} />
 
         <Route path="/vscode-auth" exact render={({ location }) => <VSCodeAuth key={location.key} scheme={parse(location.search, 'scheme')} />} />
+
+        <Route
+          path="/notifications"
+          exact
+          render={({ location }) => <NotificationsPage activeFilter={parse(location.search, 'activeFilter') || 'all'} />}
+        />
 
         {EXTERNAL_ROUTES.map((route) => (
           <Route key={route} path={route} render={({ location }) => <ExternalPageReloader key={location.key} />} />

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -287,8 +287,7 @@ export const useSuperUserHelpers = () => {
       window.scrollTo(0, 0);
       window.location.reload();
     },
-    canBecomeSuperUser:
-      cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
+    canBecomeSuperUser: cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
     superUserFeature,
   };
 };

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -287,7 +287,8 @@ export const useSuperUserHelpers = () => {
       window.scrollTo(0, 0);
       window.location.reload();
     },
-    canBecomeSuperUser: cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
+    canBecomeSuperUser: 
+      cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
     superUserFeature,
   };
 };

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -287,7 +287,7 @@ export const useSuperUserHelpers = () => {
       window.scrollTo(0, 0);
       window.location.reload();
     },
-    canBecomeSuperUser: 
+    canBecomeSuperUser:
       cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
     superUserFeature,
   };

--- a/src/state/remote-notifications.js
+++ b/src/state/remote-notifications.js
@@ -1,0 +1,229 @@
+import { createSlice } from 'redux-starter-kit';
+import { useSelector } from 'react-redux';
+import { sumBy } from 'lodash';
+
+import { appMounted } from './app-mounted';
+
+export const { reducer, actions } = createSlice({
+  slice: 'remoteNotifications',
+  initialState: {
+    status: 'init',
+    notifications: [],
+    nextPage: null,
+  },
+  reducers: {
+    requestedMoreNotifications: (state) => ({ ...state, status: 'loading' }),
+    loadedNotificationsFromAPI: (state, { payload: { notifications, nextPage } }) => ({ status: 'ready', notifications, nextPage }),
+    loadedMoreNotificationsFromAPI: (state, { payload: { notifications, nextPage } }) => ({
+      status: 'ready',
+      notifications: state.notifications.concat(notifications),
+      nextPage,
+    }),
+    loadedNewNotificationFromSocket: (state, { payload }) => {
+      state.notifications.unshift(payload);
+    },
+    updatedNotificationStatus: (state, { payload: { id, status } }) => {
+      state.notifications.find((n) => n.id === id).status = status;
+    },
+  },
+  extraReducers: {
+    [appMounted]: (state) => ({ ...state, status: 'loading' }),
+  },
+});
+
+const testProject = [
+  {
+    id: 'd1a4bc11-b58e-4b22-b6b5-4d5aa603b89b',
+    description: 'A genteel project that does magical things',
+    domain: 'dudertown',
+    baseId: null,
+    likesCount: 0,
+    suspendedReason: null,
+    avatarUpdatedAt: '2016-11-15T02:11:57.819Z',
+    showAsGlitchTeam: false,
+    isEmbedOnly: false,
+    remixChain: [],
+    notSafeForKids: false,
+    createdAt: '2015-08-24T20:18:17.078Z',
+    updatedAt: '2017-09-06T09:06:28.143Z',
+    permissions: [],
+    features: [],
+    teamIds: [],
+  },
+  {
+    id: 'c4edf527-1b20-4c4f-b3e1-101707203543',
+    description: 'hackathon hackup of a coffeetime remake',
+    domain: 'espresso-time',
+    baseId: null,
+    likesCount: 0,
+    suspendedReason: null,
+    avatarUpdatedAt: '2017-02-20T20:10:56.582Z',
+    showAsGlitchTeam: false,
+    isEmbedOnly: false,
+    remixChain: [],
+    notSafeForKids: false,
+    createdAt: '2015-10-17T18:32:34.196Z',
+    updatedAt: '2018-10-09T18:19:36.712Z',
+    permissions: [
+      {
+        userId: 8,
+        accessLevel: 30,
+      },
+    ],
+    features: [],
+    teamIds: [],
+  },
+];
+
+const testUser = [
+  {
+    isSupport: false,
+    isInfrastructureUser: false,
+    id: 1,
+    avatarUrl: 'https://s3.amazonaws.com/production-assetsbucket-8ljvyr1xczmb/user-avatar/62ebcfbd-8af0-4ba5-b7ff-7fa9216b3071-large.png',
+    avatarThumbnailUrl: 'https://s3.amazonaws.com/production-assetsbucket-8ljvyr1xczmb/user-avatar/62ebcfbd-8af0-4ba5-b7ff-7fa9216b3071-small.png',
+    login: 'STRd6',
+    name: 'Daniel X Moore',
+    location: 'Ferndale, WA',
+    color: '#fffdb2',
+    description: "I'm one of the creators of Glitch.com",
+    hasCoverImage: true,
+    coverColor: 'rgb(244,196,148)',
+    thanksCount: 12,
+    utcOffset: -420,
+    featuredProjectId: null,
+    createdAt: '2015-09-01T19:51:25.556Z',
+    updatedAt: '2019-04-28T13:28:41.239Z',
+    features: [
+      {
+        id: 785,
+        name: 'custom_domains',
+        data: null,
+        expiresAt: '2118-10-27T15:13:46.985Z',
+      },
+    ],
+  },
+  {
+    isSupport: false,
+    isInfrastructureUser: false,
+    id: 2,
+    avatarUrl: 'https://s3.amazonaws.com/production-assetsbucket-8ljvyr1xczmb/user-avatar/2ea4260e-b6aa-4b23-b867-503fdcdf175d-large.png',
+    avatarThumbnailUrl: 'https://s3.amazonaws.com/production-assetsbucket-8ljvyr1xczmb/user-avatar/2ea4260e-b6aa-4b23-b867-503fdcdf175d-small.png',
+    login: 'pirijan',
+    name: 'Pirijan',
+    location: 'New York',
+    color: '#f2c48c',
+    description:
+      'I make the interface of Glitch. Here are some [tweets](https://twitter.com/pketh), some [words](http://pketh.org), and some [feels](http://frogfeels.com). (cover by [mushbuh](https://twitter.com/mushbuh/status/940675887116173312))',
+    hasCoverImage: true,
+    coverColor: 'rgb(4,4,4)',
+    thanksCount: 21,
+    utcOffset: -240,
+    featuredProjectId: null,
+    createdAt: '2015-09-03T15:57:07.536Z',
+    updatedAt: '2019-08-12T16:52:03.610Z',
+    features: [
+      {
+        id: 712,
+        name: 'custom_domains',
+        data: null,
+        expiresAt: '2118-10-27T15:13:46.985Z',
+      },
+    ],
+  },
+];
+
+const testCollection = [
+  {
+    fullUrl: 'pirijan/fancy-knave',
+    id: 64,
+    name: 'fancy-knave',
+    url: 'fancy-knave',
+    coverColor: '#6c68dd',
+    description: 'A collection of projects that does fancy things',
+    avatarUrl: 'https://cdn.gomix.com/2bdfb3f8-05ef-4035-a06e-2043962a3a13%2Flogo-sunset.svg?1489265199230',
+    avatarThumbnailUrl: null,
+    userId: 2,
+    teamId: -1,
+    featuredProjectId: null,
+    createdAt: '2018-10-16T19:01:52.399Z',
+    updatedAt: '2019-07-12T23:03:50.050Z',
+    isMyStuff: false,
+    team: null,
+    user: {
+      isSupport: false,
+      isInfrastructureUser: false,
+      id: 2,
+      login: 'pirijan',
+    },
+  },
+  {
+    fullUrl: 'scientiffic/microbit',
+    id: 1464,
+    name: 'Microbit',
+    url: 'microbit',
+    coverColor: '#7FFFBF',
+    description: 'Playing around with Microbit hardware',
+    avatarUrl: 'https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fcollection-avatar.svg?1539891965867',
+    avatarThumbnailUrl: null,
+    userId: 867163,
+    teamId: -1,
+    featuredProjectId: '6fa6cef2-3e6a-4764-9efc-10452b84af4d',
+    createdAt: '2018-10-23T17:40:32.428Z',
+    updatedAt: '2019-09-17T17:27:11.560Z',
+    isMyStuff: false,
+    team: null,
+    user: {
+      isSupport: false,
+      isInfrastructureUser: false,
+      id: 867163,
+      login: 'scientiffic',
+    },
+  },
+];
+
+const testNotifications = [
+  {
+    id: 1,
+    createdAt: new Date('2019-09-17').toString(),
+    status: 'unread',
+    type: 'remixActivity',
+    originalProject: testProject[0],
+    remixUser: testUser[0],
+    remixProject: testProject[1],
+  },
+  {
+    id: 2,
+    createdAt: new Date('2019-09-01').toString(),
+    status: 'read',
+    type: 'collectionActivity',
+    project: testProject[0],
+    collection: testCollection[0],
+    collectionUser: testUser[0],
+  },
+  {
+    id: 3,
+    createdAt: new Date('2019-08-01').toString(),
+    status: 'read',
+    type: 'projectUserActivity',
+    project: testProject[0],
+    user: testUser[0],
+  },
+  {
+    id: 4,
+    createdAt: new Date('2018-08-01').toString(),
+    status: 'read',
+    type: 'featuredProjectActivity',
+    project: testProject[0],
+  },
+];
+
+export const handlers = {
+  [appMounted]: (action, store) => {
+    store.dispatch(actions.loadedNotificationsFromAPI({ notifications: testNotifications, nextPage: null }));
+  },
+};
+
+export const useNotifications = () => useSelector((state) => state.remoteNotifications);
+
+export const useUnreadNotificationsCount = () => useSelector((state) => sumBy(state.remoteNotifications.notifications, (n) => n.status === 'unread'));

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -5,12 +5,15 @@ import { isBrowser } from 'Utils/constants';
 import createHandlerMiddleware from './handler-middleware';
 import * as currentUser from './current-user';
 
+import * as remoteNotifications from './remote-notifications';
+
 const createStore = () =>
   configureStore({
     reducer: {
       currentUser: currentUser.reducer,
+      remoteNotifications: remoteNotifications.reducer,
     },
-    middleware: [...getDefaultMiddleware(), createHandlerMiddleware(currentUser.handlers)],
+    middleware: [...getDefaultMiddleware(), createHandlerMiddleware(currentUser.handlers, remoteNotifications.handlers)],
     devTools: isBrowser && window.ENVIRONMENT === 'dev',
   });
 


### PR DESCRIPTION
## Links
* Remix link: https://sun-culotte.glitch.me/notifications
* Specs/doc links: https://docs.google.com/document/d/1yHd6Jt86UmdiDttkdPclvjnYi16B8-fTZnEgQgCW9vM/edit#

## GIF/Screenshots
![Screen Shot 2019-09-17 at 6 02 09 PM](https://user-images.githubusercontent.com/938722/65082975-4c89a180-d975-11e9-9d3f-7ea68a29115a.png)

## Changes
* created notifications page
* created remoteNotifications state

## How To Test
* log into https://sun-culotte.glitch.me/
* visit https://sun-culotte.glitch.me/notifications
* you should be able to filter notifications by type
* clicking on the bold words or avatars should link to the respective user, team etc
* clicking anywhere else in the notification should go to the most relevant resource for the notification
* TODO: none of the popover buttons do anything yet

## Feedback I'm looking for
A couple of a11y concerns/questions:

* does it make sense to make the whole thing a link? the buttons-on-buttons thing is a little difficult to navigate via mouse, and seems highly redundant via keyboard
* would it make sense to hide the avatar links from screen readers & tab order? they're visually useful, but redundant from an information hierarchy perspective
* what's an appropriate event to trigger a notification being marked as "read"? for sighted users, the expectation would be that they're marked as "read" when they're visible on screen; does that make sense from a screen reader perspective?

## Things left to do before deploying
- [x] add party hat & handshake emoji to shared components
- [x] extract current user changes into own PR
- [ ] implement 'report abuse' in popover
- [ ] implement muting actions (depends on #914)
- [ ] implement marking as read
- [ ] roll ups? I might save that for a subsequent PR
