### PR TITLE
Fallacious slice: Don't load stuff right away, wait until it's relevant

### DIFF
--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -9,7 +9,7 @@ dependencies:
   '@babel/register': 7.5.5
   '@babel/runtime': 7.6.3
   '@babel/runtime-corejs3': 7.6.3
-  '@fogcreek/shared-components': 0.8.0
+  '@fogcreek/shared-components': 0.11.3
   '@jedmao/location': 2.0.4
   '@optimizely/optimizely-sdk': 3.3.0
   '@percy/cypress': 1.0.9
@@ -995,7 +995,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
-  /@fogcreek/shared-components/0.8.0:
+  /@fogcreek/shared-components/0.11.3:
     dependencies:
       prop-types: 15.7.2
       react-textarea-autosize: 7.1.0
@@ -1006,7 +1006,7 @@ packages:
       react: ^16.8.0
       styled-components: ^4.3.0
     resolution:
-      integrity: sha512-XhxhDAB8fElwMJVS5yWeMZ3OfFhjObh0HkomReeF9ghWYYsnQaLEliOGSGl1SyI5Krc+y1rYxTiqt/6zhoRP3w==
+      integrity: sha512-ER8ZnC6HNOorHYm/NOsh8HRDsxavSp3XVrkTxZtAiEL/YAu0oPFG8q2xycAjQEkuLZb99V5DprLyl5fZqe+8xA==
   /@hapi/address/2.1.2:
     dev: false
     resolution:
@@ -11037,7 +11037,7 @@ specifiers:
   '@babel/register': 7.5.5
   '@babel/runtime': ^7.5.4
   '@babel/runtime-corejs3': ^7.5.5
-  '@fogcreek/shared-components': ^0.8.0
+  '@fogcreek/shared-components': ^0.11.2
   '@jedmao/location': ^2.0.4
   '@optimizely/optimizely-sdk': ^3.2.2
   '@percy/cypress': ^1.0.9

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -28,20 +28,7 @@ const getLinkBodyStyles = (project, showEditButton) =>
     [styles.hasFooter]: showEditButton,
   });
 
