### PR TITLE
Fix freaky multi-tab morecollections bug and /create page i think?

### DIFF
--- a/src/presenters/pages/router.js
+++ b/src/presenters/pages/router.js
@@ -8,7 +8,6 @@ import rootTeams from 'Shared/teams';
 import { useCurrentUser } from 'State/current-user';
 import { useGlobals } from 'State/globals';
 import { useAppMounted } from 'State/app-mounted';
-import useDevToggle from 'State/dev-toggles';
 
 import LoginPage from './login';
 import ResetPasswordPage from './login/reset-password';
@@ -87,12 +86,7 @@ const PageChangeHandler = withRouter(({ location }) => {
 const Router = () => {
   const { EXTERNAL_ROUTES } = useGlobals();
   useAppMounted();
-  const userPasswordEnabled = useDevToggle('User Passwords');
-  const tfaEnabled = useDevToggle('Two Factor Auth');
-  const { currentUser } = useCurrentUser();
-  const { persistentToken, login } = currentUser;
-  const isSignedIn = persistentToken && login;
-  const settingsPageEnabled = isSignedIn && (userPasswordEnabled || tfaEnabled);
+
   return (
     <>
       <PageChangeHandler />
@@ -184,7 +178,7 @@ const Router = () => {
 
         <Route path="/secret" exact render={({ location }) => <SecretPage key={location.key} />} />
 
-        {settingsPageEnabled && <Route path="/settings" exact render={({ location }) => <SettingsPage key={location.key} />} />}
+        <Route path="/settings" exact render={({ location }) => <SettingsPage key={location.key} />} />
 
         <Route path="/vscode-auth" exact render={({ location }) => <VSCodeAuth key={location.key} scheme={parse(location.search, 'scheme')} />} />
 

--- a/src/presenters/pages/settings.js
+++ b/src/presenters/pages/settings.js
@@ -7,6 +7,8 @@ import Heading from 'Components/text/heading';
 import PasswordSettings from 'Components/account-settings-overlay/password-settings';
 import TwoFactorSettings from 'Components/account-settings-overlay/two-factor-settings';
 import useDevToggle from 'State/dev-toggles';
+import { useCurrentUser } from 'State/current-user';
+import { NotFoundPage } from './error';
 
 import styles from './settings.styl';
 import { emoji } from '../../components/global.styl';
@@ -15,6 +17,14 @@ const Settings = () => {
   const tagline = 'Account Settings';
   const userPasswordEnabled = useDevToggle('User Passwords');
   const tfaEnabled = useDevToggle('Two Factor Auth');
+  const { currentUser } = useCurrentUser();
+  const { persistentToken, login } = currentUser;
+  const isSignedIn = persistentToken && login;
+  const settingsPageEnabled = isSignedIn && (userPasswordEnabled || tfaEnabled);
+
+  if (!settingsPageEnabled) {
+    return <NotFoundPage />;
+  }
 
   return (
     <main id="main">

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -77,7 +77,6 @@ export function APIContextProvider({ children }) {
       ));
     }
   }, [api, pendingRequests]);
-
   return <Context.Provider value={api}>{children}</Context.Provider>;
 }
 


### PR DESCRIPTION
## Links
* Remix link: https://evergreen-opossum.glitch.me/

## Changes:
* when we added these conditional routes it looks like <Router/> was rerendering...forever? but only when you were running the exact same code in the same browser window in 2 different tabs (or at least thats what I think is happening!) When I move the conditional logic to within the page component the bugs seem to go away for me

## How To Test:
* to recreate the bug, open the same url in two different tabs, in the second tab you should see the /create page gifs flicker or the MoreCollections section flash as it randomly continues to choose different collections to feature
* if you repeat those same steps here, you should not see those bugs!

## Feedback I'm looking for:
do you agree with my assessment?
