### PR TITLE
Shocking panther: replace support link with help center link

### DIFF
--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -143,7 +143,7 @@ Are you sure you want to sign out?`)
         </div>
         <div className={styles.buttonWrap}>
           <Button as="a" variant="secondary" size="small" href="https://glitch.com/help/">
-            Help Center&nbsp;<Icon icon="ambulance" />
+            Help Center <Icon className={emoji} icon="ambulance" />
           </Button>
         </div>
         {userPasswordEnabled && (

--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -142,8 +142,8 @@ Are you sure you want to sign out?`)
           </Button>
         </div>
         <div className={styles.buttonWrap}>
-          <Button as="a" variant="secondary" size="small" href="https://support.glitch.com">
-            Support <Icon className={emoji} icon="ambulance" />
+          <Button as="a" variant="secondary" size="small" href="https://glitch.com/help/">
+            Help Center&nbsp;<Icon icon="ambulance" />
           </Button>
         </div>
         {userPasswordEnabled && (


### PR DESCRIPTION
## Links
* Remix link: https://shocking-panther.glitch.me/
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/412

## GIF/Screenshots:
![Screen Shot 2019-09-24 at 11 31 57 AM](https://user-images.githubusercontent.com/938722/65526494-2e64f980-debf-11e9-8fb4-bfb42ff96b4c.png)

## Changes:
* replace support link with help center link in user menu

## How To Test:
* log into https://shocking-panther.glitch.me/
* click on the user menu
* the second-to-last option should be "Help Center" and go to glitch.com/help