### PR TITLE
Don't handle the error twice for invite user

### DIFF
--- a/src/state/team.js
+++ b/src/state/team.js
@@ -97,8 +97,8 @@ export function useTeamEditor(initialTeam) {
         updateCurrentUser({ teams: [...teams, team] });
       }
     }, handleError),
-    inviteEmail: (email) => inviteEmailToTeam({ team }, email).catch(handleError),
-    inviteUser: (user) => inviteUserToTeam({ user, team }).catch(handleError),
+    inviteEmail: (email) => inviteEmailToTeam({ team }, email),
+    inviteUser: (user) => inviteUserToTeam({ user, team }),
     removeUserFromTeam: withErrorHandler(async (user, projects) => {
       // Kick them out of every project at once, and wait until it's all done
       await Promise.all(projects.map((project) => removeUserFromProject({ project, user })));


### PR DESCRIPTION
## Links
* Remix link: https://joyous-nutria.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/1702/weird-ui-messaging-in-response-to-a-team-invite-failing-due-to-rate-limiting

## GIF/Screenshots:
before:
<img width="515" alt="Screen Shot 2019-11-15 at 3 18 56 PM" src="https://user-images.githubusercontent.com/6620164/68973078-52f09a00-07bb-11ea-9ba2-6add39f3d118.png">

after:
<img width="527" alt="Screen Shot 2019-11-15 at 3 19 10 PM" src="https://user-images.githubusercontent.com/6620164/68973084-57b54e00-07bb-11ea-96de-962f3ea6a390.png">

## Changes:
When we run into an error inviting a user to a team we seem to be handling it in 2 places so I'm leaving this one: https://github.com/FogCreek/Glitch-Community/blob/master/src/components/team-users/index.js#L219 and removing the generic one in team.js

## How To Test:
* create a team and invite a test user, then remove them, then invite them again you should hit the error

## Feedback I'm looking for:
should the error handling belong in team.js... some part of me wonders if this solution is too lazy, maybe I should put move all of the errors there. This just seemed easier
