### PR TITLE
Trusting-macadamia: fix accessible names on project options pop buttons

### DIFF
--- a/src/components/collection/collection-options-pop.js
+++ b/src/components/collection/collection-options-pop.js
@@ -13,7 +13,7 @@ export default function CollectionOptions({ collection, deleteCollection }) {
       align="right"
       className={mediumPopover}
       renderLabel={({ onClick, ref }) => (
-        <PopoverMenuButton onClick={onClick} ref={ref} label={`Collection options for ${collection.name}`} />
+        <PopoverMenuButton onClick={onClick} ref={ref} aria-label={`Collection options for ${collection.name}`} />
       )}
     >
       {() => <DeleteCollection collection={collection} deleteCollection={deleteCollection} />}

--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -8,6 +8,10 @@ import styles from './styles.styl';
 
 const PopoverMenuButton = React.forwardRef((props, ref) => (<UnstyledButton className={styles.popoverMenuButton} ref={ref} {...props}><Icon icon="chevronDown" /></UnstyledButton>));
 
+PopoverMenuButton.propTypes = {
+  ['aria-label']: PropTypes.string.isRequired, 
+};
+
 export {
   PopoverContainer,
   PopoverMenuButton,

--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Icon, UnstyledButton } from '@fogcreek/shared-components';
 
 import PopoverContainer from './container';

--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -10,7 +10,7 @@ import styles from './styles.styl';
 const PopoverMenuButton = React.forwardRef((props, ref) => (<UnstyledButton className={styles.popoverMenuButton} ref={ref} {...props}><Icon icon="chevronDown" /></UnstyledButton>));
 
 PopoverMenuButton.propTypes = {
-  ['aria-label']: PropTypes.string.isRequired, 
+  'aria-label': PropTypes.string.isRequired,
 };
 
 export {

--- a/src/components/project/featured-project-options-pop.js
+++ b/src/components/project/featured-project-options-pop.js
@@ -22,7 +22,7 @@ export default function FeaturedProjectOptionsPop({ unfeatureProject, createNote
     <Popover
       align="right"
       renderLabel={({ onClick, ref }) => (
-        <PopoverMenuButton onClick={onClick} ref={ref} label="Featured Project Options" />
+        <PopoverMenuButton onClick={onClick} ref={ref} aria-label="Featured Project Options" />
       )}
     >
       {({ onClose }) => (

--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -124,7 +124,7 @@ export default function ProjectOptionsPop({ project, projectOptions }) {
     <Popover
       align="right"
       renderLabel={({ onClick, ref }) => (
-        <PopoverMenuButton onClick={onClick} ref={ref} label="Project Options for {project.domain}" />
+        <PopoverMenuButton onClick={onClick} ref={ref} aria-label="Project Options for {project.domain}" />
       )}
       views={{
         addToCollection: ({ onClose, onBack, setActiveView }) => (

--- a/src/components/project/project-options-pop.js
+++ b/src/components/project/project-options-pop.js
@@ -124,7 +124,7 @@ export default function ProjectOptionsPop({ project, projectOptions }) {
     <Popover
       align="right"
       renderLabel={({ onClick, ref }) => (
-        <PopoverMenuButton onClick={onClick} ref={ref} aria-label="Project Options for {project.domain}" />
+        <PopoverMenuButton onClick={onClick} ref={ref} aria-label={`Project Options for ${project.domain}`} />
       )}
       views={{
         addToCollection: ({ onClose, onBack, setActiveView }) => (


### PR DESCRIPTION
## Links
* https://app.clubhouse.io/glitch/story/4068/accessible-name-missing-for-project-options-buttons
* trusting-macadamia.glitch.me

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/4480480/68703169-aeb6eb00-054f-11ea-8eaf-7165813ea864.png)


## Changes:
* Buttons in HTML don't have a `label` attribute; they have `aria-label`. 
* Make `aria-label` a required prop on PopoverMenuButton since it only displays an icon that has no meaningful alt text. 
* The existing label on one of the buttons wasn't doing string interpolation correctly so it said `project options for {project.domain}` instead of `project options for soulpatch` (etc)

## How To Test:
* Run an accessibility checker extension like Axe or Accessibility Insights on pages with a project options pop

## Before deploying
Merge https://github.com/FogCreek/Glitch-Community/pull/1062  and make sure it takes precedence over the server changes here