### PR TITLE
Updating project embed styling for exploring collections

### DIFF
--- a/src/components/project/project-embed.js
+++ b/src/components/project/project-embed.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { CDN_URL } from 'Utils/constants';
 
 import { Button } from '@fogcreek/shared-components';
 import { ProjectAvatar } from 'Components/images/avatar';
@@ -20,11 +21,12 @@ import AddProjectToCollection from './add-project-to-collection-pop';
 import styles from './project-embed.styl';
 
 const cx = classNames.bind(styles);
-const fullscreenImageURL = 'https://cdn.glitch.com/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2Ffullscreen.svg?v=1571865617764';
+const fullscreenImageURL = `${CDN_URL}/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2Ffullscreen.svg?v=1571867146900`;
 
 const ProfileListWithData = ({ project }) => {
   const { value: members } = useProjectMembers(project.id);
-  return <ProfileList layout="row" glitchTeam={project.showAsGlitchTeam} {...members} size="medium" />;
+  const { users } = members || {};
+  return <ProfileList layout="row" users={users} size="small" />;
 };
 
 const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode }) => {
@@ -53,7 +55,7 @@ const ProjectEmbed = ({ project, top, addProjectToCollection, loading, hideCode 
                 <ProfileListWithData project={project} />
               </span>
             </span>
-            <Button as="a" href={`https://${project.domain}.glitch.me`}>
+            <Button as="a" href={`https://${project.domain}.glitch.me`} variant="secondary" target="_blank">
               <Image src={fullscreenImageURL} className={styles.fullscreenImg} height="auto" alt="fullscreen" />
             </Button>
           </div>

--- a/src/components/project/project-embed.styl
+++ b/src/components/project/project-embed.styl
@@ -27,18 +27,14 @@
   font-size: 14px
   padding: 8px 10px
   height: 41px
-  line-height: 25px
   width: 100%
   border-left: 1px solid #c3c3c3
   border-bottom-left-radius: 5px
   border-bottom-right-radius: 5px
 
-.embedAuthors
-  flex: 1
-  margin: 0 5px
-
 .embedLeft
   display: flex
+  align-items: center
   flex: 1
   [data-module="Avatar"]
     height: 25px
@@ -48,10 +44,24 @@
     color: black
     &:hover
       text-decoration: underline
+    > *
+      margin-right: 5px
+  ul
+    margin-left: 5px
+  
+  .embedAuthors
+    flex: 1
+    li
+      margin-right: -7px
+      img 
+        margin-right: 0
+    li:last-child
+      margin-right: 0
 
 .embedDomainLink
-  font-weight: bold
-  margin: 0 5px
+  align-self: center
+  margin: 0
+  font-weight: 600
   
 .addToCollectionWrap
   display: inline-block


### PR DESCRIPTION
## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/519336/67498249-22e72880-f64d-11e9-8fb3-bc7af57f163c.png)
![image](https://user-images.githubusercontent.com/519336/67498265-27abdc80-f64d-11e9-9fa0-cf379f60bf22.png)

## Changes:
* removed teams from embed profileList (only show users)
* fixed user list styling (avatars should overlap to be consistent with how users are displayed elsewhere)
* edited fullscreen icon to make it lighter and applied secondary button styling
* fullscreen button opens up app in new tab (rather than same window)
* fixed tooltip styling (margins were off)