### PR TITLE
Cleanup: Remove integration test build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,3 @@
-    
 # Glitch-Community CircleCI Config
 #
 # Note: Version 2.1 is required in order to use orbs.
@@ -12,7 +11,7 @@ jobs:
       - checkout
       - run:
           name: update-pnpm
-          command: 'sudo npm install -g pnpm@3.x'
+          command: "sudo npm install -g pnpm@3.x"
       - restore_cache:
           keys:
             - deps-{{ checksum "shrinkwrap.yaml" }}
@@ -46,7 +45,7 @@ jobs:
             - build-{{ .Revision }}
       - run:
           name: update-pnpm
-          command: 'sudo npm install -g pnpm@3.x'
+          command: "sudo npm install -g pnpm@3.x"
       - run:
           name: pnpm-install
           command: pnpm install
@@ -66,7 +65,7 @@ jobs:
             - build-{{ .Revision }}
       - run:
           name: update-pnpm
-          command: 'sudo npm install -g pnpm@3.x'
+          command: "sudo npm install -g pnpm@3.x"
       - run:
           name: pnpm-install
           command: pnpm install
@@ -78,9 +77,6 @@ workflows:
   regular-workflow:
     jobs:
       - lint_and_build
-      - integration_tests:
-          requires:
-          - lint_and_build
       - unit_tests:
           requires:
-          - lint_and_build
+            - lint_and_build


### PR DESCRIPTION
## Changes:
Until we finish some other projects to make integration testing a little easier, let's turn them off.
