### PR TITLE
Profuse tea: Fix project page flicker, one path for 404 errors

### DIFF
--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -45,16 +45,7 @@ const ProjectsDataLoader = ({ children, type, id, ignoreProjectId }) => {
   const args = useMemo(() => ({ type, id, ignoreProjectId }), [type, id, ignoreProjectId]);
   return (
     <DataLoader get={getProjects} args={args}>
-      {(projects) =>
-        projects && projects.length > 0 && (
-          <>
-            <h2>
-              <TeamLink team={team}>More by {team.name} <Icon className={styles.arrow} icon="arrowRight" /></TeamLink>
-            </h2>
-            <RelatedProjectsBody projects={projects} type="team" item={team} />
-          </>
-        )
-      }
+      {(projects) => projects && projects.length > 0 && children(projects)}
     </DataLoader>
   );
 };
@@ -63,9 +54,6 @@ const RelatedProjects = ({ project }) => {
   const teams = useSample(project.teams || [], 1);
   const users = useSample(project.users || [], 2 - teams.length);
 
-  const ignoreProjectId = project.id;
-  const getUserProjects = useCallback((api, id) => getProjects(api, { type: 'user', id, ignoreProjectId }), [ignoreProjectId]);
-
   if (!teams.length && !users.length) {
     return null;
   }
@@ -73,39 +61,35 @@ const RelatedProjects = ({ project }) => {
     <ul className={styles.container}>
       {teams.map((team) => (
         <li key={team.id}>
-          <DataLoader get={getTeamProjects} args={team.id}>
-            {(projects) =>
-              projects && projects.length > 0 && (
-                <>
-                  <h2>
-                    <TeamLink team={team}>More by {team.name} <Icon className={styles.arrow} icon="arrowRight" /></TeamLink>
-                  </h2>
-                  <RelatedProjectsBody projects={projects} type="team" item={team} />
-                </>
-              )
-            }
-          </DataLoader>
+          <ProjectsDataLoader type="team" id={team.id} ignoreProjectId={project.id}>
+            {(projects) => (
+              <>
+                <h2>
+                  <TeamLink team={team}>More by {team.name} <Icon className={styles.arrow} icon="arrowRight" /></TeamLink>
+                </h2>
+                <RelatedProjectsBody projects={projects} type="team" item={team} />
+              </>
+            )}
+          </ProjectsDataLoader>
         </li>
       ))}
       {users.map((user) => (
         <li key={user.id}>
-          <DataLoader get={getUserProjects} args={user.id}>
-            {(projects) =>
-              projects && projects.length > 0 && (
-                <>
-                  <h2>
-                    <UserLink user={user}>More by {getDisplayName(user)} <Icon className={styles.arrow} icon="arrowRight" /></UserLink>
-                  </h2>
-                  <RelatedProjectsBody projects={projects} type="user" item={user} />
-                </>
-              )
-            }
-          </DataLoader>
+          <ProjectsDataLoader type="user" id={user.id} ignoreProjectId={project.id}>
+            {(projects) => (
+              <>
+                <h2>
+                  <UserLink user={user}>More by {getDisplayName(user)} <Icon className={styles.arrow} icon="arrowRight" /></UserLink>
+                </h2>
+                <RelatedProjectsBody projects={projects} type="user" item={user} />
+              </>
+            )}
+          </ProjectsDataLoader>
         </li>
       ))}
     </ul>
   );
-}
+};
 RelatedProjects.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/components/related-projects/index.js
+++ b/src/components/related-projects/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { sampleSize } from 'lodash';
 import { Icon } from '@fogcreek/shared-components';
@@ -45,6 +45,7 @@ function RelatedProjects({ project }) {
   const teams = useSample(project.teams || [], 1);
   const users = useSample(project.users || [], 2 - teams.length);
   const ignoreProjectId = project.id;
+  const getTeamProjects = useCallback((api, id) => getProjects(api, { type: 'team', id, ignoreProjectId }), [])
 
   if (!teams.length && !users.length) {
     return null;
@@ -53,7 +54,7 @@ function RelatedProjects({ project }) {
     <ul className={styles.container}>
       {teams.map((team) => (
         <li key={team.id}>
-          <DataLoader get={(api) => getProjects(api, { type: 'team', id: team.id, ignoreProjectId })}>
+          <DataLoader get={getProjects} args={{ type: 'team', id: team.id, ignoreProjectId }}>
             {(projects) =>
               projects && projects.length > 0 && (
                 <>
@@ -69,7 +70,7 @@ function RelatedProjects({ project }) {
       ))}
       {users.map((user) => (
         <li key={user.id}>
-          <DataLoader get={(api) => getProjects(api, { type: 'user', id: user.id, ignoreProjectId })}>
+          <DataLoader get={getProjects} args={{ type: 'user', id: user.id, ignoreProjectId }}>
             {(projects) =>
               projects && projects.length > 0 && (
                 <>

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -15,7 +15,10 @@ async function getMembers(api, projectId, withCacheBust) {
     ]);
     return { users, teams };
   } catch (error) {
-    if (error.response )
+    if (error.response && error.response.status === 404) {
+      return { users: [], teams: [] };
+    }
+    throw error;
   }
 }
 

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -8,11 +8,15 @@ import { getAllPages } from 'Shared/api';
 
 async function getMembers(api, projectId, withCacheBust) {
   const cacheBust = withCacheBust ? `&cacheBust=${Date.now()}` : '';
-  const [users, teams] = await Promise.all([
-    getAllPages(api, `/v1/projects/by/id/users?id=${projectId}${cacheBust}`),
-    getAllPages(api, `/v1/projects/by/id/teams?id=${projectId}${cacheBust}`),
-  ]);
-  return { users, teams };
+  try {
+    const [users, teams] = await Promise.all([
+      getAllPages(api, `/v1/projects/by/id/users?id=${projectId}${cacheBust}`),
+      getAllPages(api, `/v1/projects/by/id/teams?id=${projectId}${cacheBust}`),
+    ]);
+    return { users, teams };
+  } catch (error) {
+    if (error.response )
+  }
 }
 
 const loadingResponse = { status: 'loading' };


### PR DESCRIPTION
## Links
https://profuse-tea.glitch.me/
https://app.clubhouse.io/glitch/story/2985/project-page-more-by-section-flickers-a-bunch-on-page-load

## Changes:
- The 'more by' section on project pages memoizes args so it doesn't keep reloading every render
- Added a try/catch to handle 404s when loading project members

## How To Test:
- Try loading up a project page and make sure there is no flickering
- Pin a project on your user page, refresh, delete it, then refresh again. On glitch.com a 404 will appear in the console, on this remix it won't. The 404 happens because the site ssr caches the deleted project, and the browser makes the request for members before it realizes the project is gone.