### PR TITLE
Invented Catsup: Fix small my stuff bug

### DIFF
--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -17,7 +17,7 @@ const nullMyStuffCollection = {
   coverColor: pickRandomColor(),
   projects: [],
   id: 'nullMyStuff',
-  isPrivate: true,
+  private: true,
 };
 
 // puts my stuff at the front of the array, if my stuff doesn't exist we add it.


### PR DESCRIPTION
## Links
* Remix link: https://invented-catsup.glitch.me/

## Screenshot:
<img width="528" alt="Screen Shot 2019-10-03 at 10 20 15 AM" src="https://user-images.githubusercontent.com/6620164/66135132-74107900-e5c7-11e9-9c1e-75b1b8365cde.png">

## Changes:
* Doing a bit of qa on My Stuff/Private Collections and noticed that when you create a new account, the mocked out My Stuff collection (that gets turned into a real one) was not showing as a private collection

## How To Test:
* make a new account
* enable My Stuff
* go to your user page and look at the empty My Stuff Collection, it should have a 🔒 sign before you click on it. 

