### PR TITLE
circular-passionfruit: Remove "Resume Coding" button and add "Edit Project" to recent projects project items

### DIFF
--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -20,12 +20,19 @@ const containers = {
   gridCompact: (props) => <Grid className={styles.projectsGridCompact} {...props} />,
 };
 
-const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, layout, projectOptions, showEditButton, }) => {
+const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, layout, projectOptions, showEditButton }) => {
   const Container = containers[layout];
   return (
     <Container itemClassName={styles.projectsItem} items={projects} sortable={sortable} onReorder={onReorder}>
       {(project) => (
-        <ProjectItem key={project.id} project={project} projectOptions={projectOptions} collection={collection} noteOptions={noteOptions} showEditButton={showEditButton} />
+        <ProjectItem
+          key={project.id}
+          project={project}
+          projectOptions={projectOptions}
+          collection={collection}
+          noteOptions={noteOptions}
+          showEditButton={showEditButton}
+        />
       )}
     </Container>
   );

--- a/src/components/containers/projects-list.js
+++ b/src/components/containers/projects-list.js
@@ -20,12 +20,12 @@ const containers = {
   gridCompact: (props) => <Grid className={styles.projectsGridCompact} {...props} />,
 };
 
-const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, layout, projectOptions }) => {
+const ProjectsUL = ({ collection, projects, sortable, onReorder, noteOptions, layout, projectOptions, showEditButton, }) => {
   const Container = containers[layout];
   return (
     <Container itemClassName={styles.projectsItem} items={projects} sortable={sortable} onReorder={onReorder}>
       {(project) => (
-        <ProjectItem key={project.id} project={project} projectOptions={projectOptions} collection={collection} noteOptions={noteOptions} />
+        <ProjectItem key={project.id} project={project} projectOptions={projectOptions} collection={collection} noteOptions={noteOptions} showEditButton={showEditButton} />
       )}
     </Container>
   );
@@ -45,6 +45,7 @@ function ProjectsList({
   collection,
   noteOptions,
   projectOptions,
+  showEditButton,
   dataCy,
 }) {
   const matchFn = (project, filter) => project.domain.includes(filter) || project.description.toLowerCase().includes(filter);
@@ -87,6 +88,7 @@ function ProjectsList({
                     sortable={enableSorting && paginatedProjects.length === projects.length}
                     onReorder={onReorder}
                     projectOptions={projectOptions}
+                    showEditButton={showEditButton}
                   />
                 )}
               </PaginationController>
@@ -110,6 +112,7 @@ ProjectsList.propTypes = {
   projectsPerPage: PropTypes.number,
   collection: PropTypes.object,
   noteOptions: PropTypes.object,
+  showEditButton: PropTypes.bool,
   projectOptions: PropTypes.object,
   dataCy: PropTypes.string,
 };
@@ -124,6 +127,7 @@ ProjectsList.defaultProps = {
   projectsPerPage: 6,
   collection: null,
   noteOptions: {},
+  showEditButton: false,
   projectOptions: {},
   dataCy: null,
 };

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -2,25 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@fogcreek/shared-components';
 
-import { EDITOR_URL } from 'Utils/constants';
 import SearchForm from 'Components/search-form';
 import SignInPop from 'Components/sign-in-pop';
 import UserOptionsPop from 'Components/user-options-pop';
 import NewProjectPop from 'Components/new-project-pop';
-import Link, { TrackedExternalLink } from 'Components/link';
+import Link from 'Components/link';
 import { useCurrentUser } from 'State/current-user';
 import { AnalyticsContext } from 'State/segment-analytics';
 import { useGlobals } from 'State/globals';
 import Logo from './logo';
 import styles from './header.styl';
-
-const ResumeCoding = () => (
-  <TrackedExternalLink name="Resume Coding clicked" to={EDITOR_URL}>
-    <Button variant="cta" size="small" as="span">
-      Resume Coding
-    </Button>
-  </TrackedExternalLink>
-);
 
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay }) => {
   const { currentUser } = useCurrentUser();
@@ -29,7 +20,6 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay }
   const fakeSignedIn = !currentUser.id && SSR_SIGNED_IN;
   const signedIn = !!currentUser.login || fakeSignedIn;
   const signedOut = !!currentUser.id && !signedIn;
-  const hasProjects = currentUser.projects.length > 0 || fakeSignedIn;
   return (
     <AnalyticsContext properties={{ origin: 'navbar' }}>
       <header role="banner" className={styles.header}>
@@ -47,11 +37,6 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay }
             {(signedIn || signedOut) && (
               <li className={styles.buttonWrap}>
                 <NewProjectPop />
-              </li>
-            )}
-            {hasProjects && (
-              <li className={styles.buttonWrap}>
-                <ResumeCoding />
               </li>
             )}
             {signedOut && (

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -41,7 +41,7 @@ const ProfileListLoader = ({ project }) => (
   </VisibilityContainer>
 );
 
-const ProjectItem = ({ project, projectOptions: providedProjectOptions, collection, noteOptions }) => {
+const ProjectItem = ({ project, projectOptions: providedProjectOptions, collection, noteOptions, showEditButton }) => {
   const { location } = useGlobals();
   const myStuffEnabled = useDevToggle('My Stuff');
   const { currentUser } = useCurrentUser();
@@ -146,6 +146,11 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
                       <Markdown length={80}>{project.suspendedReason ? 'suspended project' : project.description || ' '}</Markdown>
                     </div>
                   </ProjectLink>
+                  {showEditButton && (
+                    <footer>
+                      <Button variant="secondary" as={Link} href={getEditorUrl(project.domain)}>Edit Project</Button>
+                    </footer>
+                  )}
                 </div>
               </>
             );
@@ -167,11 +172,13 @@ ProjectItem.propTypes = {
   }).isRequired,
   projectOptions: PropTypes.object,
   collection: PropTypes.object,
+  showEditButton: PropTypes.bool,
 };
 
 ProjectItem.defaultProps = {
   projectOptions: {},
   collection: null,
+  showEditButton: false,
 };
 
 export default ProjectItem;

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -10,7 +10,7 @@ import ProfileList from 'Components/profile-list';
 import { ProjectLink } from 'Components/link';
 import VisibilityContainer from 'Components/visibility-container';
 import Note from 'Components/collection/note';
-import { FALLBACK_AVATAR_URL, getProjectAvatarUrl } from 'Models/project';
+import { FALLBACK_AVATAR_URL, getProjectAvatarUrl, getEditorUrl } from 'Models/project';
 import { useProjectMembers } from 'State/project';
 import { useProjectOptions } from 'State/project-options';
 import { useCurrentUser } from 'State/current-user';
@@ -26,6 +26,7 @@ const ProfileAvatar = ({ project }) => <Image className={styles.avatar} src={get
 const getLinkBodyStyles = (project) =>
   classnames(styles.linkBody, {
     [styles.private]: project.private,
+    [styles.hasFooter]: showEditButton,
   });
 
 const ProfileListWithData = ({ project }) => {
@@ -147,8 +148,8 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
                     </div>
                   </ProjectLink>
                   {showEditButton && (
-                    <footer>
-                      <Button variant="secondary" as={Link} href={getEditorUrl(project.domain)}>Edit Project</Button>
+                    <footer className={styles.footer}>
+                      <Button variant="secondary" as="a" size="small" href={getEditorUrl(project.domain)}>Edit Project</Button>
                     </footer>
                   )}
                 </div>

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -23,7 +23,7 @@ import styles from './project-item.styl';
 
 const ProfileAvatar = ({ project }) => <Image className={styles.avatar} src={getProjectAvatarUrl(project)} defaultSrc={FALLBACK_AVATAR_URL} alt="" />;
 
-const getLinkBodyStyles = (project) =>
+const getLinkBodyStyles = (project, showEditButton) =>
   classnames(styles.linkBody, {
     [styles.private]: project.private,
     [styles.hasFooter]: showEditButton,
@@ -125,7 +125,7 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
                       <ProjectOptionsPop project={project} projectOptions={animatedProjectOptions} />
                     </div>
                   </header>
-                  <ProjectLink className={getLinkBodyStyles(project)} project={project}>
+                  <ProjectLink className={getLinkBodyStyles(project, showEditButton)} project={project}>
                     <div className={styles.projectHeader}>
                       <div className={styles.avatarWrap}>
                         <ProfileAvatar project={project} />

--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -132,6 +132,6 @@ a.linkBody:hover
   color: private-foreground
   
 .footer
-  background: secondary
+  background: secondary-background
   padding: .5rem 1rem
   border-radius: 0 0 5px 5px

--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -85,6 +85,8 @@
   &.private
     background-color: private
     border-color: private
+  &.hasFooter
+    border-radius: 5px 5px 0 0
 a.linkBody:hover
   text-decoration: none
   .itemButtonWrap
@@ -128,3 +130,7 @@ a.linkBody:hover
 .privateIcon
   margin: 4px 5px 0
   color: private-foreground
+  
+.footer
+  background: secondary
+  padding: 1rem

--- a/src/components/project/project-item.styl
+++ b/src/components/project/project-item.styl
@@ -133,4 +133,5 @@ a.linkBody:hover
   
 .footer
   background: secondary
-  padding: 1rem
+  padding: .5rem 1rem
+  border-radius: 0 0 5px 5px

--- a/src/components/recent-projects/index.js
+++ b/src/components/recent-projects/index.js
@@ -59,7 +59,7 @@ const RecentProjects = () => {
           </div>
           <div className={styles.projectsWrap}>
             {fetched ? (
-              <ProjectsList layout="row" projects={currentUser.projects.slice(0, 3)} />
+              <ProjectsList layout="row" showEditButton projects={currentUser.projects.slice(0, 3)} />
             ) : (
               <Loader style={{ width: '25px' }} />
             )}


### PR DESCRIPTION
## Links
* [circular-passionfruit.glitch.me](https://circular-passionfruit.glitch.me/)
* [#453](https://github.com/FogCreek/glitch-community-work/issues/453)
* [User dashboard spec](https://docs.google.com/document/d/10KS93TQ6vaQcVSL0ujUj4__GGl7M5MlS1vimzNqiizU/edit#heading=h.3im6lap0txtw)

## GIF/Screenshots:
![Screen Shot 2019-10-03 at 11 23 55 AM](https://user-images.githubusercontent.com/7584833/66140546-509dfc00-e5d0-11e9-8099-d3adf34562e8.png)

## Changes:
* Remove the "Resume Coding" button
* Add the `showEditButton` prop to `<ProjectsList>` and `<ProjectItem>`, which if true, will render a footer with an "Edit Project Button"

<img src="https://user-images.githubusercontent.com/7584833/66140695-8fcc4d00-e5d0-11e9-8041-b192649e7e26.png" width="250" />

## How To Test:
* Log in, you should see the "Edit Project" button on your recent projects dashboard on the homepage
* The "Resume Coding" should be gone
* Check out other `<ProjectsList>`s, you should not see the "Edit Project" button on those `<ProjectItem>`s
  - Team page recent projects
  - User page recent projects
