### PR TITLE
Set pnpm to 3.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - run:
           name: update-pnpm
-          command: 'sudo npm install -g pnpm@latest'
+          command: 'sudo npm install -g pnpm@3.x'
       - restore_cache:
           keys:
             - deps-{{ checksum "shrinkwrap.yaml" }}
@@ -46,7 +46,7 @@ jobs:
             - build-{{ .Revision }}
       - run:
           name: update-pnpm
-          command: 'sudo npm install -g pnpm@latest'
+          command: 'sudo npm install -g pnpm@3.x'
       - run:
           name: pnpm-install
           command: pnpm install
@@ -66,7 +66,7 @@ jobs:
             - build-{{ .Revision }}
       - run:
           name: update-pnpm
-          command: 'sudo npm install -g pnpm@latest'
+          command: 'sudo npm install -g pnpm@3.x'
       - run:
           name: pnpm-install
           command: pnpm install


### PR DESCRIPTION
## Links
* Remix link: https://garnet-novel.glitch.me/

## Changes:
* [we're getting circle ci errors](https://circleci.com/gh/FogCreek/Glitch-Community/1482?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification) because [pnpm has a breaking change](https://github.com/pnpm/pnpm/releases/tag/v4.0.0) that is breaking our stuffs. This keeps us on the old version until we can sort it out 

## How To Test:
* I just put the code on https://garnet-novel.glitch.me/ but I think the real proof is that circle ci has passed

