### PR TITLE
Lackadaisical almandine: unsmoosh images on about and careers page

### DIFF
--- a/src/presenters/pages/about/about.styl
+++ b/src/presenters/pages/about/about.styl
@@ -208,10 +208,13 @@ body[data-grey]
 .imageRow
   margin-top: 1rem;
   display: flex;
-.imageRow img
-  max-width: calc(33% - 24px)
-  margin: 12px;
-  border-radius: 5px;
+  div
+    flex: 1;
+    margin: 12px;
+  img
+    width: 100%;
+    display: block;
+    border-radius: 5px;
 
 .thirdSectionButton 
   flex: 0 1 auto;

--- a/src/presenters/pages/about/careers.js
+++ b/src/presenters/pages/about/careers.js
@@ -126,18 +126,24 @@ const AboutCareersPage = withRouter(() => {
       </BlockSection>
       <section className={aboutStyles.backgroundSection}>
         <article className={styles.photoSection}>
-          <img
-            src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F993109ed1c7580173f8e602f3d6e881d-xlarge.jpg?1559307581786"
-            alt="Glitch staff working"
-          />
-          <img
-            src="https://cdn.glitch.com/d2b595e6-45a6-4ddc-8110-038cdb509b16%2Fbaf5e6e3eb8c3c9274bb56e3105ed452-large.jpg"
-            alt="Glitch staff walking"
-          />
-          <img
-            src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F0b1613403bacaeaf9e4f28db84bc5e75-xlarge.jpg?1559307583178"
-            alt="Glitch staff playing video games"
-          />
+          <div>
+            <img
+              src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F993109ed1c7580173f8e602f3d6e881d-xlarge.jpg?1559307581786"
+              alt="Glitch staff working"
+            />
+          </div>
+          <div>
+            <img
+              src="https://cdn.glitch.com/d2b595e6-45a6-4ddc-8110-038cdb509b16%2Fbaf5e6e3eb8c3c9274bb56e3105ed452-large.jpg"
+              alt="Glitch staff walking"
+            />
+          </div>
+          <div>
+            <img
+              src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F0b1613403bacaeaf9e4f28db84bc5e75-xlarge.jpg?1559307583178"
+              alt="Glitch staff playing video games"
+            />
+          </div>
         </article>
       </section>
       <BlockSection>
@@ -184,18 +190,24 @@ const AboutCareersPage = withRouter(() => {
       </BlockSection>
       <section className={aboutStyles.backgroundSection}>
         <article className={styles.photoSection}>
-          <img
-            src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2Fd92f352ab54cfd9be0457776317e0ec6-xlarge.jpg?1559307599792"
-            alt="Glitch staff talking"
-          />
-          <img
-            src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F7f2b4dd2435996315bb77787f0c38d0b-xlarge.jpg?1559307600387"
-            alt="Looky What We Made zine"
-          />
-          <img
-            src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F1e196309fd17fa4af027de3c345fc12f-xlarge.jpg?1559307839260"
-            alt="Glitch staff talking"
-          />
+          <div>
+            <img
+              src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2Fd92f352ab54cfd9be0457776317e0ec6-xlarge.jpg?1559307599792"
+              alt="Glitch staff talking"
+            />
+          </div>
+          <div>
+            <img
+              src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F7f2b4dd2435996315bb77787f0c38d0b-xlarge.jpg?1559307600387"
+              alt="Looky What We Made zine"
+            />
+          </div>
+          <div>
+            <img
+              src="https://cdn.glitch.com/b205c719-a61d-400a-9e80-8784c201e1d2%2F1e196309fd17fa4af027de3c345fc12f-xlarge.jpg?1559307839260"
+              alt="Glitch staff talking"
+            />
+          </div>
         </article>
       </section>
       <section>

--- a/src/presenters/pages/about/careers.styl
+++ b/src/presenters/pages/about/careers.styl
@@ -3,8 +3,10 @@
   display: flex
   @media(max-width: 968px)
       display: none
+  div
+    flex: 1;
+    padding: 12px;
   img 
-    max-width: calc(33% - 21px)
-    margin: 12px
-    margin-bottom: 8px
-    border-radius: 5px
+    display: block;
+    width: 100%;
+    border-radius: 5px;

--- a/src/presenters/pages/about/index.js
+++ b/src/presenters/pages/about/index.js
@@ -150,12 +150,18 @@ function ThirdSection() {
         descriptionText="We’re here to push the tech world to do better. We aim to set the standard for thoughtful and ethical practices in tech."
       />
       <div className={styles.imageRow}>
-        <img src={`${CDN_URL}/d2b595e6-45a6-4ddc-8110-038cdb509b16%2F1727f742f11aad77bc90a650cc0e8f1d-large.jpg`} alt="Glitch staff talking" />
-        <img
-          src={`${CDN_URL}/b205c719-a61d-400a-9e80-8784c201e1d2%2F91f31d4a0ca5cbd21d7296c723122afb-xlarge.jpg?1559307581223`}
-          alt="bag with 'You Got This' and a skateboarding turtle printed on it"
-        />
-        <img src={`${CDN_URL}/d2b595e6-45a6-4ddc-8110-038cdb509b16%2Fa64374d243f81b26f3d3742d4959cb84-large.jpg`} alt="Glitch staff smiling" />
+        <div>
+          <img src={`${CDN_URL}/d2b595e6-45a6-4ddc-8110-038cdb509b16%2F1727f742f11aad77bc90a650cc0e8f1d-large.jpg`} alt="Glitch staff talking" />
+        </div>
+        <div>
+          <img
+            src={`${CDN_URL}/b205c719-a61d-400a-9e80-8784c201e1d2%2F91f31d4a0ca5cbd21d7296c723122afb-xlarge.jpg?1559307581223`}
+            alt="bag with 'You Got This' and a skateboarding turtle printed on it"
+          />
+        </div>
+        <div>
+          <img src={`${CDN_URL}/d2b595e6-45a6-4ddc-8110-038cdb509b16%2Fa64374d243f81b26f3d3742d4959cb84-large.jpg`} alt="Glitch staff smiling" />
+        </div>
       </div>
       <Button className={styles.thirdSectionButton} as="a" href="https://glitch.com/about/company">
         Find Out What Makes Glitch Different <span aria-hidden="true">→</span>


### PR DESCRIPTION
## Links
* Remix link: https://lackadaisical-almandine.glitch.me/about/careers/

## GIF/Screenshots:
Before: 
<img width="1156" alt="Screen Shot 2019-10-18 at 11 51 37 AM" src="https://user-images.githubusercontent.com/6620164/67109117-d65ba300-f19d-11e9-8716-cc307f629161.png">

After:
<img width="1095" alt="Screen Shot 2019-10-18 at 11 51 21 AM" src="https://user-images.githubusercontent.com/6620164/67109116-d65ba300-f19d-11e9-9f74-669a9956352c.png">

## Changes:
* fixes a safari style bug that was brought to our attention by 👏 glitch user https://glitch.com/@graygilmore 👏 with a potential fix already demoed here:  🆒 https://glitch.com/~deep-curiosity 🆒

## How To Test:
* check out the careers page on safari (and other browsers too!) ensure all the images look good


