### PR TITLE
Nova chance: Disable cloudfront caching of html

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -39,7 +39,7 @@ module.exports = function(external) {
   initWebpack(app);
   const buildTime = dayjs();
 
-  const ms = dayjs.convert(7, 'days', 'miliseconds');
+  const ms = dayjs.convert(7, 'days', 'milliseconds');
   app.use(express.static('public', { index: false }));
   app.use(express.static('build/client', { index: false, maxAge: ms }));
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -128,7 +128,7 @@ module.exports = function(external) {
   );
 
   app.use(function(req, res, next) {
-    res.header('Cache-Control', 'public, max-age=1');
+    res.header('Cache-Control', 'no-cache');
     return next();
   });
 


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me/

## Changes:
- Changed `Cache-Control` to `no-cache` for all community pages (does not include proxied pages or js)
- Fixed a typo in the js cache time, doesn't actually change anything because the default was milliseconds

## How To Test:
- Load up the site, the html should have a `no-cache` header. JS and proxied pages should still be cached
- Pull up glitch.com and see how often you get `Hit from Cloudfront` in the response headers, it seems very rare for me (make sure the dev tools aren't disabling the browser cache)

## Things left to do before deploying:
This is a test for ssr optimizely, so I'll have to be ready to roll back in case this breaks the site