-const ProfileListWithData = ({ project }) => {
-  const { value: members } = useProjectMembers(project.id);
-  return <ProfileList layout="row" glitchTeam={project.showAsGlitchTeam} {...members} />;
-};
-
-const ProfileListLoader = ({ project }) => (
-  <VisibilityContainer>
-    {({ wasEverVisible }) =>
-      wasEverVisible ? <ProfileListWithData project={project} /> : <ProfileList layout="row" glitchTeam={project.showAsGlitchTeam} />
-    }
-  </VisibilityContainer>
-);
-
-const ProjectItem = ({ project, projectOptions: providedProjectOptions, collection, noteOptions, showEditButton }) => {
+const ProjectItem = ({ project, projectOptions: providedProjectOptions, collection, noteOptions, showEditButton, deferLoading }) => {
   const { location } = useGlobals();
   const { currentUser } = useCurrentUser();
   const isAnonymousUser = !currentUser.login;
@@ -60,6 +47,7 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
   };
   const onMyStuffPage = location.pathname.includes('my-stuff');
 
+  const { value: members } = useProjectMembers(project.id, deferLoading);
   const projectOptions = useProjectOptions(project, providedProjectOptions);
   const hasProjectOptions = Object.keys(projectOptions).length > 0;
 
@@ -186,4 +174,8 @@ ProjectItem.defaultProps = {
   showEditButton: false,
 };
 
-export default ProjectItem;
+export default (props) => (
+  <VisibilityContainer>
+    {({ wasEverVisible }) => <ProjectItem {...props} deferLoading={!wasEverVisible} />}
+  </VisibilityContainer>
+);

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -113,7 +113,7 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
                 <div className={styles.container} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                   <header className={styles.header}>
                     <div className={classnames(styles.userListContainer, { [styles.spaceForOptions]: hasProjectOptions })}>
-                      <ProfileListLoader project={project} />
+                      <ProfileList layout="row" glitchTeam={project.showAsGlitchTeam} {...members} />
                     </div>
                     {!isAnonymousUser && !onMyStuffPage && (
                       <div className={styles.bookmarkButtonContainer}>

--- a/src/components/project/project-item.js
+++ b/src/components/project/project-item.js
@@ -48,7 +48,7 @@ const ProjectItem = ({ project, projectOptions: providedProjectOptions, collecti
   const onMyStuffPage = location.pathname.includes('my-stuff');
 
   const { value: members } = useProjectMembers(project.id, deferLoading);
-  const projectOptions = useProjectOptions(project, providedProjectOptions);
+  const projectOptions = useProjectOptions(project, providedProjectOptions, deferLoading);
   const hasProjectOptions = Object.keys(projectOptions).length > 0;
 
   const bookmarkAction = useTrackedFunc(

--- a/src/components/visibility-container/index.js
+++ b/src/components/visibility-container/index.js
@@ -9,6 +9,7 @@ const useIntersectionObserver = ({ ratio }) => {
     if (!window.IntersectionObserver) {
       setIsVisible(true);
       setWasEverVisible(true);
+      return null;
     }
     const observer = new IntersectionObserver(([container]) => {
       if (container.intersectionRatio > ratio) {

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -71,7 +71,7 @@ const useDefaultProjectOptions = () => {
 };
 
 // eslint-disable-next-line import/prefer-default-export
-export const useProjectOptions = (project, { user, team, collection, ...options } = {}) => {
+export const useProjectOptions = (project, { user, team, collection, ...options } = {}, deferLoading = false) => {
   const { currentUser } = useCurrentUser();
   const defaultProjectOptions = useDefaultProjectOptions();
   const projectOptions = { ...defaultProjectOptions, ...options };
@@ -82,7 +82,7 @@ export const useProjectOptions = (project, { user, team, collection, ...options 
   }, [user, team, project]);
 
   const isLoggedIn = !!currentUser.login;
-  const { value: members } = useProjectMembers(project.id);
+  const { value: members } = useProjectMembers(project.id, deferLoading);
   const isProjectMember = userIsProjectMember({ members, user: currentUser });
   const isProjectAdmin = userIsProjectAdmin({ project, user: currentUser });
   const isOnlyProjectAdmin = userIsOnlyProjectAdmin({ project, user: currentUser });

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -55,11 +55,13 @@ export const ProjectContextProvider = ({ children }) => {
   const [projectResponses, setProjectResponses] = useState({});
   const api = useAPI();
 
-  const getProjectMembers = useCallback((projectId) => {
+  const getProjectMembers = useCallback((projectId, deferLoading = false) => {
     if (projectResponses[projectId] && projectResponses[projectId].members) {
       return projectResponses[projectId].members;
     }
-    loadProjectMembers(api, [projectId], setProjectResponses);
+    if (!deferLoading) {
+      loadProjectMembers(api, [projectId], setProjectResponses);
+    }
     return loadingResponse;
   }, [projectResponses, api]);
 
@@ -76,9 +78,9 @@ export const ProjectContextProvider = ({ children }) => {
   );
 };
 
-export function useProjectMembers(projectId) {
+export function useProjectMembers(projectId, deferLoading) {
   const getProjectMembers = useContext(ProjectMemberContext);
-  return getProjectMembers(projectId);
+  return getProjectMembers(projectId, deferLoading);
 }
 
 export function useProjectReload() {


### PR DESCRIPTION
## Links
https://fallacious-slice.glitch.me/@Performance-Boost
https://app.clubhouse.io/glitch/story/3199/investigate-why-the-site-is-making-so-many-network-requests

## Changes:
- Team pages only load projects owned by team members once you open their user pop, rather than loading every project owned by every team member right away
- Don't load project item teams/members until they are visible on the page

## How To Test:
- Try removing yourself from a team. It should act no different, except that it doesn't load all of your projects until you open your team user pop
- Clicking show all on pages with many projects does load everything eventually, and there are no 429 errors

## Feedback I'm looking for:
Team pages with a lot of projects slow down quite a bit as you scroll because every time a project loads the context causes every project to re render