### PR TITLE
Ivy crib: Fix/Update Analytics Events

### DIFF
--- a/src/components/collection/container.js
+++ b/src/components/collection/container.js
@@ -65,7 +65,11 @@ const CollectionContainer = ({ collection, showFeaturedProject, isAuthorized, pr
 
   const setPrivate = useTrackedFunc(
     () => funcs.updatePrivacy(!collection.private),
-    `Collection toggled ${collection.private ? 'public' : 'private'}`,
+    'Collection Privacy Changed',
+    (inherited) => ({
+      ...inherited,
+      isSettingToPrivate: !collection.private,
+    }),
   );
 
   return (

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -69,12 +69,13 @@ const FeaturedProject = ({
 
   const isAnonymousUser = !currentUser.login;
 
-  const bookmarkAction = useTrackedFunc(toggleBookmark, `Project ${hasBookmarked ? 'removed from my stuff' : 'added to my stuff'}`, (inherited) => ({
+  const bookmarkAction = useTrackedFunc(toggleBookmark, 'My Stuff Button Clicked', (inherited) => ({
     ...inherited,
     projectName: featuredProject.domain,
     baseProjectId: featuredProject.baseId || featuredProject.baseProject,
     userId: currentUser.id,
     origin: `${inherited.origin}-featured-project`,
+    isAddingToMyStuff: !hasBookmarked,
   }));
 
   return (

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -31,8 +31,8 @@ EditButton.defaultProps = {
   isMember: false,
 };
 
-export const RemixButton = ({ name, isMember }) => (
-  <Button as="a" href={getRemixUrl(name)} size="small">
+export const RemixButton = ({ name, isMember, onClick }) => (
+  <Button as="a" href={getRemixUrl(name)} size="small" onClick={onClick || undefined}>
     {isMember ? 'Remix This' : 'Remix your own'} <Icon className={emoji} icon="microphone" />
   </Button>
 );

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -65,8 +65,14 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
 
   const bookmarkAction = useTrackedFunc(
     () => projectOptions.toggleBookmark(project, hasBookmarked, setHasBookmarked),
-    `Project ${hasBookmarked ? 'removed from my stuff' : 'added to my stuff'}`,
-    (inherited) => ({ ...inherited, projectName: project.domain, baseProjectId: project.baseId || project.baseProject, userId: currentUser.id }),
+    'My Stuff Button Clicked',
+    (inherited) => ({
+      ...inherited,
+      projectName: project.domain,
+      baseProjectId: project.baseId || project.baseProject,
+      userId: currentUser.id,
+      isAddingToMyStuff: !hasBookmarked,
+    }),
   );
 
   const sequence = (doAnimation, projectOption) => {

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -147,11 +147,12 @@ const ProjectPage = ({ project: initialProject }) => {
 
   const { addProjectToCollection } = useAPIHandlers();
 
-  const bookmarkAction = useTrackedFunc(toggleBookmark, `Project ${hasBookmarked ? 'removed from my stuff' : 'added to my stuff'}`, (inherited) => ({
+  const bookmarkAction = useTrackedFunc(toggleBookmark, 'My Stuff Button Clicked', (inherited) => ({
     ...inherited,
     projectName: project.domain,
     baseProjectId: project.baseId,
     userId: currentUser.id,
+    isAddingToMyStuff: !hasBookmarked,
   }));
 
   const addProjectToCollectionAndSetHasBookmarked = (projectToAdd, collection) => {

--- a/src/state/segment-analytics.js
+++ b/src/state/segment-analytics.js
@@ -39,11 +39,13 @@ AnalyticsContext.defaultProps = {
 };
 
 export const useTracker = (name, properties, context) => {
+  console.log("useTracker!", name, properties, context)
   const inherited = React.useContext(Context);
   return () => {
     try {
       analytics.track(name, resolveProperties(properties, inherited.properties), resolveProperties(context, inherited.context));
     } catch (error) {
+      console.log("got an error", error)
       /*
       From Segment: "We currently return a 200 response for all API requests so debugging should be done in the Segment Debugger.
       The only exception is if the request is too large / json is invalid it will respond with a 400."

--- a/src/state/segment-analytics.js
+++ b/src/state/segment-analytics.js
@@ -42,10 +42,8 @@ export const useTracker = (name, properties, context) => {
   const inherited = React.useContext(Context);
   return () => {
     try {
-      console.log("making an analytics call", name, resolveProperties(properties, inherited.properties, resolveProperties(context, inherited.context)))
       analytics.track(name, resolveProperties(properties, inherited.properties), resolveProperties(context, inherited.context));
     } catch (error) {
-      console.log("got an error", error)
       /*
       From Segment: "We currently return a 200 response for all API requests so debugging should be done in the Segment Debugger.
       The only exception is if the request is too large / json is invalid it will respond with a 400."

--- a/src/state/segment-analytics.js
+++ b/src/state/segment-analytics.js
@@ -39,10 +39,10 @@ AnalyticsContext.defaultProps = {
 };
 
 export const useTracker = (name, properties, context) => {
-  console.log("useTracker!", name, properties, context)
   const inherited = React.useContext(Context);
   return () => {
     try {
+      console.log("making an analytics call", name, resolveProperties(properties, inherited.properties, resolveProperties(context, inherited.context)))
       analytics.track(name, resolveProperties(properties, inherited.properties), resolveProperties(context, inherited.context));
     } catch (error) {
       console.log("got an error", error)


### PR DESCRIPTION
## Links
* Remix link: https://ivy-crib.glitch.me
* Issue-tracker link
    - https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/538
    - https://app.zenhub.com/workspaces/community-5d07d1359dee6059a9688176/issues/fogcreek/glitch-community-work/534

## Changes:
* fix a broken analytics event on the remix this button
* change our analytics calls on the My Stuff and Privacy Toggles, per request of ezra

## How To Test:
* open segment's debugger https://app.segment.com/fogcreek/sources/glitch_website/debugger
* search for My Stuff
* open the remix and press the My Stuff button from a variety of places, you should see the events come through (though it is admittedly a bit flakey i find)
* do the same for "Collection Privacy Changed"

## Feedback I'm looking for:
Anything I'm missing?
