### PR TITLE
Profuse-tea: Call the sentry init code in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "license": "Apache License Version 2.0",
   "sideEffects": [
-    "./src/polyfills.js"
+    "./src/polyfills.js",
+    "./src/utils/sentry.js"
   ],
   "scripts": {
     "prestart": "npm run watch:lint:server & \n if if-env DEPLOY_ENV=production; then \n npm run watch:babel & npm run watch:webpack & \n fi",


### PR DESCRIPTION
## Links
https://profuse-tea.glitch.me/

## Changes:
- Mark utils/sentry as having side effects so that it doesn't get removed from the bundle

## How To Test:
- Notice that `window.Sentry` is set here, but not on glitch.com