### PR TITLE
Hungry-Pipe: Remove bad analytics origin

### DIFF
--- a/src/components/new-project-pop/index.js
+++ b/src/components/new-project-pop/index.js
@@ -48,7 +48,6 @@ const NewProjectPop = ({ projects }) => (
               name="New Project Clicked"
               properties={{
                 baseDomain: project.domain,
-                origin: 'community new project pop',
               }}
             >
               <NewProjectResultItem project={project} />


### PR DESCRIPTION
## Links
* Remix link: https://hungry-pipe.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/4218/onboarding-banner-doesn-t-fire-segment-events [ch4218]

## Changes:
At some point we added this origin to new project pop: https://github.com/FogCreek/Glitch-Community/blob/master/src/components/new-project-pop/index.js#L51 possibly when we moved to popovers? This however was a mistake. We want the origin to be set by the parent component where that New Project Pop is used and by adding it to the child we lose the parent origin. 

For example, when a user clicks on the a project in new project pop from within the onboarding banner, they will get an origin that says if they're on the onboarding banner on the home page or on their user profile: https://github.com/FogCreek/Glitch-Community/blob/ad3a3766c8aedcb0a48bdc19e520b812d30244a0/src/components/onboarding-banner/index.js#L50

When they click on the new project pop from the navbar at the top right of the screen, we set the origin to navbar: https://github.com/FogCreek/Glitch-Community/blob/master/src/components/header/index.js#L37


## How To Test:
* open segment's debugger: https://app.segment.com/fogcreek/sources/glitch_website/debugger
* open https://hungry-pipe.glitch.me/ with a user who has no projects so you see the onboarding banner
* try clicking new project pop, you should see an event for `open new-project pop` get logged with a meaningful origin
* now click on hello-webpage or some other starter project, you should see an event `New Project Clicked` get logged with a meaningful origin 
* I will add that I find segment events to be generally flakey, where if you click buttons quickly it filters things out. I often have to refresh the page for an event to get logged. 

