### PR TITLE
Fallacious slice: Fix ssr getting stuck after failing to load the client code

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -32,7 +32,7 @@ let needsTranspile = true;
 // it'll get loaded off the disk again when the render calls require
 require('chokidar').watch(directory).on('change', () => {
   needsTranspile = true;
-  clearCache();
+  clearCache(); // clear the server rendering cache
 });
 
 const requireClient = () => {

--- a/server/render.js
+++ b/server/render.js
@@ -26,30 +26,28 @@ const { directory, verb } = setup();
 const [getFromCache, clearCache] = createCache(dayjs.convert(15, 'minutes', 'ms'), 'render', {});
 
 let isFirstTranspile = true;
-let freshTranspile = true;
+let needsTranspile = true;
 
 // clear client code from the require cache whenever it gets changed
 // it'll get loaded off the disk again when the render calls require
 require('chokidar').watch(directory).on('change', () => {
-  if (!freshTranspile) {
+  needsTranspile = true;
+  clearCache();
+});
+
+const requireClient = () => {
+  if (needsTranspile) {
     // remove everything in the src directory
     Object.keys(require.cache).forEach((location) => {
       if (location.startsWith(directory)) delete require.cache[location];
     });
-    // clear out the server rendering cache
-    clearCache();
-    // flag that everything is cleared out
-    freshTranspile = true;
   }
-});
-
-const requireClient = () => {
-  freshTranspile = false;
   const startTime = performance.now();
   const required = require(path.join(directory, './server'));
   const endTime = performance.now();
-  if (freshTranspile) console.log(`SSR ${isFirstTranspile ? '' : 're'}${verb} took ${Math.round(endTime - startTime)}ms`);
+  if (needsTranspile) console.log(`SSR ${isFirstTranspile ? '' : 're'}${verb} took ${Math.round(endTime - startTime)}ms`);
   isFirstTranspile = false;
+  needsTranspile = false;
   return required;
 };
 


### PR DESCRIPTION
## Links
https://fallacious-slice.glitch.me/ (nothing interesting there)
https://github.com/FogCreek/Glitch-Community-Work/issues/494

## Changes:
If the require call failed for any reason `isTranspiled` would never be set to true, and the site would never clear the require cache so it could try again. Now it tracks that we have an outdated require, and clears the require cache each time until it works.

## How To Test:
1. Make a remix and type some gibberish into the top of something in src/
2. Load up the homepage and notice an error in the logs when trying to ssr
3. Remove the gibberish and reload the page
4. This remix will ssr, while ~community would continue showing the error that was fixed