### PR TITLE
Edited password meter styling

### DIFF
--- a/src/components/new-password-input/password-strength.js
+++ b/src/components/new-password-input/password-strength.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { Icon } from '@fogcreek/shared-components';
 
 import styles from './password-strength.styl';
@@ -13,9 +12,10 @@ const PasswordStrength = ({ strength }) => {
     2: <><Icon className={emoji} icon="faceSlightlySmiling" /> okay</>,
     3: <><Icon className={emoji} icon="bicep" /> strong</>,
   };
+
   return (
     <div className={styles.container}>
-      <progress value={Math.max(strength, 1)} max="3" className={classNames(styles.meter, styles[`score${strength}`])} />
+      <progress value={Math.max(strength, 0)} max="3" className={styles[`score${strength}`]} />
       <span className={styles.word}>
         {labels[strength]}
       </span>

--- a/src/components/new-password-input/password-strength.styl
+++ b/src/components/new-password-input/password-strength.styl
@@ -4,21 +4,23 @@
   margin-top: 5px
   margin-bottom: 5px
 
-.meter
+progress[value]
   width: calc(100% - 80px)
   display: inline-block
-  vertical-align: -webkit-baseline-middle
-  background: secondary-background
+  appearance: none
 
-.score0
-  &::-webkit-progress-value, &::-moz-progress-bar
+  &::-webkit-progress-bar
+    background-color: secondary-background
+    border-radius: 3px
+  &::-webkit-progress-value
+    border-radius: 3px
+  &.score0::-webkit-progress-value
     background-color: warning
-.score1, .score2
-  &::-webkit-progress-value, &::-moz-progress-bar
-    background-color: notification
-.score3
-  &::-webkit-progress-value, &::-moz-progress-bar
+  &.score1::-webkit-progress-value, &.score2::-webkit-progress-value
+    background-color: notification 
+  &.score3::-webkit-progress-value
     background-color: success
+
 
 .word
   float: right


### PR DESCRIPTION
## Links
* Remix link: https://grandiose-kumquat.glitch.me/

## GIF/Screenshots:
![password](https://user-images.githubusercontent.com/519336/67231721-e679b980-f40d-11e9-9076-5c5e1035a9c7.gif)

## Changes:
* The password meter styling got reverted at some point, so I'm adding it back.

## How To Test:
* Log into https://grandiose-kumquat.glitch.me/
* go to account settings and try typing in a password
* if you have a weak password, the color of the progress bar should be pink (`warning`) - example weak PW: `password`
* if you have an ok password, the color of the progress bar should be purple (`notification`) - example ok password `password2`
* if you have a strong password, the color of the progress bar should be green (`success`)
example ok password `password2N@`


