### PR TITLE
Romantic broom: fixed ratio containers for large videos on create page

### DIFF
--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import classNames from 'classnames/bind';
+import styled from 'styled-components';
 import { Button, Icon, Loader, Mark } from '@fogcreek/shared-components';
 
 import Image from 'Components/images/image';
@@ -26,6 +27,22 @@ import useSample from 'Hooks/use-sample';
 
 import styles from './create.styl';
 import { emoji as emojiStyle } from '../../components/global.styl';
+
+const RatioWrap = styled.div`
+  width: 100%;
+  height: 0;
+  padding-bottom: ${({ aspectRatio = 16 / 9 }) => aspectRatio * 100}%;
+  position: relative;
+`;
+const RatioInner = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+const RatioContainer = ({ children }) => <RatioWrap><RatioInner>{children}</RatioInner></RatioWrap>
+
 
 function RemixButton({ app, type, size, emoji, children }) {
   const trackRemix = useTracker('Click Remix', {
@@ -86,7 +103,9 @@ function WhatIsGlitch() {
         </div>
       </div>
       <div className={styles.whatIsGlitchVideoContainer}>
-        <WistiaVideo onClick={trackPlayVideo} className={styles.whatIsGlitchVideo} videoId="2vcr60pnx9" />
+        <RatioContainer>
+          <WistiaVideo onClick={trackPlayVideo} className={styles.whatIsGlitchVideo} videoId="2vcr60pnx9" />
+        </RatioContainer>
       </div>
     </section>
   );
@@ -165,7 +184,9 @@ function PlatformStarterItem(team) {
       </div>
       <div>
         <div className={styles.platformLink}>
-          <Button as="a" href={getTeamLink(team)}>{team.name}</Button>
+          <Button as="a" href={getTeamLink(team)}>
+            {team.name}
+          </Button>
         </div>
         <Text size="14px">
           <Markdown renderAsPlaintext>{team.description}</Markdown>
@@ -273,18 +294,21 @@ function ScreencapSection({ title, description, video, smallVideos, blob, image,
   const Videos = () => (
     <div className={styles.screencapContainer}>
       {smallVideos.map((v) => (
-        <Video
-          sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
-          key={v}
-          className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
-          track="muted"
-          autoPlay
-          loop
-        />
+        <RatioContainer key={v}>
+          <Video
+            sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
+            className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
+            track="muted"
+            autoPlay
+            loop
+          />
+        </RatioContainer>
       ))}
 
       <div className={classNames(styles.screencap, styles.bigScreencap)}>
-        <Video track="muted" autoPlay loop sources={[{ src: video, minWidth: 670 }]} />
+        <RatioContainer>
+          <Video track="muted" autoPlay loop sources={[{ src: video, minWidth: 670 }]} />
+        </RatioContainer>
       </div>
 
       <div className={classNames(styles.screencapBlob, styles.blobContainer)}>
@@ -393,36 +417,37 @@ function VSCode() {
       </Text>
 
       <Text className={styles.sectionDescription}>
-        <Button
-          as="a"
-          href="https://marketplace.visualstudio.com/items?itemName=glitch.glitch"
-        >
+        <Button as="a" href="https://marketplace.visualstudio.com/items?itemName=glitch.glitch">
           <Image src={vscodeIcon} alt="" width="17" height="17" />
           &nbsp;Download from Visual Studio Marketplace <span aria-hidden="true">&rarr;</span>
         </Button>
       </Text>
 
       <div className={styles.screencapContainer}>
-        <Video
-          className={classNames(styles.screencap, styles.smallScreencap)}
-          sources={[
-            {
-              src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode-small.mp4?v=1562184049096`,
-              minWidth: 0,
-              maxWidth: 669,
-            },
-          ]}
-          track="muted"
-          autoPlay
-          loop
-        />
-        <div className={classNames(styles.screencap, styles.bigScreencap)}>
+        <RatioContainer>
           <Video
-            sources={[{ src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode.mp4?v=1562182730854`, minWidth: 670 }]}
+            className={classNames(styles.screencap, styles.smallScreencap)}
+            sources={[
+              {
+                src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode-small.mp4?v=1562184049096`,
+                minWidth: 0,
+                maxWidth: 669,
+              },
+            ]}
             track="muted"
             autoPlay
             loop
           />
+        </RatioContainer>
+        <div className={classNames(styles.screencap, styles.bigScreencap)}>
+          <RatioContainer>
+            <Video
+              sources={[{ src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode.mp4?v=1562182730854`, minWidth: 670 }]}
+              track="muted"
+              autoPlay
+              loop
+            />
+          </RatioContainer>
         </div>
       </div>
     </section>

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -290,17 +290,18 @@ function YourAppIsLive() {
 
 function ScreencapSection({ title, description, video, smallVideos, blob, image, imageName, markColor }) {
   const Videos = () => (
+    <RatioContainer key={v}>
     <div className={styles.screencapContainer}>
       {smallVideos.map((v) => (
-        <RatioContainer key={v}>
+        
           <Video
+            
             sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
             className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
             track="muted"
             autoPlay
             loop
           />
-        </RatioContainer>
       ))}
 
       <div className={classNames(styles.screencap, styles.bigScreencap)}>

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -31,7 +31,7 @@ import { emoji as emojiStyle } from '../../components/global.styl';
 const RatioWrap = styled.div`
   width: 100%;
   height: 0;
-  padding-bottom: ${({ aspectRatio = 9 / 16 }) => aspectRatio * 100}%;
+  padding-bottom: ${({ aspectRatio = 617 / 1020 }) => aspectRatio * 100}%;
   position: relative;
 `;
 const RatioInner = styled.div`
@@ -41,8 +41,8 @@ const RatioInner = styled.div`
   width: 100%;
   height: 100%;
 `;
-const RatioContainer = ({ children }) => (
-  <RatioWrap>
+const RatioContainer = ({ children, ...props }) => (
+  <RatioWrap {...props}>
     <RatioInner>{children}</RatioInner>
   </RatioWrap>
 );

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -185,9 +185,7 @@ function PlatformStarterItem(team) {
       </div>
       <div>
         <div className={styles.platformLink}>
-          <Button as="a" href={getTeamLink(team)}>
-            {team.name}
-          </Button>
+          <Button as="a" href={getTeamLink(team)}>{team.name}</Button>
         </div>
         <Text size="14px">
           <Markdown renderAsPlaintext>{team.description}</Markdown>
@@ -296,8 +294,8 @@ function ScreencapSection({ title, description, video, smallVideos, blob, image,
     <div className={styles.screencapContainer}>
       {smallVideos.map((v) => (
         <Video
-          key={v}
           sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
+          key={v}
           className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
           track="muted"
           autoPlay
@@ -417,7 +415,10 @@ function VSCode() {
       </Text>
 
       <Text className={styles.sectionDescription}>
-        <Button as="a" href="https://marketplace.visualstudio.com/items?itemName=glitch.glitch">
+        <Button
+          as="a"
+          href="https://marketplace.visualstudio.com/items?itemName=glitch.glitch"
+        >
           <Image src={vscodeIcon} alt="" width="17" height="17" />
           &nbsp;Download from Visual Studio Marketplace <span aria-hidden="true">&rarr;</span>
         </Button>

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -31,7 +31,7 @@ import { emoji as emojiStyle } from '../../components/global.styl';
 const RatioWrap = styled.div`
   width: 100%;
   height: 0;
-  padding-bottom: ${({ aspectRatio = 16 / 9 }) => aspectRatio * 100}%;
+  padding-bottom: ${({ aspectRatio = 9/16 }) => aspectRatio * 100}%;
   position: relative;
 `;
 const RatioInner = styled.div`
@@ -103,9 +103,7 @@ function WhatIsGlitch() {
         </div>
       </div>
       <div className={styles.whatIsGlitchVideoContainer}>
-        <RatioContainer>
-          <WistiaVideo onClick={trackPlayVideo} className={styles.whatIsGlitchVideo} videoId="2vcr60pnx9" />
-        </RatioContainer>
+        <WistiaVideo onClick={trackPlayVideo} className={styles.whatIsGlitchVideo} videoId="2vcr60pnx9" />
       </div>
     </section>
   );

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -31,7 +31,7 @@ import { emoji as emojiStyle } from '../../components/global.styl';
 const RatioWrap = styled.div`
   width: 100%;
   height: 0;
-  padding-bottom: ${({ aspectRatio = 617 / 1020 }) => aspectRatio * 100}%;
+  padding-bottom: ${({ aspectRatio }) => aspectRatio * 100}%;
   position: relative;
 `;
 const RatioInner = styled.div`
@@ -306,7 +306,7 @@ function ScreencapSection({ title, description, video, smallVideos, blob, image,
       ))}
 
       <div className={classNames(styles.screencap, styles.bigScreencap)}>
-        <RatioContainer>
+        <RatioContainer aspectRatio={968 / 1600}>
           <Video track="muted" autoPlay loop sources={[{ src: video, minWidth: 670 }]} />
         </RatioContainer>
       </div>
@@ -438,7 +438,7 @@ function VSCode() {
           loop
         />
         <div className={classNames(styles.screencap, styles.bigScreencap)}>
-          <RatioContainer>
+          <RatioContainer aspectRatio={968 / 1600}>
             <Video
               sources={[{ src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode.mp4?v=1562182730854`, minWidth: 670 }]}
               track="muted"

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -290,12 +290,10 @@ function YourAppIsLive() {
 
 function ScreencapSection({ title, description, video, smallVideos, blob, image, imageName, markColor }) {
   const Videos = () => (
-    <RatioContainer key={v}>
     <div className={styles.screencapContainer}>
       {smallVideos.map((v) => (
-        
           <Video
-            
+            key={v}
             sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
             className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
             track="muted"
@@ -423,7 +421,6 @@ function VSCode() {
       </Text>
 
       <div className={styles.screencapContainer}>
-        <RatioContainer>
           <Video
             className={classNames(styles.screencap, styles.smallScreencap)}
             sources={[
@@ -437,7 +434,6 @@ function VSCode() {
             autoPlay
             loop
           />
-        </RatioContainer>
         <div className={classNames(styles.screencap, styles.bigScreencap)}>
           <RatioContainer>
             <Video

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -31,7 +31,7 @@ import { emoji as emojiStyle } from '../../components/global.styl';
 const RatioWrap = styled.div`
   width: 100%;
   height: 0;
-  padding-bottom: ${({ aspectRatio = 9/16 }) => aspectRatio * 100}%;
+  padding-bottom: ${({ aspectRatio = 9 / 16 }) => aspectRatio * 100}%;
   position: relative;
 `;
 const RatioInner = styled.div`
@@ -40,9 +40,12 @@ const RatioInner = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-`
-const RatioContainer = ({ children }) => <RatioWrap><RatioInner>{children}</RatioInner></RatioWrap>
-
+`;
+const RatioContainer = ({ children }) => (
+  <RatioWrap>
+    <RatioInner>{children}</RatioInner>
+  </RatioWrap>
+);
 
 function RemixButton({ app, type, size, emoji, children }) {
   const trackRemix = useTracker('Click Remix', {
@@ -292,14 +295,14 @@ function ScreencapSection({ title, description, video, smallVideos, blob, image,
   const Videos = () => (
     <div className={styles.screencapContainer}>
       {smallVideos.map((v) => (
-          <Video
-            key={v}
-            sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
-            className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
-            track="muted"
-            autoPlay
-            loop
-          />
+        <Video
+          key={v}
+          sources={[{ src: v, minWidth: 0, maxWidth: 669 }]}
+          className={classNames(styles.screencap, styles.smallScreencap, styles[`small${smallVideos.length}`])}
+          track="muted"
+          autoPlay
+          loop
+        />
       ))}
 
       <div className={classNames(styles.screencap, styles.bigScreencap)}>
@@ -421,19 +424,19 @@ function VSCode() {
       </Text>
 
       <div className={styles.screencapContainer}>
-          <Video
-            className={classNames(styles.screencap, styles.smallScreencap)}
-            sources={[
-              {
-                src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode-small.mp4?v=1562184049096`,
-                minWidth: 0,
-                maxWidth: 669,
-              },
-            ]}
-            track="muted"
-            autoPlay
-            loop
-          />
+        <Video
+          className={classNames(styles.screencap, styles.smallScreencap)}
+          sources={[
+            {
+              src: `${CDN_URL}/50f784d9-9995-4fa4-a185-b4b1ea6e77c0%2Fvscode-small.mp4?v=1562184049096`,
+              minWidth: 0,
+              maxWidth: 669,
+            },
+          ]}
+          track="muted"
+          autoPlay
+          loop
+        />
         <div className={classNames(styles.screencap, styles.bigScreencap)}>
           <RatioContainer>
             <Video


### PR DESCRIPTION
## Links
* Remix link: https://romantic-broom.glitch.me/
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/158

## Changes:
* wrapped large videos in a container that reserves space while video is loading, to prevent layout jumps

## How To Test:
* visit https://romantic-broom.glitch.me/create with network throttled to 'low-end mobile'
* there should be empty containers where the large videos go
* when the videos load, the layout should not jump around

## Feedback I'm looking for:
* should we do anything for smaller screens? it seems like those have fixed heights instead of aspect ratios