### PR TITLE
spectacular-coyote: fix onboarding banner logic on profile pages

### DIFF
--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -92,7 +92,6 @@ const UserPage = ({ user: initialUser }) => {
   const { currentUser: maybeCurrentUser } = useCurrentUser();
   const isSupport = maybeCurrentUser && maybeCurrentUser.isSupport;
   const isAuthorized = maybeCurrentUser && maybeCurrentUser.id === user.id;
-  console.log(maybeCurrentUser);
 
   const pinnedSet = new Set(user.pinnedProjects.map(({ id }) => id));
   // filter featuredProject out of both pinned & recent projects

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -128,7 +128,7 @@ const UserPage = ({ user: initialUser }) => {
           />
         </UserProfileContainer>
 
-        {isAuthorized && !maybeCurrentUser.projects.length && <OnboardingBanner />}
+        {isAuthorized && !user.projects.length && <OnboardingBanner />}
       </section>
 
       {featuredProject && (

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -128,7 +128,7 @@ const UserPage = ({ user: initialUser }) => {
           />
         </UserProfileContainer>
 
-        {isAuthorized && !recentProjects.length && <OnboardingBanner />}
+        {isAuthorized && !maybeCurrentUser.projects.length && <OnboardingBanner />}
       </section>
 
       {featuredProject && (

--- a/src/presenters/pages/user.js
+++ b/src/presenters/pages/user.js
@@ -92,6 +92,7 @@ const UserPage = ({ user: initialUser }) => {
   const { currentUser: maybeCurrentUser } = useCurrentUser();
   const isSupport = maybeCurrentUser && maybeCurrentUser.isSupport;
   const isAuthorized = maybeCurrentUser && maybeCurrentUser.id === user.id;
+  console.log(maybeCurrentUser);
 
   const pinnedSet = new Set(user.pinnedProjects.map(({ id }) => id));
   // filter featuredProject out of both pinned & recent projects


### PR DESCRIPTION
## Links
* [spectacular-coyote.glitch.me](https://spectacular-coyote.glitch.me/~cowards)
* [#473](https://github.com/FogCreek/Glitch-Community-Work/issues/473)

## GIF/Screenshots:
A user with one pinned project does not see the onboarding banner on their profile

![Screen Shot 2019-09-24 at 4 39 59 PM](https://user-images.githubusercontent.com/7584833/65548710-faeb9480-dee9-11e9-96c3-64373966f7ef.png)

## Changes:
Check if the *current user* has any projects, not if the profile we're visiting has any *recent projects*

## How To Test:
- Log in with an account that has one project
- Pin that project, refresh. You should not see the onboarding banner on your profile
- Delete that project, refresh. You *should* see the onboarding banner on your profile

## Feedback I'm looking for:
Work as expected?