### PR TITLE
woozy-damselfly: fix issue with removing a project from My Stuff after creation

### DIFF
--- a/src/state/collection.js
+++ b/src/state/collection.js
@@ -95,7 +95,7 @@ export function useCollectionReload() {
 // used by featured-project and pages/project
 export const useToggleBookmark = (project) => {
   const api = useAPI();
-  const { currentUser } = useCurrentUser();
+  const { currentUser, update: updateCurrentUser } = useCurrentUser();
   const reloadCollectionProjects = useCollectionReload();
 
   const { createNotification } = useNotifications();
@@ -118,6 +118,7 @@ export const useToggleBookmark = (project) => {
         setHasBookmarked(true);
         if (!myStuffCollection) {
           myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
+          updateCurrentUser({ collections: [myStuffCollection, ...currentUser.collections] });
         }
         await addProjectToCollection({ project, collection: myStuffCollection });
         const url = myStuffCollection.fullUrl || `${currentUser.login}/${myStuffCollection.url}`;
@@ -177,7 +178,7 @@ export function useCollectionEditor(initialCollection) {
   const { handleError, handleErrorForInput, handleCustomError } = useErrorHandlers();
   const reloadCollectionProjects = useCollectionReload();
   const { createNotification } = useNotifications();
-  const { currentUser } = useCurrentUser();
+  const { currentUser, update: updateCurrentUser } = useCurrentUser();
 
   async function updateFields(changes) {
     // A note here: we don't want to setState with the data from the server from this call, as it doesn't return back the projects in depth with users and notes and things
@@ -328,6 +329,7 @@ export function useCollectionEditor(initialCollection) {
       } else {
         if (!myStuffCollection) {
           myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
+          updateCurrentUser({ collections: [myStuffCollection, ...currentUser.collections] });
         }
         await funcs.addProjectToCollection(project, myStuffCollection);
         createNotification(

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -23,7 +23,7 @@ const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler
 const useDefaultProjectOptions = () => {
   const dispatch = useDispatch();
   const { addProjectToCollection, joinTeamProject, removeUserFromProject, removeProjectFromCollection } = useAPIHandlers();
-  const { currentUser } = useCurrentUser();
+  const { currentUser, update: updateCurrentUser } = useCurrentUser();
   const { handleError, handleCustomError } = useErrorHandlers();
   const reloadProjectMembers = useProjectReload();
   const reloadCollectionProjects = useCollectionReload();
@@ -56,6 +56,7 @@ const useDefaultProjectOptions = () => {
         if (setHasBookmarked) setHasBookmarked(true);
         if (!myStuffCollection) {
           myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
+          updateCurrentUser({ collections: [myStuffCollection, ...currentUser.collections] });
         }
         await addProjectToCollection({ project, collection: myStuffCollection });
         reloadCollectionProjects([myStuffCollection]);


### PR DESCRIPTION
## Links
* Remix link: https://woozy-damselfly.glitch.me/

## Changes:
When users click on the My Stuff button for the first time they create the collection. If they then toggle it again before a page refresh, we have not refreshed the cached user's collections and so when we try to remove it, it errors out :( 
Sad we didn't find this in QA, but seems like an easy fix to just manually update the current user's collections with the newly created collection. 

## How To Test:
* create a new account (or use an account that has never used the My Stuff collection, note you will not be able to recreate this bug with a user account that has already used my stuff in the past)
* use the my stuff button to add a project to the collection
* then use it again to remove it from a collection
* notice you get an error in prod following these steps but you do not get this error in this remix. 

## Feedback I'm looking for:
anything i'm missing?

