### PR TITLE
Fix create collection error handling

### DIFF
--- a/src/components/collection/create-collection-pop.js
+++ b/src/components/collection/create-collection-pop.js
@@ -110,6 +110,7 @@ function CreateCollectionPopBase({ name, onBack, onSubmit, options }) {
       teamId: selection.value,
       createNotification,
     });
+    if (!collection) return; // createCollection error'd out and notified user, return early
     const team = currentUser.teams.find((t) => t.id === selection.value);
     collection.fullUrl = `${team ? team.url : currentUser.login}/${collection.url}`;
     onSubmit(collection);

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -128,6 +128,7 @@ export const AddProjectToCollectionBase = ({ project, fromProject, addProjectToC
     const shouldCreateMyStuffCollection = collection.isMyStuff && collection.id === 'nullMyStuff';
     if (shouldCreateMyStuffCollection) {
       collection = await createCollection({ api, name: 'My Stuff', createNotification });
+      if (!collection) return; // create collection error'd out and notified the user, return early
       collection.fullUrl = collection.fullUrl || `${currentUser.login}/${collection.url}`;
     }
 

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -109,7 +109,7 @@ export async function createCollection({ api, name, teamId, createNotification }
 
     return collection;
   } catch (error) {
-    captureException(error)
+    captureException(error);
     let errorMessage = 'Unable to create collection.  Try again?';
     if (!generatedName && error.response && error.response.data) {
       errorMessage = error.response.data.message;

--- a/src/models/collection.js
+++ b/src/models/collection.js
@@ -1,6 +1,7 @@
 import { kebabCase } from 'lodash';
 
 import { pickRandomColor } from 'Utils/color';
+import { captureException } from 'Utils/sentry';
 
 import { getTeamLink } from './team';
 import { getUserLink, getDisplayName as getUserDisplayName } from './user';
@@ -108,6 +109,7 @@ export async function createCollection({ api, name, teamId, createNotification }
 
     return collection;
   } catch (error) {
+    captureException(error)
     let errorMessage = 'Unable to create collection.  Try again?';
     if (!generatedName && error.response && error.response.data) {
       errorMessage = error.response.data.message;

--- a/src/state/collection.js
+++ b/src/state/collection.js
@@ -118,6 +118,7 @@ export const useToggleBookmark = (project) => {
         setHasBookmarked(true);
         if (!myStuffCollection) {
           myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
+          if (!myStuffCollection) return; // createCollection error'd out and notified user, return early
           updateCurrentUser({ collections: [myStuffCollection, ...currentUser.collections] });
         }
         await addProjectToCollection({ project, collection: myStuffCollection });
@@ -329,6 +330,7 @@ export function useCollectionEditor(initialCollection) {
       } else {
         if (!myStuffCollection) {
           myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
+          if (!myStuffCollection) return; // createCollection error'd out and notified user, return early
           updateCurrentUser({ collections: [myStuffCollection, ...currentUser.collections] });
         }
         await funcs.addProjectToCollection(project, myStuffCollection);

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -56,6 +56,7 @@ const useDefaultProjectOptions = () => {
         if (setHasBookmarked) setHasBookmarked(true);
         if (!myStuffCollection) {
           myStuffCollection = await createCollection({ api, name: 'My Stuff', createNotification });
+          if (!myStuffCollection) return; // createCollection error'd out and notified user, return early
           updateCurrentUser({ collections: [myStuffCollection, ...currentUser.collections] });
         }
         await addProjectToCollection({ project, collection: myStuffCollection });


### PR DESCRIPTION
## Links
* Remix link: https://gleaming-watercress.glitch.me/
* Issue-tracker link:
- https://app.clubhouse.io/glitch/story/1592/project-missing-id-field-when-removed-from-my-stuff
- https://app.clubhouse.io/glitch/story/1595/createcollection-error-handling-typeerror-cannot-read-property-fullurl-of-null
- https://app.clubhouse.io/glitch/story/1618/create-collection-pop-cannot-read-property-url-of-null

## Changes:
We get several types of sentry errors, that I think all stem from the same issue. We try to create a collection and it fails for some reason (ex the server is down or whatever) and then rather than 
- https://sentry.io/organizations/fog-creek-software/issues/1156993388/?project=1246508&referrer=github_integration
- https://sentry.io/organizations/fog-creek-software/issues/1156993388/?project=1246508&referrer=github_integration
- https://sentry.io/organizations/fog-creek-software/issues/1191526034/?project=1246508&referrer=github_integration

## How To Test:
* Unfortunately I don't know how to really test forcing an error but would be good to check that creating a collection still works as expected

## Feedback I'm looking for:
anything