### PR TITLE
Fix missing teams on project page

### DIFF
--- a/src/components/project/project-user.js
+++ b/src/components/project/project-user.js
@@ -82,7 +82,7 @@ const ProjectUsers = ({ users, project, reassignAdmin }) => {
   if (currentUserIsMember) {
     return (
       <div>
-        {project.teams.length && (
+        {project.teams && project.teams.length && (
           <ProfileList teams={project.teams} users={[]} layout="block" size="large" />
         )}
         <div className={styles.projectUsers}>

--- a/src/components/project/project-user.js
+++ b/src/components/project/project-user.js
@@ -14,6 +14,8 @@ import { userIsProjectAdmin, userIsProjectMember } from 'Models/project';
 import { UserAvatar } from 'Components/images/avatar';
 import { UserLink } from 'Components/link';
 import TooltipContainer from 'Components/tooltips/tooltip-container';
+import ProfileList from 'Components/profile-list';
+
 import { emoji } from 'Components/global.styl';
 
 import styles from './project-user.styl';
@@ -79,37 +81,36 @@ const ProjectUsers = ({ users, project, reassignAdmin }) => {
 
   if (currentUserIsMember) {
     return (
-      <div className={styles.projectUsers}>
-        {orderedUsers.map((user) => (
-          <Popover
-            className={styles.projectUsersPopover}
-            key={user.id}
-            align="left"
-            renderLabel={({ onClick, ref }) => (
-              <span className={styles.popoverButton}>
-                <UnstyledButton onClick={onClick} ref={ref}>
-                  <UserAvatar user={user} hideTooltip />
-                </UnstyledButton>
-              </span>
-            )}
-          >
-            {({ onClose, setActiveView }) => (
-              <PermissionsPopover onClose={onClose} setActiveView={setActiveView} user={user} project={project} reassignAdmin={reassignAdmin} />
-            )}
-          </Popover>
-        ))}
+      <div>
+        {project.teams.length && (
+          <ProfileList teams={project.teams} users={[]} layout="block" size="large" />
+        )}
+        <div className={styles.projectUsers}>
+          {orderedUsers.map((user) => (
+            <Popover
+              className={styles.projectUsersPopover}
+              key={user.id}
+              align="left"
+              renderLabel={({ onClick, ref }) => (
+                <span className={styles.popoverButton}>
+                  <UnstyledButton onClick={onClick} ref={ref}>
+                    <UserAvatar user={user} hideTooltip />
+                  </UnstyledButton>
+                </span>
+              )}
+            >
+              {({ onClose, setActiveView }) => (
+                <PermissionsPopover onClose={onClose} setActiveView={setActiveView} user={user} project={project} reassignAdmin={reassignAdmin} />
+              )}
+            </Popover>
+          ))}
+        </div>
       </div>
     );
   }
 
   return (
-    <div className={styles.projectUsers}>
-      {orderedUsers.map((user) => (
-        <UserLink key={user.id} user={user}>
-          <UserAvatar user={user} />
-        </UserLink>
-      ))}
-    </div>
+    <ProfileList teams={project.teams} users={orderedUsers} layout="block" size="large" />
   );
 };
 

--- a/src/components/project/project-user.styl
+++ b/src/components/project/project-user.styl
@@ -1,6 +1,7 @@
 @import '../constants.styl'
 
 .projectUsers
+  padding-top: 7px
   a
     display: inline-block
     margin-right: -7px


### PR DESCRIPTION
## Links
* Remix link: https://buttercup-nickel.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/4901/team-section-missing-on-project-pages

## GIF/Screenshots:
<img width="1389" alt="Screen Shot 2019-11-26 at 4 50 37 PM" src="https://user-images.githubusercontent.com/6620164/69675576-e7d17e00-106c-11ea-882e-404f9b883489.png">

## Changes:
[When I deployed the project permissions changes](https://github.com/FogCreek/Glitch-Community/pull/1085), it looks like I forgot or left out teams somehow 🤦‍♀ this brings it back. Sorry about that.

## How To Test:
go to a project page where the project belongs to a team, you should be able to see the teams it belongs to. Clicking on them should bring you to the teams page.

## Feedback I'm looking for:
One thing I'm thinking is when you own the project its a little weird having tooltips for teams which are links to those team pages AND also having the users be popovers. I wonder if we should make the teams popovers (like add/remove from team or something like that), does that sound right? If so I'll make a separate ticket for that and we can address that in another pr.
