### PR TITLE
Glowing draw: Update Embed to optionally point directly to project

### DIFF
--- a/src/components/collection/collection-projects-player.js
+++ b/src/components/collection/collection-projects-player.js
@@ -32,7 +32,16 @@ const getCurrentProjectIndexFromUrl = (projectId, projects) => {
 const wakeUpAllProjectsInACollection = (projects) => {
   const chunkedProjects = chunk(projects, 10);
   chunkedProjects.map(async (projectsBatch) => {
-    const promisedBatch = projectsBatch.map(async (project) => fetch(`https://${project.domain}.glitch.me`, { mode: 'no-cors' }));
+    const promisedBatch = projectsBatch.map((nextItem) => {
+      const xhttp = new XMLHttpRequest();
+      xhttp.addEventListener('readystatechange', () => {
+        if (this.readyState === this.DONE) {
+          console.log(this.responseText);
+        }
+      });
+      xhttp.open('GET', `https://${nextItem.domain}.glitch.me`, true);
+      xhttp.send();
+    });
     await Promise.all(promisedBatch);
   });
 };

--- a/src/components/collection/collection-projects-player.js
+++ b/src/components/collection/collection-projects-player.js
@@ -32,16 +32,7 @@ const getCurrentProjectIndexFromUrl = (projectId, projects) => {
 const wakeUpAllProjectsInACollection = (projects) => {
   const chunkedProjects = chunk(projects, 10);
   chunkedProjects.map(async (projectsBatch) => {
-    const promisedBatch = projectsBatch.map((nextItem) => {
-      const xhttp = new XMLHttpRequest();
-      xhttp.addEventListener('readystatechange', () => {
-        if (this.readyState === this.DONE) {
-          console.log(this.responseText);
-        }
-      });
-      xhttp.open('GET', `https://${nextItem.domain}.glitch.me`, true);
-      xhttp.send();
-    });
+    const promisedBatch = projectsBatch.map(async (project) => fetch(`https://${project.domain}.glitch.me`, { mode: 'no-cors' }));
     await Promise.all(promisedBatch);
   });
 };

--- a/src/components/profile-list/index.js
+++ b/src/components/profile-list/index.js
@@ -73,6 +73,11 @@ const parametersForSize = {
     userOffset: -5,
     teamOffset: 2,
   },
+  medium: {
+    avatarWidth: 25,
+    userOffset: -5,
+    teamOffset: 2,
+  },
 };
 
 const RowContainer = ({ size, users, teams }) => {

--- a/src/components/profile-list/index.js
+++ b/src/components/profile-list/index.js
@@ -172,7 +172,7 @@ const ProfileList = React.memo(({ size, users, teams, layout, glitchTeam }) => {
 
 ProfileList.propTypes = {
   layout: PropTypes.oneOf(['row', 'block']).isRequired,
-  size: PropTypes.oneOf(['small', 'large']),
+  size: PropTypes.oneOf(Object.keys(parametersForSize)),
   users: PropTypes.array,
   teams: PropTypes.array,
   glitchTeam: PropTypes.bool,

--- a/src/components/project/embed.js
+++ b/src/components/project/embed.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
 import { APP_URL } from 'Utils/constants';
 import Image from 'Components/images/image';
 import styles from './embed.styl';
@@ -24,19 +26,19 @@ const browserSatisfiesRequirements = (() => {
   return false;
 })();
 
-const Embed = ({ domain, loading }) => (
-  <div className={styles.embedContainer}>
+const Embed = ({ domain, loading, hideCode }) => (
+  <div className={classnames(styles.embedContainer, hideCode && styles.embedContainerWithPadding)}>
     {browserSatisfiesRequirements ? (
       // Embed iframe for app
       <iframe
-        className={styles.embedIframe}
+        className={classnames(styles.embedIframe, hideCode && styles.mimicGlitchEmbed)}
         title={`${domain} on Glitch`}
         allow="geolocation; microphone; camera; midi; encrypted-media"
         height="100%"
         width="100%"
         allowvr="yes"
         loading={loading}
-        src={`${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
+        src={hideCode ? `https://${domain}.glitch.me` : `${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
       />
     ) : (
       // Error message if JS not supported
@@ -55,10 +57,12 @@ const Embed = ({ domain, loading }) => (
 Embed.propTypes = {
   domain: PropTypes.string.isRequired,
   loading: PropTypes.oneOf(['lazy', 'eager', 'auto']),
+  hideCode: PropTypes.bool,
 };
 
 Embed.defaultProps = {
   loading: 'auto',
+  hideCode: false,
 };
 
 export default Embed;

--- a/src/components/project/embed.js
+++ b/src/components/project/embed.js
@@ -26,19 +26,19 @@ const browserSatisfiesRequirements = (() => {
   return false;
 })();
 
-const Embed = ({ domain, loading, hideCode }) => (
-  <div className={classnames(styles.embedContainer, hideCode && styles.embedContainerWithPadding)}>
+const Embed = ({ domain, loading, previewOnly }) => (
+  <div className={classnames(styles.embedContainer, previewOnly && styles.embedContainerWithPadding)}>
     {browserSatisfiesRequirements ? (
       // Embed iframe for app
       <iframe
-        className={classnames(styles.embedIframe, hideCode && styles.mimicGlitchEmbed)}
+        className={classnames(styles.embedIframe, previewOnly && styles.mimicGlitchEmbed)}
         title={`${domain} on Glitch`}
         allow="geolocation; microphone; camera; midi; encrypted-media"
         height="100%"
         width="100%"
         allowvr="yes"
         loading={loading}
-        src={hideCode ? `https://${domain}.glitch.me` : `${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
+        src={previewOnly ? `https://${domain}.glitch.me` : `${APP_URL}/embed/#!/embed/${domain}?path=README.md&previewSize=100`}
       />
     ) : (
       // Error message if JS not supported
@@ -57,12 +57,12 @@ const Embed = ({ domain, loading, hideCode }) => (
 Embed.propTypes = {
   domain: PropTypes.string.isRequired,
   loading: PropTypes.oneOf(['lazy', 'eager', 'auto']),
-  hideCode: PropTypes.bool,
+  previewOnly: PropTypes.bool,
 };
 
 Embed.defaultProps = {
   loading: 'auto',
-  hideCode: false,
+  previewOnly: false,
 };
 
 export default Embed;

--- a/src/components/project/embed.styl
+++ b/src/components/project/embed.styl
@@ -2,5 +2,14 @@
   width: 100%
   height: 100%
 
+.embedContainerWithPadding
+  padding-bottom: 4px
+
 .embedIframe
   border: none 
+
+.mimicGlitchEmbed
+  border: 1px solid #c3c3c3
+  border-radius: 5px
+  box-shadow: 4px 4px #c3c3c3
+  background-color: transparent

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -108,7 +108,7 @@ const FeaturedProject = ({
             }
             project={featuredProject}
             addProjectToCollection={addProjectToCollection}
-            hideCode={isPlayer}
+            previewOnly={isPlayer}
           />
         )}
       </AnimationContainer>

--- a/src/components/project/featured-project.js
+++ b/src/components/project/featured-project.js
@@ -108,6 +108,7 @@ const FeaturedProject = ({
             }
             project={featuredProject}
             addProjectToCollection={addProjectToCollection}
+            hideCode={isPlayer}
           />
         )}
       </AnimationContainer>

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -54,7 +54,7 @@ const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode 
               </span>
             </span>
             <Button as="a" href={`https://${project.domain}.glitch.me`}>
-              <Image src={fullscreenImageURL} className={styles.fullscreenImg} height="auto" />
+              <Image src={fullscreenImageURL} className={styles.fullscreenImg} height="auto" alt="fullscreen" />
             </Button>
           </div>
         )}

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -2,6 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
+import { Button } from '@fogcreek/shared-components';
+import { ProjectAvatar } from 'Components/images/avatar';
+import { ProjectLink } from 'Components/link';
+import ProfileList from 'Components/profile-list';
+import { useProjectMembers } from 'State/project';
+import Image from 'Components/images/image';
+
 import Embed from 'Components/project/embed';
 import ReportButton from 'Components/report-abuse-pop';
 import { EditButton, RemixButton } from 'Components/project/project-actions';
@@ -13,6 +20,12 @@ import AddProjectToCollection from './add-project-to-collection-pop';
 import styles from './project-embed.styl';
 
 const cx = classNames.bind(styles);
+const fullscreenImageURL = 'https://cdn.glitch.com/1b65cd5c-de77-474f-81ed-1b8109651212%2Ffullscreen.svg?v=1571859608927';
+
+const ProfileListWithData = ({ project }) => {
+  const { value: members } = useProjectMembers(project.id);
+  return <ProfileList layout="row" glitchTeam={project.showAsGlitchTeam} {...members} size="medium" />;
+};
 
 const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode }) => {
   const projectOptions = useProjectOptions(project, addProjectToCollection ? { addProjectToCollection } : {});
@@ -28,6 +41,23 @@ const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode 
       {top}
       <div className={styles.embedWrap}>
         <Embed domain={project.domain} loading={loading} hideCode={hideCode} />
+        {hideCode && (
+          <div className={styles.embedBottomBar}>
+            <span className={styles.embedLeft}>
+              <ProjectLink project={project}>
+                <ProjectAvatar project={project} />
+                <span claåssName={styles.embedDomainLink}>{project.domain}</span>
+              </ProjectLink>
+              by
+              <span className={styles.embedAuthors}>
+                <ProfileListWithData project={project} />
+              </span>
+            </span>
+            <Button as="a" href={`https://${project.domain}.glitch.me`}>
+              <Image src={fullscreenImageURL} className={styles.fullscreenImg} height="auto" />
+            </Button>
+          </div>
+        )}
       </div>
       <div className={styles.buttonContainer}>
         <div className={styles.left}>

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -29,7 +29,7 @@ const ProfileListWithData = ({ project }) => {
   return <ProfileList layout="row" users={users} size="small" />;
 };
 
-const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode }) => {
+const ProjectEmbed = ({ project, top, addProjectToCollection, loading, previewOnly }) => {
   const projectOptions = useProjectOptions(project, addProjectToCollection ? { addProjectToCollection } : {});
   const { currentUser } = useCurrentUser();
   const isMember = currentUser.projects.some(({ id }) => id === project.id);
@@ -42,8 +42,8 @@ const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode 
     <section className={styles.projectEmbed}>
       {top}
       <div className={styles.embedWrap}>
-        <Embed domain={project.domain} loading={loading} hideCode={hideCode} />
-        {hideCode && (
+        <Embed domain={project.domain} loading={loading} previewOnly={previewOnly} />
+        {previewOnly && (
           <div className={styles.embedBottomBar}>
             <span className={styles.embedLeft}>
               <ProjectLink project={project}>
@@ -87,14 +87,14 @@ ProjectEmbed.propTypes = {
   addProjectToCollection: PropTypes.func,
   top: PropTypes.any,
   loading: PropTypes.oneOf(['lazy', 'eager', 'auto']),
-  hideCode: PropTypes.bool,
+  previewOnly: PropTypes.bool,
 };
 
 ProjectEmbed.defaultProps = {
   addProjectToCollection: null,
   top: null,
   loading: 'auto',
-  hideCode: false,
+  previewOnly: false,
 };
 
 export default ProjectEmbed;

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -14,7 +14,7 @@ import styles from './project-embed.styl';
 
 const cx = classNames.bind(styles);
 
-const ProjectEmbed = ({ project, top, addProjectToCollection, loading }) => {
+const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode }) => {
   const projectOptions = useProjectOptions(project, addProjectToCollection ? { addProjectToCollection } : {});
   const { currentUser } = useCurrentUser();
   const isMember = currentUser.projects.some(({ id }) => id === project.id);
@@ -27,7 +27,7 @@ const ProjectEmbed = ({ project, top, addProjectToCollection, loading }) => {
     <section className={styles.projectEmbed}>
       {top}
       <div className={styles.embedWrap}>
-        <Embed domain={project.domain} loading={loading} />
+        <Embed domain={project.domain} loading={loading} hideCode={hideCode} />
       </div>
       <div className={styles.buttonContainer}>
         <div className={styles.left}>
@@ -55,12 +55,14 @@ ProjectEmbed.propTypes = {
   addProjectToCollection: PropTypes.func,
   top: PropTypes.any,
   loading: PropTypes.oneOf(['lazy', 'eager', 'auto']),
+  hideCode: PropTypes.bool,
 };
 
 ProjectEmbed.defaultProps = {
   addProjectToCollection: null,
   top: null,
   loading: 'auto',
+  hideCode: false,
 };
 
 export default ProjectEmbed;

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -46,7 +46,7 @@ const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode 
             <span className={styles.embedLeft}>
               <ProjectLink project={project}>
                 <ProjectAvatar project={project} />
-                <span claåssName={styles.embedDomainLink}>{project.domain}</span>
+                <span className={styles.embedDomainLink}>{project.domain}</span>
               </ProjectLink>
               by
               <span className={styles.embedAuthors}>

--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -20,7 +20,7 @@ import AddProjectToCollection from './add-project-to-collection-pop';
 import styles from './project-embed.styl';
 
 const cx = classNames.bind(styles);
-const fullscreenImageURL = 'https://cdn.glitch.com/1b65cd5c-de77-474f-81ed-1b8109651212%2Ffullscreen.svg?v=1571859608927';
+const fullscreenImageURL = 'https://cdn.glitch.com/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2Ffullscreen.svg?v=1571865617764';
 
 const ProfileListWithData = ({ project }) => {
   const { value: members } = useProjectMembers(project.id);

--- a/src/components/project/project-embed.styl
+++ b/src/components/project/project-embed.styl
@@ -16,6 +16,45 @@
     
 .embedWrap
   height: 500px
+  position: relative
 
+.embedBottomBar
+  position: absolute
+  bottom: 5px
+  z-index: 1
+  background-color: #f5f5f5
+  display: flex
+  font-size: 14px
+  padding: 8px 10px
+  height: 41px
+  line-height: 25px
+  width: 100%
+  border-left: 1px solid #c3c3c3
+  border-bottom-left-radius: 5px
+  border-bottom-right-radius: 5px
+
+.embedAuthors
+  flex: 1
+
+.embedLeft
+  display: flex
+  flex: 1
+  [data-module="Avatar"]
+    height: 25px
+    width: 25px
+  a
+    display: flex
+    color: black
+    &:hover
+      text-decoration: underline
+    > *
+      margin: 0 5px
+
+.embedDomainLink
+  font-weight: bold
+  
 .addToCollectionWrap
   display: inline-block
+
+.fullscreenImg
+  margin-top: -10px

--- a/src/components/project/project-embed.styl
+++ b/src/components/project/project-embed.styl
@@ -35,6 +35,7 @@
 
 .embedAuthors
   flex: 1
+  margin: 0 5px
 
 .embedLeft
   display: flex
@@ -47,11 +48,10 @@
     color: black
     &:hover
       text-decoration: underline
-    > *
-      margin: 0 5px
 
 .embedDomainLink
   font-weight: bold
+  margin: 0 5px
   
 .addToCollectionWrap
   display: inline-block


### PR DESCRIPTION
## Links
* Remix link: https://glowing-draw.glitch.me/@glitch/glitch-team-faves/play
* Issue-tracker link: https://app.clubhouse.io/glitch/story/1691/create-or-reuse-an-iframe-to-display-current-project-item-in-a-collection
* Specs/doc links: https://fogcreek.slack.com/archives/CNW257T7E/p1571759715050000

## GIF/Screenshots:
before/after
![Screen Shot 2019-10-23 at 5 09 24 PM](https://user-images.githubusercontent.com/6620164/67434294-e4535e80-f5b7-11e9-827a-03e232ff4f50.png)

## Changes:
* before we always pointed our embeds to glitch.com/embed/#!/embed/project-name which meant that as you tabbed through the different projects in a collection it was pretty slow, even waking the projects up all in one go on load of the page didn't quite work, as we still had to load the code, not just the project.
* now we optionally let the project embeds point directly to the project at projectname.glitch.me, which means we can wake them all up when we load the component, making them really easy to breeze through quickly. 
* the only issue there is that there's no embed bar that links to who made the project and stuff like that, so we have to mimic that on our end here. 

## How To Test:
* compare clicking around https://long-city.glitch.me/@glitch/glitch-team-faves/play with https://glowing-draw.glitch.me/@glitch/glitch-team-faves/play the glowing-draw one should be much faster

## Feedback I'm looking for:
anything!

## Things left to do before deploying:
not really a thing to do but a thing to note is that this pr is based off of long-city. We're not really ready to merge that pr yet, but I wanted to make it easier to look at pieces of the work to get better feedback, so I'll merge this and it won't get deployed for a bit. 