### PR TITLE
Quartz latency: Replace Magikarp Image

### DIFF
--- a/src/components/global.styl
+++ b/src/components/global.styl
@@ -78,11 +78,8 @@ section
     #fallback
       main
         width: 700px
-        position: absolute
-        top: 40%
-        left: 50%
+        margin: 0 auto
         display: flex
-        transform: translate(-50%, -40%)
       #fallback-img
         padding: 0
         float: left
@@ -92,3 +89,4 @@ section
         width: 350px
         margin-top: 65px
         height: max-content
+        align-self: center

--- a/src/components/global.styl
+++ b/src/components/global.styl
@@ -81,6 +81,7 @@ section
         position: absolute
         top: 40%
         left: 50%
+        display: flex
         transform: translate(-50%, -40%)
       #fallback-img
         padding: 0
@@ -90,3 +91,4 @@ section
         float: left
         width: 350px
         margin-top: 65px
+        height: max-content

--- a/src/presenters/pages/error.js
+++ b/src/presenters/pages/error.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet-async';
 import { Button } from '@fogcreek/shared-components';
 
+import { CDN_URL } from 'Utils/constants';
+
 import Image from 'Components/images/image';
 import Text from 'Components/text/text';
 import Heading from 'Components/text/heading';
@@ -36,7 +38,7 @@ export const NotFoundPage = () => {
   );
 };
 
-const emailImageUrl = 'https://cdn.glitch.com/26ac422d-705d-42be-b9cb-1fbdfe7e5a63%2Ferror-mailer.svg?1543429767321';
+const emailImageUrl = `${CDN_URL}/26ac422d-705d-42be-b9cb-1fbdfe7e5a63%2Ferror-mailer.svg?1543429767321`;
 
 export const EmailErrorPage = ({ title, description }) => (
   <Layout>
@@ -53,7 +55,7 @@ EmailErrorPage.propTypes = {
   description: PropTypes.string.isRequired,
 };
 
-const oauthImageUrl = 'https://cdn.glitch.com/8ae9b195-ef39-406b-aee0-764888d15665%2Foauth-key.svg?1544466885907';
+const oauthImageUrl = `${CDN_URL}/02863ac1-a499-4a41-ac9c-41792950000f%2Foauth.svg?v=1571423403881`;
 
 export const OauthErrorPage = ({ title, description }) => (
   <Layout>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -53,7 +53,7 @@
           </a>
         </header>
           <main>
-            <img id="fallback-img" alt="" style="display: none" src="https://cdn.glitch.com/dbd73211-c667-4832-9229-c27f4cb66f5c%2Fmagikarp-illust.svg?1542746418939"/>
+            <img id="fallback-img" alt="" style="display: none" src="https://cdn.glitch.com/02863ac1-a499-4a41-ac9c-41792950000f%2Fbonsai.svg?v=157142334"/>
             <div class="error-msg" id="fallback-noscript" style="display: none">
               <h1>The web browser that you're using does not support Javascript</h1>
               <p>Since Glitch requires Javascript to run, please try using Glitch in a different web browser.</p>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -90,8 +90,6 @@
         container.style.display = 'none';
       }
       
-      showFallback('notbuilt');
-      
       var isIe = /Trident\/[7]{1}/i.test(navigator.userAgent);
       var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com"; 
       

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -89,8 +89,12 @@
         document.getElementById('fallback-' + name).removeAttribute('style');
         container.style.display = 'none';
       }
+      
+      showFallback('notbuilt');
+      
       var isIe = /Trident\/[7]{1}/i.test(navigator.userAgent);
-      var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com";
+      var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com"; 
+      
       if (isIe) {
         // ie doesn't support our css
         showFallback('ie');


### PR DESCRIPTION
## Links
* Remix link: https://quartz-latency.glitch.me/
* Issue-tracker link: https://github.com/FogCreek/Glitch-Community-Work/issues/504#issuecomment-543247130

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/519336/67124065-bc32bc80-f1bf-11e9-8492-e9fde2157378.png)

## Changes:
* Replaced the Magikarp image with a bonsai tree

## How To Test:
* The only way I knew how to do this was to force view the error page is to go into `/views/index.ejs` and to run `showFallback('notbuilt');` to the script a the bottom of the file.
