### PR TITLE
Fix rerender bug

### DIFF
--- a/src/presenters/pages/settings.js
+++ b/src/presenters/pages/settings.js
@@ -51,7 +51,7 @@ const Settings = () => {
   const { persistentToken, login } = currentUser;
   const isSignedIn = persistentToken && login;
   const settingsPageEnabled = isSignedIn && (userPasswordEnabled || tfaEnabled);
-  console.log("rerendering")
+
   if (!settingsPageEnabled) {
     return <NotFoundPage />;
   }

--- a/src/presenters/pages/settings.js
+++ b/src/presenters/pages/settings.js
@@ -51,7 +51,7 @@ const Settings = () => {
   const { persistentToken, login } = currentUser;
   const isSignedIn = persistentToken && login;
   const settingsPageEnabled = isSignedIn && (userPasswordEnabled || tfaEnabled);
-
+  console.log("rerendering")
   if (!settingsPageEnabled) {
     return <NotFoundPage />;
   }

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -68,7 +68,7 @@ const LocalStorageProvider = ({ children }) => {
         if (event.key) {
           setCache((oldCache) => {
             // segment updates localstorage but that doesn't need to affect our cache
-            if (event.key.includes("segment")) return oldCache;
+            if (event.key.includes('segment')) return oldCache;
 
             const newCache = new Map(oldCache);
             newCache.delete(event.key);

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -67,6 +67,9 @@ const LocalStorageProvider = ({ children }) => {
       if (event.storageArea === storageRef.current) {
         if (event.key) {
           setCache((oldCache) => {
+            // segment (and maybe other things) could update localstorage, no need to update cache
+            if (!oldCache.has(event.key)) return oldCache;
+
             const newCache = new Map(oldCache);
             newCache.delete(event.key);
             return newCache;

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -67,8 +67,8 @@ const LocalStorageProvider = ({ children }) => {
       if (event.storageArea === storageRef.current) {
         if (event.key) {
           setCache((oldCache) => {
-            // segment (and maybe other things) could update localstorage, no need to update cache
-            if (!oldCache.has(event.key)) return oldCache;
+            // segment updates localstorage but that doesn't need to affect our cache
+            if (event.key.includes("segment")) return oldCache;
 
             const newCache = new Map(oldCache);
             newCache.delete(event.key);


### PR DESCRIPTION
## Links
* Remix link: https://tremendous-handstand.glitch.me/settings

## GIF/Screenshots:
after/before
<img width="1525" alt="Screen Shot 2019-11-21 at 2 17 43 PM" src="https://user-images.githubusercontent.com/6620164/69369244-b706d880-0c69-11ea-85d4-5393d1364ef6.png">

## Changes:
While working on: https://github.com/FogCreek/Glitch-Community/pull/1069 we noticed that the /settings route kept re-rendering forever. 

This behavior matches up with what we saw back when we made /settings a conditional route and it actually caused `<Router/>` to re-render indefinitely. We made a change to put the conditional inside the Settings page component, but never really got to the bottom of why re-renders were happening in the first place, we just isolated the issue to a page that only glitch devs are using right now.

@GregWeil and @whimsicallyson and I looked at it again today and realized that when we used the dev toggle and when we had 2 versions of glitch open at one time we could see the re-renders happening. We learned that we have a storage event that fires everytime local storage is updated:
https://github.com/FogCreek/Glitch-Community/blob/master/src/state/local-storage.js#L80
and that that storage event will save a new cached object, even if the old cached object is the same as before:
https://github.com/FogCreek/Glitch-Community/blob/master/src/state/local-storage.js#L70
doing so will then update the value we then pass to our localStorageProvider:
https://github.com/FogCreek/Glitch-Community/blob/master/src/state/local-storage.js#L101
which then causes the whole page to rerender

As it turns out segment regularly updates our localStorage, about once every few seconds are so, and this is expected behavior. So instead we're only interested in updating the cache if it's a key we already know about (not any of the segment event keys for example).

This seems to prevent it from rerendering forever, and yet still seems to update the app across multiple tabs :)

## How To Test:
* It's a bit challenging to see the effects of the lack of forced rerenders without adding a bunch of console.logs (but you could locally!) For example you could console.log("hello") in the settings page and see it rerender forever in a remix of prod, but you'll see it a reasonable amount of times in this remix. I did try using the profiler react-dev tools thing and recorded the results for 30 seconds and show the screenshots up above. You can see the one on the right which is a remix of prod, seems to have many more re-renders than the one on the left which is this remix.
* I think in terms of bugs we'd be interested in seeing if anything else that is relying on this localstorage provider is broken. I'm not entirely sure what is interested in it, but I did test that signing in/out seems to work fine across tabs, as does using different dev toggles on the secret page. If you think of other things to look out for feel free to call them out here/qa them :)

## Feedback I'm looking for:
anything! this is pretty confusing stuff, so feel free to shout if something doesn't look right/make sense, its possible we're misunderstanding stuff, but this does seem to make the bug go away.

