### PR TITLE
Fix signin bug

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -60,7 +60,7 @@ export function APIContextProvider({ children }) {
 
   if (!api.persistentToken) {
     // stall requests until we have a persistentToken
-    ['get', 'post'].forEach((method) => {
+    ['get', 'post', 'put', 'patch', 'delete'].forEach((method) => {
       api[method] = async (...args) => {
         const apiWithToken = await new Promise((resolve) => {
           setPendingRequests((latestPendingRequests) => [...latestPendingRequests, resolve]);

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -57,9 +57,10 @@ export function APIContextProvider({ children }) {
   const api = getAPIForToken(persistentToken);
 
   const [pendingRequests, setPendingRequests] = useState([]);
+
   if (!api.persistentToken) {
     // stall requests until we have a persistentToken
-    ['get'].forEach((method) => {
+    ['get', 'post'].forEach((method) => {
       api[method] = async (...args) => {
         const apiWithToken = await new Promise((resolve) => {
           setPendingRequests((latestPendingRequests) => [...latestPendingRequests, resolve]);


### PR DESCRIPTION
## Links
* Remix link: https://olive-staircase.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/2523/logging-in-doesn-t-merge-in-anon-user-s-project-s-regression

## Changes:
* do not make any post requests before we have a persistent token

## How To Test:
To recreate the bug:
- go to glitch.com and log out
- create a project (remember the name of it!)
- go back to glitch.com
- you should now be an anonymous user
- try logging in with email/magic code and **click on the link** (do not copy paste code you won't recreate the bug)
- search for your project, notice it's still owned by an anoymous user and not yourself!

To see the bug fixed:
- go to glitch.com and log out
- create a project (remember the name of it!)
- go back to glitch.com
- you should now be an anonymous user
- grab your persistent token
- go to the remix and use the persistent token to be an anonymous user on your remix
- try logging in with email/magic code, when you get the email copy the link and make the domain the remix: https://olive-staircase.glitch.me/login/email?token={token}
- search for your project, you should now own it, yay!

## Feedback I'm looking for:
- is this a bad idea for some reason I'm not thinking about? It seems highly possible... 👀 
- i haven't tested the other login methods to see if those merge the two users together... not sure if there's bugs there as well and/or if they are on us, if you see another way to fix this that is more **right** definitely let me know
- one thing I noticed is that current user has a `fetched` property which I figured would be more meaningful here than a missing token, but when I used that instead, it seemed to cause an endless rerender and crashed my browser lol. But maybe you have thoughts!



