### PR TITLE
Nova chance: Add unit tests for server side rendering

### DIFF
--- a/mochapack.opts
+++ b/mochapack.opts
@@ -1,4 +1,3 @@
 --webpack-config ./webpack.test.config.js
---include test/setup.js
--- include test/reactA11yHelper.js
+--include test/reactA11yHelper.js
 test/**/*.js

--- a/src/hooks/use-window-size.js
+++ b/src/hooks/use-window-size.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 export const mediumSmallViewport = 592; // 592px is the cutoff for hiding some of the button text for mobile
 
 export const useWindowSize = () => {
-  const [windowSize, setWindowSize] = useState([window.innerWidth, window.innerHeight]);
+  const [windowSize, setWindowSize] = useState([0, 0]);
   useEffect(() => {
     const handleResize = () => setWindowSize([window.innerWidth, window.innerHeight]);
     window.addEventListener('resize', handleResize);

--- a/src/hooks/use-window-size.js
+++ b/src/hooks/use-window-size.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 export const mediumSmallViewport = 592; // 592px is the cutoff for hiding some of the button text for mobile
 
 export const useWindowSize = () => {
-  const [windowSize, setWindowSize] = useState([0, 0]);
+  const [windowSize, setWindowSize] = useState([window.innerWidth, window.innerHeight]);
   useEffect(() => {
     const handleResize = () => setWindowSize([window.innerWidth, window.innerHeight]);
     window.addEventListener('resize', handleResize);

--- a/test/ProjectsList/index.js
+++ b/test/ProjectsList/index.js
@@ -26,6 +26,8 @@ configure({ adapter: new Adapter() });
 const FakeVisibilityContainer = ({children}) => (<div>{children({ isVisible: true, wasEverVisible: true })}</div>);
 
 describe('ProjectsList', function() {
+  a11yHelper.setup();
+
   describe('a11y testing', function() {
     it('should have no errors when there are no projects', function() {
       a11yHelper.testEnzymeComponent(<ProjectsList layout="row" projects={[]} enableFiltering />, {}, function(results) {

--- a/test/ProjectsList/index.js
+++ b/test/ProjectsList/index.js
@@ -30,7 +30,7 @@ describe('ProjectsList', function() {
 
   describe('a11y testing', function() {
     it('should have no errors when there are no projects', function() {
-      a11yHelper.testEnzymeComponent(<ProjectsList layout="row" projects={[]} enableFiltering />, {}, function(results) {
+      a11yHelper.testEnzymeComponent(<ProjectsList layout="row" projects={[]} enableFiltering debounceFunction={(arg) => arg} />, {}, function(results) {
         results.violations.length.should.equal(0);
       });
     });

--- a/test/components/private-badge.js
+++ b/test/components/private-badge.js
@@ -17,6 +17,8 @@ const mockStore = configureStore(middlewares);
 configure({ adapter: new Adapter() });
 
 describe('PrivateBadge', function() {
+  a11yHelper.setup();
+
   it('should have no a11y errors', function() {
     const component = <PrivateToggle align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
     a11yHelper.testEnzymeComponent(component, {}, function(results) {

--- a/test/helpers/models.js
+++ b/test/helpers/models.js
@@ -88,6 +88,7 @@ export const makeTestTeam = (options) => {
     authUserIsTeamMember: false,
     teamPermissions: [],
     teamPermission: {},
+    pinnedProjects: [],
     ...options,
   };
 };

--- a/test/reactA11yHelper.js
+++ b/test/reactA11yHelper.js
@@ -3,8 +3,16 @@ import React from 'react';
 import { render } from 'react-dom';
 import { mount } from 'enzyme';
 import axeCore from 'axe-core';
+import jsdom from 'mocha-jsdom';
 
 export const a11yHelper = {};
+
+/**
+ * Init ally helper test hooks
+ */
+a11yHelper.setup = function() {
+  jsdom({ url: 'https://glitch.com/' });
+}
 
 /**
  * Test a component with React's Test Utils.

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+
 import HOME_CONTENT from 'Curated/home.json';
 import PUPDATES_CONTENT from 'Curated/pupdates.json';
 import { tests } from 'Shared/ab-tests';
+
 import { Page, resetState } from '../../src/server';
 import { makeTestCollection, makeTestProject, makeTestTeam, makeTestUser } from '../helpers/models';
 
@@ -13,7 +15,7 @@ function renderPage(route, props) {
     ...assignments,
     [name]: Object.keys(tests[name])[0],
   }), {});
-  renderToString(
+  const result = renderToString(
     <Page
       helmetContext={{}}
       optimizely={optimizely}
@@ -30,6 +32,8 @@ function renderPage(route, props) {
     />
   );
   resetState();
+  if (result.includes("We didn't find")) console.log('oh no');
+  return result;
 }
 
 describe('Server Side Rendering', function() {

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -13,21 +13,22 @@ function renderPage(route, props) {
     ...assignments,
     [name]: Object.keys(tests[name])[0],
   }), {});
-  const page = <Page
-    helmetContext={{}}
-    optimizely={optimizely}
-    origin="https://glitch.com"
-    route={route}
-    AB_TESTS={abTests}
-    API_CACHE={{}}
-    EXTERNAL_ROUTES={[]}
-    HOME_CONTENT={HOME_CONTENT}
-    PUPDATES_CONTENT={PUPDATES_CONTENT}
-    SSR_SIGNED_IN={false}
-    ZINE_POSTS={[]}
-    {...props}
-  />
-  renderToString(page);
+  renderToString(
+    <Page
+      helmetContext={{}}
+      optimizely={optimizely}
+      origin="https://glitch.com"
+      route={route}
+      AB_TESTS={abTests}
+      API_CACHE={{}}
+      EXTERNAL_ROUTES={[]}
+      HOME_CONTENT={HOME_CONTENT}
+      PUPDATES_CONTENT={PUPDATES_CONTENT}
+      SSR_SIGNED_IN={false}
+      ZINE_POSTS={[]}
+      {...props}
+    />
+  );
   resetState();
 }
 

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -37,16 +37,18 @@ describe('Server Side Rendering', function() {
     renderToString(<Page {...makeDefaultProps()} route="/~test-project" API_CACHE={apiCache} />);
   });
   it('team page', function() {
+    const collections = [makeTestCollection()];
     const projects = [makeTestProject()];
     const users = [makeTestUser()];
-    const team = makeTestTeam({ url: 'test-team', projects, users })
+    const team = makeTestTeam({ url: 'test-team', collections, projects, users })
     const apiCache = { 'team-or-user:test-team': { team } };
     renderToString(<Page {...makeDefaultProps()} route="/@test-team" API_CACHE={apiCache} />);
   });
   it('user page', function() {
+    const collections = [makeTestCollection()];
     const projects = [makeTestProject()];
     const teams = [makeTestTeam()];
-    const user = makeTestUser({ login: 'glitch-user', projects, teams })
+    const user = makeTestUser({ login: 'glitch-user', collections, projects, teams })
     const apiCache = { 'team-or-user:glitch-user': { user } };
     renderToString(<Page {...makeDefaultProps()} route="/@glitch-user" API_CACHE={apiCache} />);
   });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -30,6 +30,16 @@ describe('Server Side Rendering', function() {
     renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={true} />);
   });
   it('project page', function() {
-    const project = makeTestProject({ users: [makeTestUser()] });
+    const users = [makeTestUser()];
+    const project = makeTestProject({ domain: 'test-project', users });
+    const apiCache = { 'project:test-project': project };
+    renderToString(<Page {...makeDefaultProps()} route="/~test-project" API_CACHE={apiCache} />);
+  });
+  it('team page', function() {
+    const projects = [makeTestProject()];
+    const users = [makeTestUser()];
+    const team = makeTestTeam({ url: 'test-team', projects, users })
+    const apiCache = { 'team-or-user:test-team': { team } };
+    renderToString(<Page {...makeDefaultProps()} route="/@test-team" API_CACHE={apiCache} />);
   });
 });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -63,7 +63,7 @@ describe('Server Side Rendering', function() {
     const teams = [makeTestTeam()];
     const project = makeTestProject({ domain: 'test-project', teams, users });
     const API_CACHE = { 'project:test-project': project };
-    console.log(window.origin);
+    console.log(window.location.href);
     renderPageAndEnsureItHasContent('/~test-project', { API_CACHE });
   });
   it('team page', function() {

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -32,7 +32,7 @@ function renderPage(route, props) {
     />
   );
   resetState();
-  if (/we\sdidn.t\sfind/.test(result)) throw new Error('Rendered a not found page');
+  if (/We couldn[^\s<>]+t find/.test(result)) throw new Error('Rendered a not found page');
   return result;
 }
 

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -20,14 +20,21 @@ const makeDefaultProps = () => ({
 });
 
 describe('Server Side Rendering', function() {
-  it('create page', function() {
-    renderToString(<Page {...makeDefaultProps()} route="/create" />);
-  });
   it('signed out home page', function() {
     renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={false} />);
   });
   it('signed in home page', function() {
     renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={true} />);
+  });
+  it('create page', function() {
+    renderToString(<Page {...makeDefaultProps()} route="/create" />);
+  });
+  it('collection page', function() {
+    const projects = [makeTestProject()];
+    const user = makeTestUser();
+    const collection = makeTestCollection({ projects, user });
+    const apiCache = { 'collection:test-user-1/test-collection': collection };
+    renderToString(<Page {...makeDefaultProps()} route="/@test-user-1/test-collection" API_CACHE={apiCache} />);
   });
   it('project page', function() {
     const users = [makeTestUser()];

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -1,16 +1,27 @@
 import React from 'react';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 import chai from 'chai';
+import HOME_CONTENT from 'Curated/home.json';
+import PUPDATES_CONTENT from 'Curated/pupdates.json';
 import { Page, resetState } from '../../src/server';
-
 import { makeTestCollection, makeTestProject, makeTestTeam, makeTestUser } from '../helpers/models';
 
 chai.should();
-configure({ adapter: new Adapter() });
 
-describe('PrivateBadge', function() {
-  it('should have no a11y errors', function() {
+const makeDefaultProps = () => ({
+  helmer
+  optimizely: 
+  origin: 'https://glitch.com',
+  AB_TESTS: {},
+  API_CACHE: {},
+  EXTERNAL_ROUTES: [],
+  HOME_CONTENT,
+  PUPDATES_CONTENT,
+  SSR_SIGNED_IN: false,
+  ZINE_POSTS: [],
+});
+
+describe('Server Side Rendering', function() {
+  it('should render the create page', function() {
     const component = <PrivateToggle align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
   });
 });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import chai from 'chai';
+import { renderToString } from 'react-dom/server';
 import HOME_CONTENT from 'Curated/home.json';
 import PUPDATES_CONTENT from 'Curated/pupdates.json';
+import { tests } from 'Shared/ab-tests';
 import { Page, resetState } from '../../src/server';
 import { makeTestCollection, makeTestProject, makeTestTeam, makeTestUser } from '../helpers/models';
 
-chai.should();
-
 const makeDefaultProps = () => ({
   helmetContext: {},
-  optimizely: { isFeatureEnabled: () => false },
+  optimizely: { isFeatureEnabled: () => false }, // gross :(
   origin: 'https://glitch.com',
-  AB_TESTS: {},
+  AB_TESTS: Object.keys(tests).reduce((assignments, name) => ({ ...assignments, [name]: Object.keys(tests[name])[0] }), {}),
   API_CACHE: {},
   EXTERNAL_ROUTES: [],
   HOME_CONTENT,
@@ -21,7 +20,16 @@ const makeDefaultProps = () => ({
 });
 
 describe('Server Side Rendering', function() {
-  it('should render the create page', function() {
-    const component = <Page align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
+  it('create page', function() {
+    renderToString(<Page {...makeDefaultProps()} route="/create" />);
+  });
+  it('signed out home page', function() {
+    renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={false} />);
+  });
+  it('signed in home page', function() {
+    renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={true} />);
+  });
+  it('project page', function() {
+    const project = makeTestProject({ users: [makeTestUser()] });
   });
 });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import chai from 'chai';
+import { Page, resetState } from '../../src/server';
+
+import { makeTestCollection, makeTestProject, makeTestTeam, makeTestUser } from '../helpers/models';
+
+chai.should();
+configure({ adapter: new Adapter() });
+
+describe('PrivateBadge', function() {
+  it('should have no a11y errors', function() {
+    const component = <PrivateToggle align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
+  });
+});

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -6,57 +6,69 @@ import { tests } from 'Shared/ab-tests';
 import { Page, resetState } from '../../src/server';
 import { makeTestCollection, makeTestProject, makeTestTeam, makeTestUser } from '../helpers/models';
 
-const makeDefaultProps = () => ({
-  helmetContext: {},
-  optimizely: { isFeatureEnabled: () => false }, // gross :(
-  origin: 'https://glitch.com',
-  AB_TESTS: Object.keys(tests).reduce((assignments, name) => ({ ...assignments, [name]: Object.keys(tests[name])[0] }), {}),
-  API_CACHE: {},
-  EXTERNAL_ROUTES: [],
-  HOME_CONTENT,
-  PUPDATES_CONTENT,
-  SSR_SIGNED_IN: false,
-  ZINE_POSTS: [],
-});
+function renderPage(route, props) {
+  resetState();
+  const optimizely = { isFeatureEnabled: () => false }; //gross
+  const abTests = Object.keys(tests).reduce((assignments, name) => ({
+    ...assignments,
+    [name]: Object.keys(tests[name])[0],
+  }), {});
+  const page = <Page
+    helmetContext={{}}
+    optimizely={optimizely}
+    origin="https://glitch.com"
+    route={route}
+    AB_TESTS={abTests}
+    API_CACHE={{}}
+    EXTERNAL_ROUTES={[]}
+    HOME_CONTENT={HOME_CONTENT}
+    PUPDATES_CONTENT={PUPDATES_CONTENT}
+    SSR_SIGNED_IN={false}
+    ZINE_POSTS={[]}
+    {...props}
+  />
+  renderToString(page);
+  resetState();
+}
 
 describe('Server Side Rendering', function() {
   it('signed out home page', function() {
-    renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={false} />);
+    renderPage('/', { SSR_SIGNED_IN: false });
   });
   it('signed in home page', function() {
-    renderToString(<Page {...makeDefaultProps()} route="/" SSR_SIGNED_IN={true} />);
+    renderPage('/', { SSR_SIGNED_IN: true });
   });
   it('create page', function() {
-    renderToString(<Page {...makeDefaultProps()} route="/create" />);
+    renderPage('/create');
   });
   it('collection page', function() {
     const projects = [makeTestProject()];
     const user = makeTestUser();
     const collection = makeTestCollection({ projects, user });
-    const apiCache = { 'collection:test-user-1/test-collection': collection };
-    renderToString(<Page {...makeDefaultProps()} route="/@test-user-1/test-collection" API_CACHE={apiCache} />);
+    const API_CACHE = { 'collection:test-user-1/test-collection': collection };
+    renderPage('/@test-user-1/test-collection', { API_CACHE });
   });
   it('project page', function() {
     const users = [makeTestUser()];
     const teams = [makeTestTeam()];
     const project = makeTestProject({ domain: 'test-project', teams, users });
-    const apiCache = { 'project:test-project': project };
-    renderToString(<Page {...makeDefaultProps()} route="/~test-project" API_CACHE={apiCache} />);
+    const API_CACHE = { 'project:test-project': project };
+    renderPage('/~test-project', { API_CACHE });
   });
   it('team page', function() {
     const collections = [makeTestCollection()];
     const projects = [makeTestProject()];
     const users = [makeTestUser()];
     const team = makeTestTeam({ url: 'test-team', collections, projects, users })
-    const apiCache = { 'team-or-user:test-team': { team } };
-    renderToString(<Page {...makeDefaultProps()} route="/@test-team" API_CACHE={apiCache} />);
+    const API_CACHE = { 'team-or-user:test-team': { team } };
+    renderPage('/@test-team', { API_CACHE });
   });
   it('user page', function() {
     const collections = [makeTestCollection()];
     const projects = [makeTestProject()];
     const teams = [makeTestTeam()];
     const user = makeTestUser({ login: 'glitch-user', collections, projects, teams })
-    const apiCache = { 'team-or-user:glitch-user': { user } };
-    renderToString(<Page {...makeDefaultProps()} route="/@glitch-user" API_CACHE={apiCache} />);
+    const API_CACHE = { 'team-or-user:glitch-user': { user } };
+    renderPage('/@glitch-user', { API_CACHE });
   });
 });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -32,7 +32,7 @@ function renderPage(route, props) {
     />
   );
   resetState();
-  if (result.includes("We didn't find")) console.log('oh no');
+  if (/we\sdidn.t\sfind/.test(result)) throw new Error('Rendered a not found page');
   return result;
 }
 
@@ -57,7 +57,7 @@ describe('Server Side Rendering', function() {
     const users = [makeTestUser()];
     const teams = [makeTestTeam()];
     const project = makeTestProject({ domain: 'test-project', teams, users });
-    const API_CACHE = { 'project:test-project': project };
+    const API_CACHE = { 'aproject:test-project': project };
     renderPage('/~test-project', { API_CACHE });
   });
   it('team page', function() {

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -32,8 +32,13 @@ function renderPage(route, props) {
     />
   );
   resetState();
-  if (/We couldn[^\s<>]+t find/.test(result)) throw new Error('Rendered a not found page');
   return result;
+}
+
+function renderPageAndEnsureItHasContent(route, props) {
+  const emptyPage = renderPage(route, { ...props, API_CACHE: {} });
+  const page = renderPage(route, props);
+  if (page === emptyPage) throw new Error('The page is empty')
 }
 
 describe('Server Side Rendering', function() {
@@ -51,14 +56,15 @@ describe('Server Side Rendering', function() {
     const user = makeTestUser();
     const collection = makeTestCollection({ projects, user });
     const API_CACHE = { 'collection:test-user-1/test-collection': collection };
-    renderPage('/@test-user-1/test-collection', { API_CACHE });
+    renderPageAndEnsureItHasContent('/@test-user-1/test-collection', { API_CACHE });
   });
   it('project page', function() {
     const users = [makeTestUser()];
     const teams = [makeTestTeam()];
     const project = makeTestProject({ domain: 'test-project', teams, users });
-    const API_CACHE = { 'aproject:test-project': project };
-    renderPage('/~test-project', { API_CACHE });
+    const API_CACHE = { 'project:test-project': project };
+    console.log(window.origin);
+    renderPageAndEnsureItHasContent('/~test-project', { API_CACHE });
   });
   it('team page', function() {
     const collections = [makeTestCollection()];
@@ -66,7 +72,7 @@ describe('Server Side Rendering', function() {
     const users = [makeTestUser()];
     const team = makeTestTeam({ url: 'test-team', collections, projects, users })
     const API_CACHE = { 'team-or-user:test-team': { team } };
-    renderPage('/@test-team', { API_CACHE });
+    renderPageAndEnsureItHasContent('/@test-team', { API_CACHE });
   });
   it('user page', function() {
     const collections = [makeTestCollection()];
@@ -74,6 +80,6 @@ describe('Server Side Rendering', function() {
     const teams = [makeTestTeam()];
     const user = makeTestUser({ login: 'glitch-user', collections, projects, teams })
     const API_CACHE = { 'team-or-user:glitch-user': { user } };
-    renderPage('/@glitch-user', { API_CACHE });
+    renderPageAndEnsureItHasContent('/@glitch-user', { API_CACHE });
   });
 });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -38,7 +38,7 @@ function renderPage(route, props) {
 function renderPageAndEnsureItHasContent(route, props) {
   const emptyPage = renderPage(route, { ...props, API_CACHE: {} });
   const page = renderPage(route, props);
-  if (page === emptyPage) throw new Error('The page is empty')
+  if (page === emptyPage) throw new Error('the api cache was not used')
 }
 
 describe('Server Side Rendering', function() {
@@ -63,7 +63,6 @@ describe('Server Side Rendering', function() {
     const teams = [makeTestTeam()];
     const project = makeTestProject({ domain: 'test-project', teams, users });
     const API_CACHE = { 'project:test-project': project };
-    console.log(window.location.href);
     renderPageAndEnsureItHasContent('/~test-project', { API_CACHE });
   });
   it('team page', function() {

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -31,7 +31,8 @@ describe('Server Side Rendering', function() {
   });
   it('project page', function() {
     const users = [makeTestUser()];
-    const project = makeTestProject({ domain: 'test-project', users });
+    const teams = [makeTestTeam()];
+    const project = makeTestProject({ domain: 'test-project', teams, users });
     const apiCache = { 'project:test-project': project };
     renderToString(<Page {...makeDefaultProps()} route="/~test-project" API_CACHE={apiCache} />);
   });
@@ -41,5 +42,12 @@ describe('Server Side Rendering', function() {
     const team = makeTestTeam({ url: 'test-team', projects, users })
     const apiCache = { 'team-or-user:test-team': { team } };
     renderToString(<Page {...makeDefaultProps()} route="/@test-team" API_CACHE={apiCache} />);
+  });
+  it('user page', function() {
+    const projects = [makeTestProject()];
+    const teams = [makeTestTeam()];
+    const user = makeTestUser({ login: 'glitch-user', projects, teams })
+    const apiCache = { 'team-or-user:glitch-user': { user } };
+    renderToString(<Page {...makeDefaultProps()} route="/@glitch-user" API_CACHE={apiCache} />);
   });
 });

--- a/test/server/render.js
+++ b/test/server/render.js
@@ -8,8 +8,8 @@ import { makeTestCollection, makeTestProject, makeTestTeam, makeTestUser } from 
 chai.should();
 
 const makeDefaultProps = () => ({
-  helmer
-  optimizely: 
+  helmetContext: {},
+  optimizely: { isFeatureEnabled: () => false },
   origin: 'https://glitch.com',
   AB_TESTS: {},
   API_CACHE: {},
@@ -22,6 +22,6 @@ const makeDefaultProps = () => ({
 
 describe('Server Side Rendering', function() {
   it('should render the create page', function() {
-    const component = <PrivateToggle align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
+    const component = <Page align={['left']} type={'userCollection'} isPrivate={true} setPrivate={() => {}} />;
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,0 @@
-//const jsdom = require('mocha-jsdom');
-
-/*jsdom({
-  url: 'https://glitch.com/',
-});*/
-
-//var ENVIRONMENT = "testing"; 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,7 @@
-const jsdom = require('mocha-jsdom');
+//const jsdom = require('mocha-jsdom');
 
 /*jsdom({
   url: 'https://glitch.com/',
 });*/
 
-var ENVIRONMENT = "testing"; 
+//var ENVIRONMENT = "testing"; 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,7 @@
 const jsdom = require('mocha-jsdom');
 
-jsdom({
+/*jsdom({
   url: 'https://glitch.com/',
-});
+});*/
 
 var ENVIRONMENT = "testing"; 


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me/ (nothing to see there)
https://app.clubhouse.io/glitch/story/3112/create-unit-test-for-top-level-page-in-ssr

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/8932174/68228116-ddb6e500-ffc2-11e9-87b5-cb669414b291.png)

## Changes:
- Added tests for the home page, create page, and the entity pages (checks that they render without errors and use the api cache data)
- Only setup jsom for tests that use it, so that other tests can test in a node env
- Removed setup.js because the setup it did happens at a fixture level

## How To Test:
Change a component to reference window and make sure the tests fail