### PR TITLE
Show Category Avatar instead of generated avatar

### DIFF
--- a/src/components/collection/container.js
+++ b/src/components/collection/container.js
@@ -56,8 +56,11 @@ const CollectionContainer = ({ collection, showFeaturedProject, isAuthorized, pr
   const enableSorting = isAuthorized && projects.length > 1;
 
   let avatar = null;
+  const defaultAvatarName = "collection-avatar"; // this was the old name for the default picture frame collection avatar
   if (myStuffIsEnabled && collection.isMyStuff) {
     avatar = <BookmarkAvatar width="50%" />;
+  } else if (collection.avatarUrl && !collection.avatarUrl.includes(defaultAvatarName)){
+    avatar = <Image src={collection.avatarUrl} alt='' />;
   } else if (collection.projects.length > 0) {
     avatar = <CollectionAvatar collection={collection} />;
   }

--- a/src/components/collection/container.js
+++ b/src/components/collection/container.js
@@ -56,16 +56,19 @@ const CollectionContainer = ({ collection, showFeaturedProject, isAuthorized, pr
   const enableSorting = isAuthorized && projects.length > 1;
 
   let avatar = null;
-  const defaultAvatarName = "collection-avatar"; // this was the old name for the default picture frame collection avatar
+  const defaultAvatarName = 'collection-avatar'; // this was the old name for the default picture frame collection avatar
   if (myStuffIsEnabled && collection.isMyStuff) {
     avatar = <BookmarkAvatar width="50%" />;
-  } else if (collection.avatarUrl && !collection.avatarUrl.includes(defaultAvatarName)){
-    avatar = <Image src={collection.avatarUrl} alt='' />;
+  } else if (collection.avatarUrl && !collection.avatarUrl.includes(defaultAvatarName)) {
+    avatar = <Image src={collection.avatarUrl} alt="" />;
   } else if (collection.projects.length > 0) {
     avatar = <CollectionAvatar collection={collection} />;
   }
 
-  const setPrivate = useTrackedFunc(() => funcs.updatePrivacy(!collection.private), `Collection toggled ${collection.private ? 'public' : 'private'}`);
+  const setPrivate = useTrackedFunc(
+    () => funcs.updatePrivacy(!collection.private),
+    `Collection toggled ${collection.private ? 'public' : 'private'}`,
+  );
 
   return (
     <article className={classnames(styles.container, isDarkColor(collection.coverColor) && styles.dark, preview && styles.preview)}>


### PR DESCRIPTION
## Links
* Remix link: https://functional-politician.glitch.me/hardware

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/519336/66077185-758d6300-e52d-11e9-95bd-d14dfc33d55d.png)
Category collections should show the category avatar

![image](https://user-images.githubusercontent.com/519336/66077683-7377d400-e52e-11e9-9983-8bb01b6221c8.png)
Non-category collections should show the generated avatar

## Changes:
* Unintentionally removed the avatar from category collections (e.g., `/games`, `/art`, `/hardware`).  Added them back in here.

## How to test:
* Check that the avatar appears on category collections:
https://functional-politician.glitch.me/hardware

* Check that the generated avatars appear on non-category collections:
https://functional-politician.glitch.me/@scientiffic/microbit
