### PR TITLE
Fix tests & add more & a11y fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "markdown-it-sanitizer": "^0.4.3",
     "memory-cache": "^0.2.0",
     "mini-css-extract-plugin": "^0.8.0",
-    "mocha-jsdom": "^2.0.0",
     "module-alias": "^2.2.0",
     "nodemon": "^1.19.3",
     "prop-types": "^15.7.2",
@@ -159,6 +158,7 @@
     "jsdom": "^15.1.1",
     "mocha": "^6.2.0",
     "mochapack": "^1.1.5",
+    "mocha-jsdom": "^2.0.0",
     "redux-mock-store": "^1.5.3",
     "sinon": "^7.5.0",
     "webpack-node-externals": "^1.7.2"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "markdown-it-sanitizer": "^0.4.3",
     "memory-cache": "^0.2.0",
     "mini-css-extract-plugin": "^0.8.0",
+    "mocha-jsdom": "^2.0.0",
     "module-alias": "^2.2.0",
     "nodemon": "^1.19.3",
     "prop-types": "^15.7.2",

--- a/src/components/buttons/bookmark-button.js
+++ b/src/components/buttons/bookmark-button.js
@@ -160,6 +160,7 @@ const BookmarkButton = ({ action, initialIsBookmarked, containerDetails, project
       <div
         className={`${styles.bookmarkButton} ${state.isFocused ? styles.focused : ''} ${state.isVisible ? styles.visible : ''}`}
         aria-label={`Add ${projectName} to My Stuff`}
+        role="img"
       >
         <Halo isAnimating={state.isAnimating} onAnimationEnd={onAnimationEnd} />
         {state.isBookmarked ? <FilledBookmark /> : <EmptyBookmark />}

--- a/src/components/buttons/bookmark-button.js
+++ b/src/components/buttons/bookmark-button.js
@@ -157,7 +157,7 @@ const BookmarkButton = ({ action, initialIsBookmarked, containerDetails, project
 
   return (
     <HiddenCheckbox value={state.isBookmarked} onChange={onClick} onFocus={onFocus} onBlur={onBlur}>
-      <div
+      <span
         className={`${styles.bookmarkButton} ${state.isFocused ? styles.focused : ''} ${state.isVisible ? styles.visible : ''}`}
         aria-label={`Add ${projectName} to My Stuff`}
         role="img"
@@ -165,7 +165,7 @@ const BookmarkButton = ({ action, initialIsBookmarked, containerDetails, project
         <Halo isAnimating={state.isAnimating} onAnimationEnd={onAnimationEnd} />
         {state.isBookmarked ? <FilledBookmark /> : <EmptyBookmark />}
         <Image className={checkClassName} src={CHECKMARK} onAnimationEnd={onAnimationEnd} alt="" width="10px" height="10px" />
-      </div>
+      </span>
     </HiddenCheckbox>
   );
 };

--- a/src/components/private-badge/index.js
+++ b/src/components/private-badge/index.js
@@ -48,7 +48,7 @@ export const PrivateToggle = ({ isPrivate, setPrivate, type, align }) => {
       tooltip={isPrivate ? TYPES[type].privateText : TYPES[type].publicText}
       target={
         <HiddenCheckbox value={isPrivate} onChange={setPrivate} onFocus={() => setFocus(true)} onBlur={() => setFocus(false)}>
-          <span aria-label="Mark as private" className={classnames(styles.privateIcon, styles.privateButton, isPrivate ? styles.private : styles.public, isFocused && styles.focused)}>
+          <span role="img" aria-label="Mark as private" className={classnames(styles.privateIcon, styles.privateButton, isPrivate ? styles.private : styles.public, isFocused && styles.focused)}>
             {isPrivate ? <Icon icon="private" alt="private" /> : <Icon icon="public" alt="public" />}
           </span>
         </HiddenCheckbox>

--- a/test/components/private-badge.js
+++ b/test/components/private-badge.js
@@ -6,7 +6,6 @@ import configureStore from 'redux-mock-store';
 import sinon from 'sinon';
 import { MemoryRouter } from 'react-router-dom';
 import Location from '@jedmao/location';
-
 import { PrivateToggle } from 'Components/private-badge';
 
 import { a11yHelper } from '../reactA11yHelper';

--- a/test/components/private-badge.js
+++ b/test/components/private-badge.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import chai from 'chai';
+import configureStore from 'redux-mock-store';
+import sinon from 'sinon';
+import { MemoryRouter } from 'react-router-dom';
+import Location from '@jedmao/location';
+
+import { PrivateToggle } from 'Components/private-badge';
+
+import { a11yHelper } from '../reactA11yHelper';
+import { makeTestProject, makeTestUser } from '../helpers/models';
+
+chai.should();
+const middlewares = [];
+const mockStore = configureStore(middlewares);
+configure({ adapter: new Adapter() });
+
+describe('PrivateBadge', function() {
+  it('should have no a11y errors', function() {
+    const component = <PrivateToggle align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
+    a11yHelper.testEnzymeComponent(component, {}, function(results) {
+      results.violations.length.should.equal(0);
+    });
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,26 +1,7 @@
-const { JSDOM } = require('jsdom');
+const jsdom = require('mocha-jsdom');
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
-const { window } = jsdom;
+jsdom({
+  url: 'https://glitch.com/',
+});
 
-function copyProps(src, target) {
-  Object.defineProperties(target, {
-    ...Object.getOwnPropertyDescriptors(src),
-    ...Object.getOwnPropertyDescriptors(target),
-  });
-}
-
-global.window = window;
-global.document = window.document;
-global.navigator = {
-  userAgent: 'node.js',
-};
-global.requestAnimationFrame = function (callback) {
-  return setTimeout(callback, 0);
-};
-global.cancelAnimationFrame = function (id) {
-  clearTimeout(id);
-};
-copyProps(window, global);
-
-var ENVIRONMENT = "testing";
+var ENVIRONMENT = "testing"; 


### PR DESCRIPTION
## Links
* Remix link
* https://github.com/FogCreek/Glitch-Community-Work/issues/542

## GIF/Screenshots:
no visual changes

## Changes:
* Adds a package called mocha-jsdom which does jsdom setup + teardown 
  * This prevents a memory leak which can lead to a timeout of mocha
* Adds a unit test for the PrivateToggle component
* Adds a role to the children of hidden checkbox for greater assistive technology compatability
* makes BookmarkButton's child a span because labels can't semantically contain divs


## How To Test:
* Make sure the bookmark button looks/acts the same

