### PR TITLE
Pickle suggestion: wake up some projects in a collection while in play mode

### DIFF
--- a/src/components/collection/collection-projects-player.js
+++ b/src/components/collection/collection-projects-player.js
@@ -150,25 +150,24 @@ const CollectionProjectsPlayer = withRouter(({ history, match, isAuthorized, fun
   const [wokeProjects, setWokeProjects] = useState({});
   const featuredProject = projects[currentProjectIndex];
 
-  /* 
+  /*
     as we tab through the projects, on every 5th project we wake up the next batch of 6.
     this makes the play experience feel snappier without having to wake up every project in the collection.
     we keep an lightweight cache in state to see if we've already woken up a project, this prevents us from
     pinging the same projects over and over again if a user is clicking the left and right arrows repeatedly.
-    
-    note: users who tab from the last project backwards or who navigate to a project directly 
+
+    note: users who tab from the last project backwards or who navigate to a project directly
     will have limited to no benefits from this useEffect, unfortunately.
   */
   useEffect(() => {
     if (currentProjectIndex % 5 === 0) {
       const nextBatch = [];
-      projects.slice(currentProjectIndex + 1, currentProjectIndex + 6).forEach(p => {
-        const alreadyWoke = wokeProjects[p.id]
-        console.log(wokeProjects, p.id, p)
+      projects.slice(currentProjectIndex + 1, currentProjectIndex + 6).forEach((p) => {
+        const alreadyWoke = wokeProjects[p.id];
         if (!alreadyWoke) {
-          setWokeProjects((prev) => ({ 
+          setWokeProjects((prev) => ({
             ...prev,
-            [p.id]: p
+            [p.id]: p,
           }));
           nextBatch.push(p);
         }


### PR DESCRIPTION
## Links
* Remix link: https://pickle-suggestion.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/4600/wake-up-projects-a-few-at-a-time

## Changes:
We decided to deploy Exploring Collection without waking up projects since we didn't want to put any additional pressure on infrastructure. That said we looked into the outage on 11-12-19, and we don't think it was related to the exploring collections feature so now that it's out and doing fine, we'd like to deploy a change to wake up some of the projects again so that the embeds transition better from one project to another as you tab through. 

to be extra conservative I've added some logic here to ensure a client only requests to wake up a few projects at a time.


## How To Test:
To test you can go to the remix and look at a collection in play mode and open the network tab and search for requests that contain `glitch.me` in them.
<img width="1584" alt="69072849-4d34c780-09fa-11ea-93cf-7c5dc64a5a64" src="https://user-images.githubusercontent.com/6620164/69568023-c303da80-0f88-11ea-9675-8d93600effe7.png">

You should see that on every 5th project we wake up 6 projects (something like this:)
<img width="1070" alt="69073032-9be26180-09fa-11ea-8470-88a4a96f4a00" src="https://user-images.githubusercontent.com/6620164/69568024-c303da80-0f88-11ea-91d6-0418d1df488c.png">

We should not re-wake up projects until you refresh the page.

## Feedback I'm looking for:
any reasons not to do this or alternatives folks can think of that they like better?
