### PR TITLE
Profuse-tea: Filter optimizely network errors out of sentry

### DIFF
--- a/shared/sentryHelpers.js
+++ b/shared/sentryHelpers.js
@@ -10,7 +10,7 @@ const filterSecrets = function(jsonEvent) {
   return jsonEvent;
 };
 
-const ignoreErrors = ['Network Error', 'timeout', 'status code 401'];
+const ignoreErrors = ['Network Error', 'Request error', 'timeout', 'status code 401'];
 
 const beforeSend = function(projectDomain, apiEnv, event) {
   if (!onProductionSite(projectDomain, apiEnv)) {


### PR DESCRIPTION
## Links
https://profuse-tea.glitch.me/
https://github.com/FogCreek/Glitch-Community-Work/issues/544

## Changes:
Add an extra ignore errors entry because it's flooding sentry and sentry isn't merging them on its own

## How To Test:
Do a search on sentry and notice that all 'Request error' errors are optimizely. (I've merged 100 or so into the 87k events one, there are probably new errors since then)