### PR TITLE
Fix bugs for My Stuff and Private Collections, mostly a11y issues

### DIFF
--- a/src/components/buttons/bookmark-button.js
+++ b/src/components/buttons/bookmark-button.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Image from 'Components/images/image';
 import classNames from 'classnames/bind';
 import { CDN_URL } from 'Utils/constants';
-import TooltipContainer from 'Components/tooltips/tooltip-container';
 import HiddenCheckbox from 'Components/fields/hidden-checkbox';
 
 import styles from './bookmark-button.styl';
@@ -131,9 +130,6 @@ const BookmarkButton = ({ action, initialIsBookmarked, containerDetails, project
     }
   }, [containerDetails, initialIsBookmarked]);
 
-  const addText = 'Add to My Stuff';
-  const removeText = 'Remove from My Stuff';
-
   const onClick = (e) => {
     const fromKeyboard = !e.detail; // only show focus highlighting if onClick triggered from keyboard input
     if (!state.isBookmarked) {
@@ -160,22 +156,16 @@ const BookmarkButton = ({ action, initialIsBookmarked, containerDetails, project
   });
 
   return (
-    <TooltipContainer
-      type="action"
-      tooltip={state.isBookmarked ? removeText : addText}
-      target={
-        <HiddenCheckbox value={state.isBookmarked} onChange={onClick} onFocus={onFocus} onBlur={onBlur}>
-          <div
-            className={`${styles.bookmarkButton} ${state.isFocused ? styles.focused : ''} ${state.isVisible ? styles.visible : ''}`}
-            aria-label={`Add ${projectName} to My Stuff`}
-          >
-            <Halo isAnimating={state.isAnimating} onAnimationEnd={onAnimationEnd} />
-            {state.isBookmarked ? <FilledBookmark /> : <EmptyBookmark />}
-            <Image className={checkClassName} src={CHECKMARK} onAnimationEnd={onAnimationEnd} alt="" width="10px" height="10px" />
-          </div>
-        </HiddenCheckbox>
-      }
-    />
+    <HiddenCheckbox value={state.isBookmarked} onChange={onClick} onFocus={onFocus} onBlur={onBlur}>
+      <div
+        className={`${styles.bookmarkButton} ${state.isFocused ? styles.focused : ''} ${state.isVisible ? styles.visible : ''}`}
+        aria-label={`Add ${projectName} to My Stuff`}
+      >
+        <Halo isAnimating={state.isAnimating} onAnimationEnd={onAnimationEnd} />
+        {state.isBookmarked ? <FilledBookmark /> : <EmptyBookmark />}
+        <Image className={checkClassName} src={CHECKMARK} onAnimationEnd={onAnimationEnd} alt="" width="10px" height="10px" />
+      </div>
+    </HiddenCheckbox>
   );
 };
 

--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -122,9 +122,7 @@ const CreateMyStuffOnClickComponent = withRouter(({ history, children, className
 
   return (
     <button type="submit" onClick={createMyStuffCollection} className={styles.onClickMyStuffButton} style={style}>
-      <div className={className}>
-        {children}
-      </div>
+      <div className={className}>{children}</div>
     </button>
   );
 });
@@ -137,7 +135,12 @@ export const MyStuffItem = ({ collection, isAuthorized, showLoader }) => {
       <div className={styles.collectionItem}>
         {isAuthorized && <div className={styles.header} />}
         <div className={styles.collectionItemBody} style={{ '--border-color': collection.coverColor }}>
-          <CollectionLinkComponent collection={collection} className={styles.linkBody} style={collectionColorStyles(collection)}>
+          <CollectionLinkComponent
+            collection={collection}
+            className={styles.linkBody}
+            style={collectionColorStyles(collection)}
+            label={`${collection.private ? 'private ' : ''}${collection.name}`}
+          >
             <div className={styles.avatarContainer}>
               <BookmarkAvatar />
             </div>
@@ -176,6 +179,7 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
             collection={collection}
             className={classNames(styles.linkBody, { [styles.showCurator]: showCurator })}
             style={collectionColorStyles(collection)}
+            label={`${collection.private ? 'private ' : ''}${collection.name}`}
           >
             <div className={styles.nameDescriptionContainer}>
               <div className={styles.itemButtonWrap}>

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -262,11 +262,12 @@ svg.arrow
   vertical-align: text-top
 
 .onClickMyStuffButton
-  flex: 0 1 110px;
-  border-top-right-radius: 5px;
-  border-top-left-radius: 5px;
-  text-align: left;
+  flex: 0 1 110px
+  border-top-right-radius: 5px
+  border-top-left-radius: 5px
+  text-align: left
   .linkBody
-    top: 0;
-    left: 0;
-    position: absolute;
+    top: 0
+    left: 0
+    position: absolute
+    z-index: 10

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -272,8 +272,4 @@ svg.arrow
     position: absolute
     z-index: 1
     &:hover
-    .itemButtonWrap
-      width: fit-content
-      height: fit-content
-      box-shadow: 2px 2px 0 primary
-      border-radius: 5px
+      box-shadow: none

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -271,6 +271,6 @@ svg.arrow
     left: 0
     position: absolute
     z-index: 1
-    &:hover
     .itemButtonWrap
-      box-shadow: none
+      &:hover
+        box-shadow: none

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -272,4 +272,5 @@ svg.arrow
     position: absolute
     z-index: 1
     &:hover
+    .itemButtonWrap
       box-shadow: none

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -94,8 +94,8 @@
       height: auto
   &:hover
     .itemButtonWrap
-      display: inline-block
-      width: auto
+      display: inline-block 
+      width: auto // edge doesn't support width: fit-content, using display: inline-block and width auto helps recreate that
       box-shadow: 2px 2px 0 primary
       border-radius: 5px
 

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -270,4 +270,10 @@ svg.arrow
     top: 0
     left: 0
     position: absolute
-    z-index: 10
+    z-index: 1
+    &:hover
+    .itemButtonWrap
+      width: fit-content
+      height: fit-content
+      box-shadow: 2px 2px 0 primary
+      border-radius: 5px

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -94,8 +94,8 @@
       height: auto
   &:hover
     .itemButtonWrap
-      width: fit-content
-      height: fit-content
+      display: inline-block
+      width: auto
       box-shadow: 2px 2px 0 primary
       border-radius: 5px
 
@@ -271,6 +271,3 @@ svg.arrow
     left: 0
     position: absolute
     z-index: 1
-    .itemButtonWrap
-      &:hover
-        box-shadow: none

--- a/src/components/collection/collection-result-item.js
+++ b/src/components/collection/collection-result-item.js
@@ -36,24 +36,27 @@ const CollectionResultItem = ({ onClick, collection, active }) => {
   const collectionIsMyStuff = useDevToggle('My Stuff') && collection.isMyStuff;
 
   return (
-    <ResultItem active={active} onClick={onClick} href={`/@${collection.fullUrl}`} className={classnames(collection.private && styles.private)}>
-      {collectionIsMyStuff && (
-        <div className={styles.avatarWrap}>
-          <BookmarkAvatar />
-        </div>
-      )}
-      <ResultInfo>
-        <VisuallyHidden>Add to collection</VisuallyHidden>
-        <ResultName>{collection.name}</ResultName>
-        {collection.description.length > 0 && (
-          <ResultDescription>
-            <VisuallyHidden>with description</VisuallyHidden>
-            <Markdown renderAsPlaintext>{collection.description}</Markdown>
-          </ResultDescription>
+    <div className={classnames(collection.private && styles.private)}>
+      <ResultItem active={active} onClick={onClick} href={`/@${collection.fullUrl}`}>
+        {collectionIsMyStuff && (
+          <div className={styles.avatarWrap}>
+            <BookmarkAvatar />
+          </div>
         )}
-        {collection.teamId && collection.teamId !== -1 && <ProfileItemWrap collection={collection} />}
-      </ResultInfo>
-    </ResultItem>
+        <ResultInfo>
+          <VisuallyHidden>Add to collection</VisuallyHidden>
+          <ResultName>{collection.name}</ResultName>
+          {collection.description.length > 0 && (
+            <ResultDescription>
+              <VisuallyHidden>with description</VisuallyHidden>
+              <Markdown renderAsPlaintext>{collection.description}</Markdown>
+            </ResultDescription>
+          )}
+          {collection.teamId && collection.teamId !== -1 && <ProfileItemWrap collection={collection} />}
+        </ResultInfo>
+      </ResultItem>
+
+    </div>
   );
 };
 

--- a/src/components/collection/collection-result-item.styl
+++ b/src/components/collection/collection-result-item.styl
@@ -13,4 +13,7 @@
   z-index: 1
 
 .private
-  background-color: private
+  > div
+    background-color: private
+  > div:hover
+      background-color: general-link

--- a/src/components/private-badge/index.js
+++ b/src/components/private-badge/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Icon } from '@fogcreek/shared-components';
@@ -28,8 +28,8 @@ export const PrivateBadge = ({ type }) => (
     type="info"
     tooltip={TYPES[type].privateText}
     target={
-      <span className={classnames(styles.privateIcon, styles.privateBadge, styles.private)}>
-        <Icon icon="private" />
+      <span aria-label="private" className={classnames(styles.privateIcon, styles.privateBadge, styles.private)}>
+        <Icon icon="private" alt="private" />
       </span>
     }
   />
@@ -38,20 +38,24 @@ PrivateBadge.propTypes = {
   type: PropTypes.oneOf(Object.keys(TYPES)).isRequired,
 };
 
-export const PrivateToggle = ({ isPrivate, setPrivate, type, align }) => (
-  <TooltipContainer
-    type="action"
-    align={align}
-    tooltip={isPrivate ? TYPES[type].privateText : TYPES[type].publicText}
-    target={
-      <span className={classnames(styles.privateIcon, styles.privateButton, isPrivate ? styles.private : styles.public)}>
-        <HiddenCheckbox value={isPrivate} onChange={setPrivate}>
-          {isPrivate ? <Icon icon="private" /> : <Icon icon="public" />}
+export const PrivateToggle = ({ isPrivate, setPrivate, type, align }) => {
+  const [isFocused, setFocus] = useState(false);
+
+  return (
+    <TooltipContainer
+      type="action"
+      align={align}
+      tooltip={isPrivate ? TYPES[type].privateText : TYPES[type].publicText}
+      target={
+        <HiddenCheckbox value={isPrivate} onChange={setPrivate} onFocus={() => setFocus(true)} onBlur={() => setFocus(false)}>
+          <span aria-label="Mark as private" className={classnames(styles.privateIcon, styles.privateButton, isPrivate ? styles.private : styles.public, isFocused && styles.focused)}>
+            {isPrivate ? <Icon icon="private" alt="private" /> : <Icon icon="public" alt="public" />}
+          </span>
         </HiddenCheckbox>
-      </span>
-    }
-  />
-);
+      }
+    />
+  );
+};
 PrivateToggle.propTypes = {
   isPrivate: PropTypes.bool.isRequired,
   setPrivate: PropTypes.func.isRequired,

--- a/src/components/private-badge/styles.styl
+++ b/src/components/private-badge/styles.styl
@@ -32,3 +32,7 @@
   color: private-foreground
   svg
     opacity: 0.7
+
+.focused
+  outline-color: -webkit-focus-ring-color;
+  outline-style: auto;

--- a/src/components/private-badge/styles.styl
+++ b/src/components/private-badge/styles.styl
@@ -34,5 +34,5 @@
     opacity: 0.7
 
 .focused
-  outline-color: -webkit-focus-ring-color;
-  outline-style: auto;
+  outline: 1px dotted #212121
+  outline: 5px auto -webkit-focus-ring-color


### PR DESCRIPTION
## Links
* Remix link: https://ember-spell.glitch.me/
* Issue-tracker link:
    - https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/499
    - https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/500
    - https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/498

## Changes:
* We decided to remove the tooltip from "My Stuff", as it was acting weird on mobile, and we're hoping the button is intuitive enough that we don't need one
* Added a label to the Collection Link items in a collections list on the user page so it would announce via screenreader when a collection is private
* fixed an issue where private collections were not showing with a yellow background in the add project to collection dropdown
* fixed an issue with our privacy toggles, where they were not outlining when they were focused
* added some missing alt tags to our privacy icons
* added an aria label to the privacy toggle to match the behavior we have on the my stuff-bookmark buttons (the label stays the same, and voice over will clarify if it's checked or unchecked, rather than alternating the help text if it's checked or unchecked)

## How To Test:
* enable My Stuff
* ensure you can use the My Stuff Buttons and the Privacy Toggle buttons well, including while using voice over

## Feedback I'm looking for:
anything else we might have missed? I've done a bunch of manual testing and very quickly ran through the Accessibility Insights for Web extension, but I'm sure I've missed things.

