### PR TITLE
Broadleaf-yttrium: Release My Stuff and Private Collections

### DIFF
--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -114,7 +114,7 @@ const CreateMyStuffOnClickComponent = withRouter(({ history, children, className
   const { currentUser } = useCurrentUser();
 
   const createMyStuffCollection = async () => {
-    const myStuff = await createCollection({ api, name: 'My Stuff', createNotification, myStuffEnabled: true });
+    const myStuff = await createCollection({ api, name: 'My Stuff', createNotification });
     if (myStuff) {
       history.push(`@${currentUser.login}/${myStuff.url}`);
     }

--- a/src/components/collection/collection-result-item.js
+++ b/src/components/collection/collection-result-item.js
@@ -10,8 +10,6 @@ import VisibilityContainer from 'Components/visibility-container';
 import { useCollectionCurator } from 'State/collection';
 import { BookmarkAvatar } from 'Components/images/avatar';
 
-import useDevToggle from 'State/dev-toggles';
-
 import styles from './collection-result-item.styl';
 
 const ProfileItemWithData = ({ collection }) => {
@@ -33,7 +31,7 @@ const ProfileItemWrap = ({ collection }) => (
 );
 
 const CollectionResultItem = ({ onClick, collection, active }) => {
-  const collectionIsMyStuff = useDevToggle('My Stuff') && collection.isMyStuff;
+  const collectionIsMyStuff = collection.isMyStuff;
 
   return (
     <div className={classnames(collection.private && styles.private)}>

--- a/src/components/collection/container.js
+++ b/src/components/collection/container.js
@@ -21,7 +21,6 @@ import CollectionAvatar from 'Components/collection/collection-avatar';
 import { CollectionLink } from 'Components/link';
 import { PrivateToggle } from 'Components/private-badge';
 import { useCollectionCurator } from 'State/collection';
-import useDevToggle from 'State/dev-toggles';
 import useSample from 'Hooks/use-sample';
 import { useTrackedFunc } from 'State/segment-analytics';
 
@@ -43,8 +42,7 @@ const CollectionContainer = ({ collection, showFeaturedProject, isAuthorized, pr
     [[featuredProject], projects] = partition(collection.projects, (p) => p.id === collection.featuredProjectId);
   }
 
-  const myStuffIsEnabled = useDevToggle('My Stuff');
-  const canEditNameAndDescription = myStuffIsEnabled ? isAuthorized && !collection.isMyStuff : isAuthorized;
+  const canEditNameAndDescription = isAuthorized && !collection.isMyStuff;
 
   let collectionName = collection.name;
   if (canEditNameAndDescription) {
@@ -57,7 +55,7 @@ const CollectionContainer = ({ collection, showFeaturedProject, isAuthorized, pr
 
   let avatar = null;
   const defaultAvatarName = 'collection-avatar'; // this was the old name for the default picture frame collection avatar
-  if (myStuffIsEnabled && collection.isMyStuff) {
+  if (collection.isMyStuff) {
     avatar = <BookmarkAvatar width="50%" />;
   } else if (collection.avatarUrl && !collection.avatarUrl.includes(defaultAvatarName)) {
     avatar = <Image src={collection.avatarUrl} alt="" />;
@@ -77,7 +75,7 @@ const CollectionContainer = ({ collection, showFeaturedProject, isAuthorized, pr
         <div>
           <h1 className={styles.name}>{collectionName}</h1>
 
-          {isAuthorized && myStuffIsEnabled && (
+          {isAuthorized && (
             <div className={styles.privacyToggle}>
               <PrivateToggle
                 align={['left']}

--- a/src/components/collections-list/index.js
+++ b/src/components/collections-list/index.js
@@ -12,24 +12,14 @@ import { useAPIHandlers } from 'State/api';
 import { useCurrentUser } from 'State/current-user';
 import { useCollectionContext, useCollectionProjects } from 'State/collection';
 import { getCollectionsWithMyStuff } from 'Models/collection';
-import useDevToggle from 'State/dev-toggles';
 
 import styles from './styles.styl';
-
-const CreateFirstCollection = () => (
-  <div className={styles.createFirstCollection}>
-    <img src="https://cdn.glitch.com/1afc1ac4-170b-48af-b596-78fe15838ad3%2Fpsst-pink.svg?1541086338934" alt="" />
-    <p className={styles.createFirstCollectionText}>Create collections to organize your favorite projects.</p>
-    <br />
-  </div>
-);
 
 /*
   - ensures my stuff is at the beginning of the list (even if it doesn't exist yet)
   - ensures we remove mystuff if the collection has no projects and the user is not authorized we need to remove it from the list
 */
 function MyStuffController({ children, collections, isAuthorized, maybeTeam }) {
-  const myStuffEnabled = useDevToggle('My Stuff');
   // put mystuff at beginning of list (and fake one if it's not there yet)
   const collectionsWithMyStuff = getCollectionsWithMyStuff({ collections });
 
@@ -40,7 +30,7 @@ function MyStuffController({ children, collections, isAuthorized, maybeTeam }) {
     return children([]);
   }
 
-  if (!myStuffEnabled || maybeTeam) {
+  if (maybeTeam) {
     return children(collections);
   }
 
@@ -66,7 +56,6 @@ function CollectionsList({
   const { deleteItem } = useAPIHandlers();
   const { currentUser } = useCurrentUser();
   const [deletedCollectionIds, setDeletedCollectionIds] = useState([]);
-  const myStuffEnabled = useDevToggle('My Stuff');
   const getCollectionProjects = useCollectionContext();
 
   function deleteCollection(collection) {
@@ -107,7 +96,6 @@ function CollectionsList({
                 {canMakeCollections && (
                   <>
                     <CreateCollectionButton team={maybeTeam} />
-                    {!hasCollections && !myStuffEnabled && <CreateFirstCollection />}
                   </>
                 )}
 
@@ -123,7 +111,7 @@ function CollectionsList({
                         {(paginatedCollections, isExpanded) => (
                           <Grid items={paginatedCollections} className={styles.collectionsGrid}>
                             {(collection) =>
-                              myStuffEnabled && collection.isMyStuff ? (
+                              collection.isMyStuff ? (
                                 <MyStuffItem collection={collection} isAuthorized={isAuthorized} showLoader={isExpanded} />
                               ) : (
                                 <CollectionItem

--- a/src/components/collections-list/styles.styl
+++ b/src/components/collections-list/styles.styl
@@ -12,23 +12,6 @@
   color: primary
   text-decoration: none
 
-.createFirstCollection
-  display: flex
-  flex-direction: row
-  align-items: flex-start
-  width: 100%
-  margin: 1rem 0
-  // align with grids
-  @media (min-width: mediumViewport)
-    width: 50%
-    padding-right: 10px
-  @media (min-width: largeViewport)
-    width: 33%
-
-.createFirstCollectionText
-  padding-left: 15px
-  margin: 0
-
 .row
   --gap: 25px
   padding-right: 10px

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -24,7 +24,6 @@ import { useTrackedFunc } from 'State/segment-analytics';
 import { useAlgoliaSearch } from 'State/search';
 import { useCurrentUser } from 'State/current-user';
 import { useNotifications } from 'State/notifications';
-import useDevToggle from 'State/dev-toggles';
 import { useAPI } from 'State/api';
 import { getCollectionsWithMyStuff, createCollection } from 'Models/collection';
 import useDebouncedValue from '../../hooks/use-debounced-value';
@@ -101,10 +100,9 @@ function useCollectionSearch(query, project, collectionType) {
   const filters = collectionType === 'user' ? { userIDs: [currentUser.id] } : { teamIDs: currentUser.teams.map((team) => team.id) };
 
   const searchResults = useAlgoliaSearch(debouncedQuery, { ...filters, filterTypes: ['collection'], allowEmptyQuery: true, isMyStuff: true }, [collectionType]);
-  const myStuffEnabled = useDevToggle('My Stuff');
 
   const searchResultsWithMyStuff = useMemo(() => {
-    const shouldPutMyStuffAtFrontOfList = myStuffEnabled && searchResults.collection && collectionType === 'user' && query.length === 0 && searchResults.status === 'ready';
+    const shouldPutMyStuffAtFrontOfList = searchResults.collection && collectionType === 'user' && query.length === 0 && searchResults.status === 'ready';
     if (shouldPutMyStuffAtFrontOfList) {
       return getCollectionsWithMyStuff({ collections: searchResults.collection });
     }
@@ -126,12 +124,11 @@ export const AddProjectToCollectionBase = ({ project, fromProject, addProjectToC
   const { currentUser } = useCurrentUser();
   const { createNotification } = useNotifications();
   const api = useAPI();
-  const myStuffEnabled = useDevToggle('My Stuff');
 
   const addProjectTo = async (collection) => {
-    const shouldCreateMyStuffCollection = myStuffEnabled && collection.isMyStuff && collection.id === 'nullMyStuff';
+    const shouldCreateMyStuffCollection = collection.isMyStuff && collection.id === 'nullMyStuff';
     if (shouldCreateMyStuffCollection) {
-      collection = await createCollection({ api, name: 'My Stuff', createNotification, myStuffEnabled: true });
+      collection = await createCollection({ api, name: 'My Stuff', createNotification });
       collection.fullUrl = collection.fullUrl || `${currentUser.login}/${collection.url}`;
     }
 

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -9,7 +9,6 @@ import BookmarkButton from 'Components/buttons/bookmark-button';
 
 import { useCurrentUser } from 'State/current-user';
 import { useToggleBookmark } from 'State/collection';
-import useDevToggle from 'State/dev-toggles';
 import { useTrackedFunc } from 'State/segment-analytics';
 
 import FeaturedProjectOptionsPop from './featured-project-options-pop';
@@ -24,7 +23,6 @@ const Top = ({
   isAuthorized,
   unfeatureProject,
   createNote,
-  myStuffEnabled,
   isAnonymousUser,
   bookmarkAction,
   hasBookmarked,
@@ -42,7 +40,7 @@ const Top = ({
       )}
     </div>
     <div className={styles.right}>
-      {myStuffEnabled && !isAnonymousUser && !window.location.pathname.includes('my-stuff') && (
+      {!isAnonymousUser && !window.location.pathname.includes('my-stuff') && (
         <div className={styles.bookmarkButtonContainer}>
           <BookmarkButton action={bookmarkAction} initialIsBookmarked={hasBookmarked} projectName={featuredProject.domain} />
         </div>
@@ -66,7 +64,6 @@ const FeaturedProject = ({
   updateNote,
   unfeatureProject,
 }) => {
-  const myStuffEnabled = useDevToggle('My Stuff');
   const { currentUser } = useCurrentUser();
   const [hasBookmarked, toggleBookmark] = useToggleBookmark(featuredProject);
 
@@ -94,7 +91,6 @@ const FeaturedProject = ({
                 isAuthorized={isAuthorized}
                 unfeatureProject={animateAndUnfeatureProject}
                 createNote={collection ? () => displayNewNote(featuredProject) : null}
-                myStuffEnabled={myStuffEnabled}
                 isAnonymousUser={isAnonymousUser}
                 bookmarkAction={bookmarkAction}
                 hasBookmarked={hasBookmarked}

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -14,7 +14,6 @@ import { FALLBACK_AVATAR_URL, getProjectAvatarUrl, getEditorUrl } from 'Models/p
 import { useProjectMembers } from 'State/project';
 import { useProjectOptions } from 'State/project-options';
 import { useCurrentUser } from 'State/current-user';
-import useDevToggle from 'State/dev-toggles';
 import { useGlobals } from 'State/globals';
 import { useTrackedFunc } from 'State/segment-analytics';
 
@@ -44,7 +43,6 @@ const ProfileListLoader = ({ project }) => (
 
 const ProjectItem = ({ project, projectOptions: providedProjectOptions, collection, noteOptions, showEditButton }) => {
   const { location } = useGlobals();
-  const myStuffEnabled = useDevToggle('My Stuff');
   const { currentUser } = useCurrentUser();
   const isAnonymousUser = !currentUser.login;
 
@@ -111,7 +109,7 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
                     <div className={classnames(styles.userListContainer, { [styles.spaceForOptions]: hasProjectOptions })}>
                       <ProfileListLoader project={project} />
                     </div>
-                    {myStuffEnabled && !isAnonymousUser && !onMyStuffPage && (
+                    {!isAnonymousUser && !onMyStuffPage && (
                       <div className={styles.bookmarkButtonContainer}>
                         <BookmarkButton
                           action={bookmarkAction}

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -57,7 +57,7 @@ export function getCollectionLink(collection) {
   return `/@${collection.fullUrl}`;
 }
 
-export async function createCollection({ api, name, teamId, createNotification, myStuffEnabled = false }) {
+export async function createCollection({ api, name, teamId, createNotification }) {
   let description = '';
   let generatedName = false;
   let isMyStuff = false;
@@ -75,7 +75,7 @@ export async function createCollection({ api, name, teamId, createNotification, 
     description = `A ${collectionSynonym} of projects that does ${predicate} things`;
   }
 
-  if (name === 'My Stuff' && myStuffEnabled) {
+  if (name === 'My Stuff') {
     isMyStuff = true;
     description = 'My place to save cool finds';
     isPrivate = true;

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -31,7 +31,6 @@ import { userIsProjectMember, userIsProjectAdmin } from 'Models/project';
 import { addBreadcrumb } from 'Utils/sentry';
 import { getAllPages } from 'Shared/api';
 import useFocusFirst from 'Hooks/use-focus-first';
-import useDevToggle from 'State/dev-toggles';
 import { useAPIHandlers } from 'State/api';
 import { useCachedProject } from 'State/api-cache';
 
@@ -133,7 +132,6 @@ DeleteProjectPopover.propTypes = {
 };
 
 const ProjectPage = ({ project: initialProject }) => {
-  const myStuffEnabled = useDevToggle('My Stuff');
   const [project, { updateDomain, updateDescription, updatePrivate, deleteProject, uploadAvatar }] = useProjectEditor(initialProject);
   useFocusFirst();
   const { currentUser } = useCurrentUser();
@@ -184,7 +182,7 @@ const ProjectPage = ({ project: initialProject }) => {
                     placeholder="Name your project"
                   />
                 </Heading>
-                {myStuffEnabled && !isAnonymousUser && (
+                {!isAnonymousUser && (
                   <div className={styles.bookmarkButton}>
                     <BookmarkButton action={bookmarkAction} initialIsBookmarked={hasBookmarked} projectName={project.domain} />
                   </div>
@@ -198,7 +196,7 @@ const ProjectPage = ({ project: initialProject }) => {
             <>
               <div className={styles.headingWrap}>
                 <Heading tagName="h1">{!currentUser.isSupport && suspendedReason ? 'suspended project' : domain}</Heading>
-                {myStuffEnabled && !isAnonymousUser && (
+                {!isAnonymousUser && (
                   <div className={styles.bookmarkButton}>
                     <BookmarkButton action={bookmarkAction} initialIsBookmarked={hasBookmarked} projectName={project.domain} />
                   </div>

--- a/src/state/collection.js
+++ b/src/state/collection.js
@@ -8,7 +8,6 @@ import { createCollection, getCollectionLink } from 'Models/collection';
 import { AddProjectToCollectionMsg } from 'Components/notification';
 import { useNotifications } from 'State/notifications';
 import { useCurrentUser } from 'State/current-user';
-import useDevToggle from 'State/dev-toggles';
 
 async function getCollectionProjectsFromAPI(api, collection, withCacheBust) {
   const url = `/v1/collections/by/id/projects?id=${collection.id}&orderKey=projectOrder&limit=100`;
@@ -99,7 +98,6 @@ export const useToggleBookmark = (project) => {
   const { currentUser } = useCurrentUser();
   const reloadCollectionProjects = useCollectionReload();
 
-  const myStuffEnabled = useDevToggle('My Stuff');
   const { createNotification } = useNotifications();
 
   const { addProjectToCollection, removeProjectFromCollection } = useAPIHandlers();
@@ -119,7 +117,7 @@ export const useToggleBookmark = (project) => {
       } else {
         setHasBookmarked(true);
         if (!myStuffCollection) {
-          myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification, myStuffEnabled });
+          myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
         }
         await addProjectToCollection({ project, collection: myStuffCollection });
         const url = myStuffCollection.fullUrl || `${currentUser.login}/${myStuffCollection.url}`;
@@ -329,7 +327,7 @@ export function useCollectionEditor(initialCollection) {
         createNotification(`Removed ${project.domain} from collection My Stuff`);
       } else {
         if (!myStuffCollection) {
-          myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification, myStuffEnabled: true });
+          myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
         }
         await funcs.addProjectToCollection(project, myStuffCollection);
         createNotification(

--- a/src/state/dev-toggles.js
+++ b/src/state/dev-toggles.js
@@ -15,10 +15,6 @@ const toggleData = [
     name: 'User Passwords',
     description: 'Enable users to set a password for their account',
   },
-  {
-    name: 'My Stuff',
-    description: 'One click add to a collection',
-  },
 ].slice(0, 4); // <-- Yeah really, only 3...or rather 4.  If you need more, clean up one first.
 
 // Usage:

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -55,7 +55,7 @@ const useDefaultProjectOptions = () => {
       } else {
         if (setHasBookmarked) setHasBookmarked(true);
         if (!myStuffCollection) {
-          myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification, myStuffEnabled: true });
+          myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
         }
         await addProjectToCollection({ project, collection: myStuffCollection });
         reloadCollectionProjects([myStuffCollection]);


### PR DESCRIPTION
## Links
* Remix link: https://broadleaf-yttrium.glitch.me/

## Changes:
* Remove dev toggle for My Stuff and Private Collections, should be available for everyone now. 

## How To Test:
* go to https://broadleaf-yttrium.glitch.me/ and make sure you don't have a dev toggle set for My Stuff, in fact you shouldn't even see the My Stuff dev toggle as an option
* you should see My Stuff appear in your collections list
* you should see the My Stuff Button appear on any project item
* you should see My Stuff listed as an option in Add project to Collections dropdown
* you should see a privacy toggle on all collections pages

## Feedback I'm looking for:
any last minute thoughts? 

## Things left to do before deploying:
- [x] **don't deploy** until we have the go-ahead from marketing
