### PR TITLE
Add trailing comma: Fix lint failures

### DIFF
--- a/src/curated/starter-kits.js
+++ b/src/curated/starter-kits.js
@@ -34,5 +34,5 @@ export default [
     url: 'https://glitch.com/~starter-discord/',
     description: 'Want to make a Discord Bot on Glitch? Our starter will walk you through the steps with our interactive install guide.',
     coverColor: '#F6AE78',
-  }
+  },
 ];


### PR DESCRIPTION
## Summary:
A missing comma was causing linting to fail on master

## Changes:
* Adds a trailing comma to `starter-kits.js`

## How To Test:
* Tests should pass on CircleCI
