### PR TITLE
Quixotic-rocket: Increased memory limit for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "prestart": "npm run watch:lint:server & \n if if-env DEPLOY_ENV=production; then \n npm run watch:babel & npm run watch:webpack & \n fi",
-    "start": "forever --minUptime 5000 --spinSleepTime 1000 --killSignal=SIGTERM -c 'nodemon --watch server --watch shared --watch views --exitcrash' ./server/server.js",
+    "start": "NODE_OPTIONS='--max-old-space-size=4096' forever --minUptime 5000 --spinSleepTime 1000 --killSignal=SIGTERM -c 'nodemon --watch server --watch shared --watch views --exitcrash' ./server/server.js",
     "lint:server": "eslint --config server/.eslintrc.server.js server shared webpack.config.js",
     "lint:src": "eslint --config src/.eslintrc.js src",
     "lint": "npm run lint:server && npm run lint:src",


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/
https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/479

## Changes:
Apply `--max-old-space-size=4096` to the server process. I'm setting it using an env var rather than in the nodemon command because nesting strings in the shell gets really messy and unreliable

## How To Test:
If the process doesn't run out of memory it is working?

## Feedback I'm looking for:
This increases memory for the main server in all cases, but it's probably only needed when we're running webpack in the same process.