### PR TITLE
Calm babcat: Updated UI for Exploring Collections (Play Mode)

### DIFF
--- a/src/components/collection/collection-projects-player.js
+++ b/src/components/collection/collection-projects-player.js
@@ -9,9 +9,7 @@ import { chunk, findIndex } from 'lodash';
 import { Icon, Popover, ResultsList, ResultItem, ResultName, UnstyledButton, ButtonGroup, ButtonSegment } from '@fogcreek/shared-components';
 import Markdown from 'Components/text/markdown';
 import FeaturedProject from 'Components/project/featured-project';
-import ProfileList from 'Components/profile-list';
 import { ProjectAvatar } from 'Components/images/avatar';
-import { useProjectMembers } from 'State/project';
 import { ProjectLink } from 'Components/link';
 import Text from 'Components/text/text';
 
@@ -114,7 +112,7 @@ const PlayerControls = ({ featuredProject, currentProjectIndex, setCurrentProjec
         <Markdown length={80}>{featuredProject.description || ' '}</Markdown>
       </div>
 
-      <div className={classnames(styles.projectCounter, isDarkColor(collection.coverColor && styles.dark))}>
+      <div className={classnames(styles.projectCounter, isDarkColor(collection.coverColor) && styles.dark)}>
         {currentProjectIndex + 1}/{projects.length}
       </div>
 
@@ -172,7 +170,6 @@ const CollectionProjectsPlayer = withRouter(({ history, match, isAuthorized, fun
               <Text>{featuredProject.domain}</Text>
             </ProjectLink>
           )}
-
         </div>
       </div>
       <FeaturedProject

--- a/src/components/collection/collection-projects-player.js
+++ b/src/components/collection/collection-projects-player.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { withRouter } from 'react-router-dom';
 import classnames from 'classnames';
-import { isDarkColor } from 'Utils/color';
+import { hexToRgbA, isDarkColor } from 'Utils/color';
 
 import { chunk, findIndex } from 'lodash';
 import { Icon, Popover, ResultsList, ResultItem, ResultName, UnstyledButton, ButtonGroup, ButtonSegment } from '@fogcreek/shared-components';
@@ -109,6 +109,15 @@ const PlayerControls = ({ featuredProject, currentProjectIndex, setCurrentProjec
           </div>
         )}
       </Popover>
+
+      <div className={classnames(styles.playerDescription, isDarkColor(collection.coverColor) && styles.dark)}>
+        <Markdown length={80}>{featuredProject.description || ' '}</Markdown>
+      </div>
+
+      <div className={classnames(styles.projectCounter, isDarkColor(collection.coverColor && styles.dark))}>
+        {currentProjectIndex + 1}/{projects.length}
+      </div>
+
       <div className={styles.buttonWrap}>
         <ButtonGroup variant="primary" size="normal">
           <ButtonSegment onClick={back} disabled={currentProjectIndex === 0}>
@@ -139,13 +148,11 @@ const CollectionProjectsPlayer = withRouter(({ history, match, isAuthorized, fun
 
   const featuredProject = projects[currentProjectIndex];
 
-  const { value: members } = useProjectMembers(featuredProject.id);
-
   return (
     <>
       <div
         className={classnames(styles.playerContainer, isDarkColor(collection.coverColor) && styles.dark)}
-        style={{ backgroundColor: collection.coverColor, borderColor: collection.coverColor }}
+        style={{ backgroundColor: hexToRgbA(collection.coverColor), borderColor: collection.coverColor }}
       >
         <div className={styles.playerHeader}>
           {projects.length > 1 ? (
@@ -165,17 +172,7 @@ const CollectionProjectsPlayer = withRouter(({ history, match, isAuthorized, fun
               <Text>{featuredProject.domain}</Text>
             </ProjectLink>
           )}
-        </div>
-        <div className={styles.playerDescription}>
-          <Markdown length={80}>{featuredProject.description || ' '}</Markdown>
-          {members && (
-            <div className={styles.membersContainer}>
-              <ProfileList layout="row" {...members} />
-            </div>
-          )}
-        </div>
-        <div className={styles.projectCounter}>
-          {currentProjectIndex + 1}/{projects.length}
+
         </div>
       </div>
       <FeaturedProject

--- a/src/components/collection/collection-projects-player.styl
+++ b/src/components/collection/collection-projects-player.styl
@@ -9,13 +9,13 @@
     color: white
 
 .playerHeader
-  padding: 12px
+  padding: 12px 20px
   display: flex
 
 // PlayerControls
 .popoverButton
   padding: 0 12px
-  border-radius: 3px
+  border-radius: 5px
   display: flex
   > *
     align-self: center
@@ -45,7 +45,7 @@
   color: tertiary
   align-self: center
   flex-grow: 1
-  margin-right: 20px
+  margin: 0 20px
   text-align: right
   &.dark
     color: white

--- a/src/components/collection/collection-projects-player.styl
+++ b/src/components/collection/collection-projects-player.styl
@@ -43,7 +43,8 @@
 .projectCounter
   font-size: 14px
   color: tertiary
-  align-self: center
+  align-self: flex-start
+  padding: 8px 0 0
   flex-grow: 1
   margin: 0 20px
   text-align: right

--- a/src/components/collection/collection-projects-player.styl
+++ b/src/components/collection/collection-projects-player.styl
@@ -2,44 +2,53 @@
 
 // CollectionProjectsPlayer
 .playerContainer
-  border: 2px solid
-  border-radius: 5px
-  max-width: 400px
+  border-bottom: 1px solid
+  width: calc(100% + 40px)
+  margin: -20px -20px 20px -20px
   &.dark
     color: white
 
 .playerHeader
-  padding: 12px 12px 12px 0
+  padding: 12px
   display: flex
-
-.playerDescription
-  background-color: white
-  color: black
-  padding: 12px
-
-.membersContainer
-  margin-top: 10px
-
-.projectCounter
-  background-color: secondary-background
-  color: black
-  border-bottom-left-radius: 5px
-  border-bottom-right-radius: 5px
-  padding: 12px
 
 // PlayerControls
 .popoverButton
-  padding-left: 12px
+  padding: 0 12px
+  border-radius: 3px
   display: flex
   > *
     align-self: center
+  background-color: overlay-background
   p 
     padding: 5px
     font-weight: 600
     color: black
   &.dark
+    background-color: tertiary
     p
       color: white
+  
+.playerDescription
+  font-size: 14px
+  margin-top: -0.2rem
+  flex-grow: 2
+  margin-left: 20px
+  font-family: monospace
+  &.dark
+    color: white
+  @media(max-width: mediumViewport)
+    display: none
+
+.projectCounter
+  font-size: 14px
+  color: tertiary
+  align-self: center
+  flex-grow: 1
+  margin-right: 20px
+  text-align: right
+  &.dark
+    color: white
 
 .projectAvatar
   img

--- a/src/components/collection/container.styl
+++ b/src/components/collection/container.styl
@@ -36,8 +36,6 @@
   padding: 20px
   background-color: secondary-background
   border-radius: 0 0 5px 5px
-  @media (min-width: largeViewport)
-    border-radius: 0 5px 5px 0
     
   article
     margin: 0

--- a/src/components/text/markdown.styl
+++ b/src/components/text/markdown.styl
@@ -2,7 +2,7 @@
 
 .markdownContent
   text-rendering: optimizeLegibility
-  font-family: sansserif
+  font-family: inherit
   line-height: 20px
   word-break: break-word
   


### PR DESCRIPTION
## Links
* Remix link: https://calm-babcat.glitch.me/@glitch/glitch-team-faves/play

## GIF/Screenshots:
![collection-nav](https://user-images.githubusercontent.com/519336/67030527-96cd8200-f0dd-11e9-828b-0692a130bb4a.gif)


## Changes:
* Edited the UI of the projects player for exploring collections to make it more streamlined and take up less space on the page.

## How To Test:
* Check on desktop that you can view the project name, description, counter, and controls on a collection playlist: https://calm-babcat.glitch.me/@glitch/glitch-team-faves/play
* Check when viewing it on mobile that the collection description disappears
* Check that it looks right with dark colored collections: https://calm-babcat.glitch.me/@scientiffic/microbit/play/04e6b592-f7d3-43a4-aab8-7f52e3e34931

## Feedback I'm looking for:
- Does the layout look right on all viewport sizes?
