### PR TITLE
Warm fossa: make internal button links use react-router

### DIFF
--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -9,7 +9,7 @@ import Image from 'Components/images/image';
 import Thanks from 'Components/thanks';
 import VerifiedBadge from 'Components/verified-badge';
 import ProfileList from 'Components/profile-list';
-import { WrappingLink } from 'Components/link';
+import { TeamLink, WrappingLink } from 'Components/link';
 import { getTeamLink, getTeamAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
 import { createAPIHook } from 'State/api';
 import { captureException } from 'Utils/sentry';
@@ -41,7 +41,7 @@ const TeamItem = ({ team }) => {
         </div>
         <div className={styles.body}>
           <div className={styles.itemButtonWrap}>
-            <Button as="a" href={getTeamLink(team)}>{team.name}</Button>
+            <Button as={TeamLink} team={team}>{team.name}</Button>
             {!!team.isVerified && <VerifiedBadge />}
           </div>
           <div className={styles.usersList}>

--- a/src/components/user-options-pop/index.js
+++ b/src/components/user-options-pop/index.js
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import { orderBy } from 'lodash';
 import { Button, CheckboxButton, Icon, UnstyledButton } from '@fogcreek/shared-components';
 
-import { getTeamLink } from 'Models/team';
 import { getUserAvatarThumbnailUrl } from 'Models/user';
 import Image from 'Components/images/image';
 import { UserAvatar, TeamAvatar } from 'Components/images/avatar';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
-import { UserLink } from 'Components/link';
+import { TeamLink, UserLink } from 'Components/link';
 import { MultiPopover, PopoverContainer, PopoverActions, PopoverInfo, PopoverDialog, PopoverTitle, InfoDescription } from 'Components/popover';
 import CreateTeamPop from 'Components/create-team-pop';
 import { useGlobals } from 'State/globals';
@@ -44,8 +43,8 @@ const TeamList = ({ teams, showCreateTeam }) => {
       {orderedTeams.map((team) => (
         <div className={styles.buttonWrap} key={team.id}>
           <Button
-            as="a"
-            href={getTeamLink(team)}
+            as={TeamLink}
+            team={team}
             size="small"
             variant="secondary"
           >

--- a/src/presenters/pages/create.js
+++ b/src/presenters/pages/create.js
@@ -8,7 +8,7 @@ import { TeamAvatar, ProjectAvatar } from 'Components/images/avatar';
 import Text from 'Components/text/text';
 import Markdown from 'Components/text/markdown';
 import Heading from 'Components/text/heading';
-import Link from 'Components/link';
+import Link, { TeamLink } from 'Components/link';
 import Embed from 'Components/project/embed';
 import Video from 'Components/video';
 import WistiaVideo from 'Components/wistia-video';
@@ -19,7 +19,6 @@ import CategoriesGrid from 'Components/categories-grid';
 import { useAPI } from 'State/api';
 import { useTracker } from 'State/segment-analytics';
 import { getRemixUrl } from 'Models/project';
-import { getTeamLink } from 'Models/team';
 import { emojiPattern } from 'Shared/regex';
 import { CDN_URL } from 'Utils/constants';
 import useSample from 'Hooks/use-sample';
@@ -165,7 +164,7 @@ function PlatformStarterItem(team) {
       </div>
       <div>
         <div className={styles.platformLink}>
-          <Button as="a" href={getTeamLink(team)}>{team.name}</Button>
+          <Button as={TeamLink} team={team}>{team.name}</Button>
         </div>
         <Text size="14px">
           <Markdown renderAsPlaintext>{team.description}</Markdown>

--- a/src/presenters/pages/home-v2/banner.js
+++ b/src/presenters/pages/home-v2/banner.js
@@ -5,6 +5,7 @@ import { Button, Icon, Mark } from '@fogcreek/shared-components';
 import { Overlay, OverlaySection, OverlayBackground } from 'Components/overlays';
 import { PopoverContainer } from 'Components/popover';
 import WistiaVideo from 'Components/wistia-video';
+import Link from 'Components/link';
 import { useTracker } from 'State/segment-analytics';
 
 import styles from './banner.styl';
@@ -125,7 +126,7 @@ const Banner = () => (
       <div className={styles.bannerCopyAndButtons}>
         <p>Simple, powerful, free tools to create and use millions of apps.</p>
         <div className={styles.bannerButtonWrap}>
-          <Button as="a" variant="cta" href="/create">
+          <Button as={Link} variant="cta" to="/create">
             Start Creating <Icon icon="arrowRight" />
           </Button>
           <div className={styles.watchVideoBtnWrap}>

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -73,7 +73,7 @@ const NameConflictWarning = ({ id }) => (
     <Text>
       This team has your name. You should update your info to remain unique <Icon className={emoji} icon="sparkles" />
     </Text>
-    <Button as="a" size="small" variant="secondary" href={`/user/${id}`}>
+    <Button as={Link} size="small" variant="secondary" to={`/user/${id}`}>
       Your Profile
     </Button>
   </>


### PR DESCRIPTION
## Links
* Remix link: https://warm-fossa.glitch.me
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/464

## Changes:
* replace internal `<Button as="a" href={href}>` links with `<Button as={Link} to={href}>`, `<Button as={TeamLink} team={team}>` etc.

## How To Test:
* log into https://warm-fossa.glitch.me
* click on the user menu
* click on a team
* the page should navigate to that team's page without a full refresh

## Feedback I'm looking for:
I think all the remaining cases of `<Button as="a">` are external or open in a new tab; did I miss any?