### PR TITLE
cms-updates: Check for a secret instead of persistentToken and team membership

### DIFF
--- a/server/curated.js
+++ b/server/curated.js
@@ -1,24 +1,13 @@
 const fs = require('fs');
 const util = require('util');
 const path = require('path');
-const axios = require('axios');
-
-const { API_URL } = require('./constants').current;
-const { getAllPages } = require('Shared/api');
-
-const GLITCH_TEAM_ID = 74;
-
-const api = axios.create({
-  baseURL: API_URL,
-  timeout: 5000,
-});
 
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 
 let pageCache = {};
 
-async function getData(page) {
+async function readCuratedContent(page) {
   if (!pageCache[page]) {
     const json = await readFile(path.join(__dirname, `../src/curated/${page}.json`));
     pageCache[page] = JSON.parse(json);
@@ -26,11 +15,9 @@ async function getData(page) {
   return pageCache[page];
 }
 
-async function saveDataToFile({ page, data, persistentToken }) {
-  const teams = await getAllPages(api, `/v1/users/by/persistentToken/teams?persistentToken=${persistentToken}&limit=100`);
-  if (!teams.some((team) => team.id === GLITCH_TEAM_ID)) throw new Error('Forbidden'); 
+async function writeCuratedContent({ page, data }) {
   pageCache[page] = data;
   await writeFile(path.join(__dirname, `../src/curated/${page}.json`), JSON.stringify(data), { encoding: 'utf8' });
 }
 
-module.exports = { getData, saveDataToFile };
+module.exports = { readCuratedContent, writeCuratedContent };

--- a/server/routes.js
+++ b/server/routes.js
@@ -15,7 +15,7 @@ const { APP_URL } = constants.current;
 const renderPage = require('./render');
 const getAssignments = require('./ab-tests');
 const { getOptimizelyData } = require('./optimizely');
-const { getData, saveDataToFile } = require('./curated');
+const { readCuratedContent, writeCuratedContent } = require('./curated');
 const rootTeams = require('../shared/teams');
 
 module.exports = function(external) {
@@ -75,7 +75,7 @@ module.exports = function(external) {
 
     const assignments = getAssignments(req, res);
     const signedIn = !!req.cookies.hasLogin;
-    const [zine, homeContent, pupdatesContent] = await Promise.all([getZine(), getData('home'), getData('pupdates')]);
+    const [zine, homeContent, pupdatesContent] = await Promise.all([getZine(), readCuratedContent('home'), readCuratedContent('pupdates')]);
 
     let ssr = { rendered: null, helmet: null, styleTags: '' };
     try {
@@ -171,13 +171,12 @@ module.exports = function(external) {
     }
     await render(req, res);
   });
-  
+
   categories.forEach((category) => {
     app.get(`/${category.url}`, (req, res) => {
       res.redirect(301, `/@glitch/${category.collectionName}`);
     });
   });
-  
 
   // redirect legacy root team URLs to '@' URLs (eg. glitch.com/slack => glitch.com/@slack)
   Object.keys(rootTeams).forEach((teamName) => {
@@ -205,10 +204,9 @@ module.exports = function(external) {
 
   app.get('/api/:page', async (req, res) => {
     const { page } = req.params;
-    console.log(page);
     if (!['home', 'pupdates'].includes(page)) return res.sendStatus(400);
 
-    const data = await getData(page);
+    const data = await readCuratedContent(page);
     res.send(data);
   });
 
@@ -216,13 +214,10 @@ module.exports = function(external) {
     const { page } = req.params;
     if (!['home', 'pupdates'].includes(page)) return res.sendStatus(400);
 
-    const persistentToken = req.headers.authorization;
-    const data = req.body;
-    try {
-      await saveDataToFile({ page, persistentToken, data });
+    if (res.headers.authorization === process.env.CMS_POST_SECRET) {
+      await writeCuratedContent({ page, data: req.body });
       res.sendStatus(200);
-    } catch (e) {
-      console.warn(e);
+    } else {
       res.sendStatus(403);
     }
   });


### PR DESCRIPTION
## Links
* Remix link: 
* Issue-tracker link
* Specs/doc links

## GIF/Screenshots:

## Changes:
* Moves the authorization check before writing curated content to disk up to the route level
* Checks for a secret that the CMS is sending rather than a specific user's `persistentToken`
* Renames a couple of methods to describe what they're doing more specifically

## How To Test:
* I need to set this up

## Feedback I'm looking for:
- Is this secret thing okay? It seems better than sending and checking someone's `persistentToken`.

## Things left to do before deploying:
- [ ] Add environment variables to staging before deploying, and again after swapping projects