### PR TITLE
Fast bottom: redirect `/~:domain/edit` to editor, `/~:domain/console` to console

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -187,7 +187,7 @@ module.exports = function(external) {
   
   app.get('/~:domain/console', async (req, res) => {
     const { domain } = req.params;
-    const consoleUrl = `${APP_URL}/console.html?${domain}`;
+    const consoleUrl = `${APP_URL}/edit/console.html?${domain}`;
 
     res.redirect(consoleUrl);
   });

--- a/server/routes.js
+++ b/server/routes.js
@@ -178,6 +178,13 @@ module.exports = function(external) {
     await render(req, res, { title: domain, canonicalUrl, description, image: avatar, cache }, true);
   });
 
+  app.get('/~:domain/edit', async (req, res) => {
+    const { domain } = req.params;
+    const editorUrl = `${APP_URL}/edit/#!/${domain}`;
+    
+    res.redirect(editorUrl);
+  });
+  
   app.get('/@:name', async (req, res) => {
     const { name } = req.params;
     const canonicalUrl = `${APP_URL}/@${name}`;

--- a/server/routes.js
+++ b/server/routes.js
@@ -181,7 +181,7 @@ module.exports = function(external) {
   app.get('/~:domain/edit', async (req, res) => {
     const { domain } = req.params;
     const editorUrl = `${APP_URL}/edit/#!/${domain}`;
-    
+
     res.redirect(editorUrl);
   });
   

--- a/server/routes.js
+++ b/server/routes.js
@@ -185,6 +185,13 @@ module.exports = function(external) {
     res.redirect(editorUrl);
   });
   
+  app.get('/~:domain/console', async (req, res) => {
+    const { domain } = req.params;
+    const consoleUrl = `${APP_URL}/console.html?${domain}`;
+
+    res.redirect(consoleUrl);
+  });
+  
   app.get('/@:name', async (req, res) => {
     const { name } = req.params;
     const canonicalUrl = `${APP_URL}/@${name}`;

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -138,7 +138,7 @@ const Router = () => {
         <Route path="/~:name" exact render={({ location, match }) => <ProjectPage key={location.key} name={punycode.toASCII(match.params.name)} />} />
 
         <Route path="/~:name/edit" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
-        <Route path="/~:name/console" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
+        <Route path="/~:name/console" exact render={({ match }) => <Redirect to={`/edit/console.html?${match.params.name}`} />} />
 
         <Route path="/@:name" exact render={({ location, match }) => <TeamOrUserPage key={location.key} name={match.params.name} />} />
 

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Route, Switch, Redirect, withRouter } from 'react-router-dom';
+import { Route, Switch, withRouter } from 'react-router-dom';
 import punycode from 'punycode';
 
 import categories from 'Curated/categories';
@@ -136,9 +136,6 @@ const Router = () => {
         <Route path="/questions" exact render={({ location }) => <QuestionsPage key={location.key} />} />
 
         <Route path="/~:name" exact render={({ location, match }) => <ProjectPage key={location.key} name={punycode.toASCII(match.params.name)} />} />
-
-        <Route path="/~:name/edit" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
-        <Route path="/~:name/console" exact render={({ match }) => <Redirect to={`/edit/console.html?${match.params.name}`} />} />
 
         <Route path="/@:name" exact render={({ location, match }) => <TeamOrUserPage key={location.key} name={match.params.name} />} />
 

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Route, Switch, withRouter } from 'react-router-dom';
+import { Route, Switch, Redirect, withRouter } from 'react-router-dom';
 import punycode from 'punycode';
 
 import categories from 'Curated/categories';
@@ -136,6 +136,8 @@ const Router = () => {
         <Route path="/questions" exact render={({ location }) => <QuestionsPage key={location.key} />} />
 
         <Route path="/~:name" exact render={({ location, match }) => <ProjectPage key={location.key} name={punycode.toASCII(match.params.name)} />} />
+        
+        <Route path="/~:name/edit" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
 
         <Route path="/@:name" exact render={({ location, match }) => <TeamOrUserPage key={location.key} name={match.params.name} />} />
 

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -138,6 +138,7 @@ const Router = () => {
         <Route path="/~:name" exact render={({ location, match }) => <ProjectPage key={location.key} name={punycode.toASCII(match.params.name)} />} />
 
         <Route path="/~:name/edit" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
+        <Route path="/~:name/console" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
 
         <Route path="/@:name" exact render={({ location, match }) => <TeamOrUserPage key={location.key} name={match.params.name} />} />
 

--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -136,7 +136,7 @@ const Router = () => {
         <Route path="/questions" exact render={({ location }) => <QuestionsPage key={location.key} />} />
 
         <Route path="/~:name" exact render={({ location, match }) => <ProjectPage key={location.key} name={punycode.toASCII(match.params.name)} />} />
-        
+
         <Route path="/~:name/edit" exact render={({ match }) => <Redirect to={`/edit/#!/${match.params.name}`} />} />
 
         <Route path="/@:name" exact render={({ location, match }) => <TeamOrUserPage key={location.key} name={match.params.name} />} />


### PR DESCRIPTION
## Links
* Remix link: https://fast-bottom.glitch.me
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/451

## Changes:
* added server-side and client-side redirects for redirecting `/~:domain/edit` url to `/edit/#!/:domain`
* added redirects for `/~:domain/console` to `/edit/console.html?:domain`

## How To Test:
* visit https://fast-bottom.glitch.me/~community/edit
* it should redirect you to https://fast-bottom.glitch.me/edit/#!/community (which will show the message "Sorry, no editor for remixes!")
* visit https://fast-bottom.glitch.me/~community/console
* it should redirect you to https://fast-bottom.glitch.me/edit/console.html?community (which will also not load, but the URL is correct)

## Feedback I'm looking for:
- do we actually need the client-side part? The `~project/edit` link is really more for hand-typed convenience; we can continue to use the proper links internally
