### PR TITLE
Sour maize: update recent projects when leaving a project

### DIFF
--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -188,6 +188,10 @@ export const { reducer, actions } = createSlice({
     }),
     // TODO: more granular actions for managing user's teams, collections etc
     updated: (state, { payload }) => ({ ...state, ...payload }),
+    // TODO: use the same action that's defined in the resource manager PR
+    leftProject: (state, { payload }) => {
+      state.projects = state.projects.filter((p) => p.id !== payload.id);
+    },
   },
 });
 
@@ -287,8 +291,7 @@ export const useSuperUserHelpers = () => {
       window.scrollTo(0, 0);
       window.location.reload();
     },
-    canBecomeSuperUser:
-      cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
+    canBecomeSuperUser: cachedUser && cachedUser.projects && cachedUser.projects.some((p) => p.id === 'b9f7fbdd-ac07-45f9-84ea-d484533635ff'),
     superUserFeature,
   };
 };

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import { pickBy } from 'lodash';
+import { useDispatch } from 'react-redux';
 
-import { useCurrentUser } from 'State/current-user';
+import { useCurrentUser, actions as currentUserActions } from 'State/current-user';
 import { useAPIHandlers, useAPI } from 'State/api';
 import useErrorHandlers from 'State/error-handlers';
 import { userOrTeamIsAuthor, useCollectionReload } from 'State/collection';
@@ -20,6 +21,7 @@ const bind = (fn, ...args) => {
 const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler);
 
 const useDefaultProjectOptions = () => {
+  const dispatch = useDispatch();
   const { addProjectToCollection, joinTeamProject, removeUserFromProject, removeProjectFromCollection } = useAPIHandlers();
   const { currentUser } = useCurrentUser();
   const { handleError, handleCustomError } = useErrorHandlers();
@@ -40,6 +42,7 @@ const useDefaultProjectOptions = () => {
     leaveProject: withErrorHandler(async (project) => {
       await removeUserFromProject({ project, user: currentUser });
       reloadProjectMembers([project.id]);
+      dispatch(currentUserActions.leftProject(project));
     }, handleError),
     // toggleBookmark is defined here and on state/collection and are very similar. Their only differences are how they modify state.
     // we'll probably want to revisit condensing these when we have a centralized state object to work off of.


### PR DESCRIPTION
## Links
* Remix link: http://sour-maize.glitch.me
* Issue-tracker link: https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/486

## Changes:
* update current user's "projects" array when leaving a project

## How To Test:
* log into http://sour-maize.glitch.me
* click on the project options menu for one of your recent projects
* leave the project
* the project should be removed from your recent projects

## Future work (not in this PR)
Update the current user's cached projects/collections/etc when any other relevant action happens