### PR TITLE
Quixotic rocket: Send 'Experiment Viewed' events to segment

### DIFF
--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -8,7 +8,7 @@ dependencies:
   '@babel/register': 7.5.5
   '@babel/runtime': 7.7.1
   '@babel/runtime-corejs3': 7.7.1
-  '@fogcreek/shared-components': 0.13.4
+  '@fogcreek/shared-components': 0.13.5
   '@jedmao/location': 2.0.4
   '@optimizely/optimizely-sdk': 3.3.1
   '@percy/cypress': 1.0.9
@@ -989,8 +989,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
-  /@fogcreek/shared-components/0.13.4:
+  /@fogcreek/shared-components/0.13.5:
     dependencies:
+      dotenv: 8.2.0
       prop-types: 15.7.2
       react-textarea-autosize: 7.1.2
     dev: false
@@ -1000,7 +1001,7 @@ packages:
       react: ^16.8.0
       styled-components: ^4.3.0
     resolution:
-      integrity: sha512-E8WA2gKGcJ88W4taN/Eizuz6I0ermnzJUaNfDF3kFxM0YKuiKz1LK6P9E1aDrjPu4V7iAu4eUxQ4zDvuYWJlCg==
+      integrity: sha512-KPxgZSxsS2km8n2jRoyzkh+sTUCqdQvX9iYalIiNqY8uEaACT4DJRG0rVnhR+GhvJjdYNrJuXVGiEWFUv36JOA==
   /@hapi/address/2.1.2:
     dev: false
     resolution:
@@ -11586,7 +11587,7 @@ specifiers:
   '@babel/register': 7.5.5
   '@babel/runtime': ^7.5.4
   '@babel/runtime-corejs3': ^7.5.5
-  '@fogcreek/shared-components': ^0.13.4
+  '@fogcreek/shared-components': ^0.13.5
   '@jedmao/location': ^2.0.4
   '@optimizely/optimizely-sdk': ^3.3.0
   '@percy/cypress': ^1.0.9

--- a/src/client.js
+++ b/src/client.js
@@ -3,7 +3,7 @@ import './polyfills';
 // Init our dayjs plugins
 import dayjs from 'dayjs';
 import relativeTimePlugin from 'dayjs/plugin/relativeTime';
-import { createInstance } from '@optimizely/optimizely-sdk';
+import { createInstance, enums } from '@optimizely/optimizely-sdk';
 
 import React from 'react';
 import ReactDOM, { hydrate, render } from 'react-dom';
@@ -61,6 +61,9 @@ window.bootstrap = async (container) => {
       },
     },
     logLevel: 'warn',
+  });
+  optimizely.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, (event) => {
+    console.log(event);
   });
   window.optimizelyClientInstance = optimizely;
   // This will happen immediately because we provided a datafile

--- a/src/client.js
+++ b/src/client.js
@@ -51,7 +51,7 @@ window.bootstrap = async (container) => {
     },
     errorHandler: {
       handleError: (error) => {
-        const ignoredErrors = ['Request error', 'localStorage', 'getItem'];
+        const ignoredErrors = ['Request error', 'localStorage', 'getItem', 'SecurityError'];
         if (ignoredErrors.some((ignored) => error.message.includes(ignored))) {
           console.warn(error);
         } else {

--- a/src/client.js
+++ b/src/client.js
@@ -62,8 +62,8 @@ window.bootstrap = async (container) => {
     },
     logLevel: 'warn',
   });
-  optimizely.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, (event) => {
-    console.log(event);
+  optimizely.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, (event) => {
+    console.log(event.decisionInfo);
   });
   window.optimizelyClientInstance = optimizely;
   // This will happen immediately because we provided a datafile

--- a/src/client.js
+++ b/src/client.js
@@ -3,7 +3,7 @@ import './polyfills';
 // Init our dayjs plugins
 import dayjs from 'dayjs';
 import relativeTimePlugin from 'dayjs/plugin/relativeTime';
-import { createInstance, enums } from '@optimizely/optimizely-sdk';
+import { createInstance } from '@optimizely/optimizely-sdk';
 
 import React from 'react';
 import ReactDOM, { hydrate, render } from 'react-dom';
@@ -61,9 +61,6 @@ window.bootstrap = async (container) => {
       },
     },
     logLevel: 'warn',
-  });
-  optimizely.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, (event) => {
-    console.log(event.decisionInfo);
   });
   window.optimizelyClientInstance = optimizely;
   // This will happen immediately because we provided a datafile

--- a/src/components/team-analytics/index.js
+++ b/src/components/team-analytics/index.js
@@ -59,14 +59,12 @@ const useAnalyticsData = createAPIHook(async (api, { id, projects, fromDate, cur
 });
 
 function useAnalytics(props) {
-  const featureEnabled = useFeatureEnabledForEntity('analytics', props.id);
   // make an object with a stable identity so it can be used as single argument to api hook
-  const memoProps = useMemo(() => ({ ...props, featureEnabled }), [featureEnabled, ...Object.values(props)]);
+  const memoProps = useMemo(() => props, Object.values(props));
   return useAnalyticsData(memoProps);
 }
 
-function BannerMessage({ id, projects }) {
-  const featureEnabled = useFeatureEnabledForEntity('analytics', id);
+function BannerMessage({ projects, featureEnabled }) {
   if (!featureEnabled) {
     return (
       <aside className={styles.inlineBanner}>
@@ -81,6 +79,8 @@ function BannerMessage({ id, projects }) {
 }
 
 function TeamAnalytics({ id, projects }) {
+  const featureEnabled = useFeatureEnabledForEntity('analytics', id);
+
   const [activeFilter, setActiveFilter] = useState('views');
 
   const [currentTimeFrame, setCurrentTimeFrame] = useState('Last 2 Weeks');
@@ -88,9 +88,9 @@ function TeamAnalytics({ id, projects }) {
 
   const [currentProject, setCurrentProject] = useState({ id: 'all-projects', domain: '' }); // empty string means all projects
 
-  const placeholder = !useFeatureEnabledForEntity('analytics', id) || projects.length === 0;
+  const placeholder = !featureEnabled || projects.length === 0;
 
-  const { value: analytics } = useAnalytics({ id, projects, fromDate, currentProjectDomain: currentProject.domain });
+  const { value: analytics } = useAnalytics({ id, projects, fromDate, currentProjectDomain: currentProject.domain, featureEnabled });
 
   const buckets = analytics ? analytics.buckets : [];
   const { totalAppViews, totalRemixes } = useMemo(
@@ -119,7 +119,7 @@ function TeamAnalytics({ id, projects }) {
     <section className={styles.container}>
       <h2>
         Analytics
-        {placeholder && <BannerMessage id={id} projects={projects} />}
+        {placeholder && <BannerMessage projects={projects} featureEnabled={featureEnabled} />}
       </h2>
 
       {projects.length > 0 && (

--- a/src/presenters/pages/secret.js
+++ b/src/presenters/pages/secret.js
@@ -5,7 +5,7 @@ import GlitchHelmet from 'Components/glitch-helmet';
 import Heading from 'Components/text/heading';
 import { useDevToggles } from 'State/dev-toggles';
 import useTest, { useTestAssignments, tests } from 'State/ab-tests';
-import { useFeatureEnabled, useRolloutsDebug } from 'State/rollouts';
+import { useRolloutsDebug } from 'State/rollouts';
 
 import styles from './secret.styl';
 
@@ -50,8 +50,7 @@ const ABTests = () => {
   );
 };
 
-const RolloutFeature = ({ feature, forced, setForced }) => {
-  const enabled = useFeatureEnabled(feature);
+const RolloutFeature = ({ feature, enabled, forced, setForced }) => {
   const onChange = (event) => {
     if (event.target.value === 'true') {
       setForced(true);
@@ -62,7 +61,7 @@ const RolloutFeature = ({ feature, forced, setForced }) => {
     }
   };
   const defaultIcon = enabled ? '✔' : null;
-  const forcedIcon = enabled ? '☑' : '☐';
+  const forcedIcon = forced ? '☑' : '☐';
   return (
     <tr>
       <td>{feature}</td>
@@ -91,8 +90,8 @@ const Rollouts = () => {
           </tr>
         </thead>
         <tbody>
-          {features.map(({ key, forced, setForced }) => (
-            <RolloutFeature key={key} feature={key} forced={forced} setForced={setForced} />
+          {features.map(({ key, enabled, forced, setForced }) => (
+            <RolloutFeature key={key} feature={key} enabled={enabled} forced={forced} setForced={setForced} />
           ))}
         </tbody>
       </table>

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -4,6 +4,11 @@ import { useTracker } from './segment-analytics';
 import { useCurrentUser } from './current-user';
 import useUserPref from './user-prefs';
 
+// human readable rollout state to include in analytics
+const DEFAULT_DESCRIPTION = {
+  true: ['variant', 'showing the new form'],
+  false: ['control', 'showing the original form'],
+};
 const ROLLOUT_DESCRIPTIONS = {
   analytics: {
     true: ['enabled', 'analytics are shown on team pages'],
@@ -17,10 +22,6 @@ const ROLLOUT_DESCRIPTIONS = {
     true: ['swapped', 'create is shown at the index'],
     false: ['control', 'see the existing homepage'],
   },
-};
-const DEFAULT_DESCRIPTION = {
-  true: ['variant', 'showing the new form'],
-  false: ['control', 'showing the original form'],
 };
 
 const Context = createContext();

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -45,7 +45,7 @@ export const useFeatureEnabledForEntity = (whichToggle, entityId) => {
 };
 
 export const useFeatureEnabled = (whichToggle) => {
-  const { optimizelyId } = useOptimizely();
+  const { optimizely, optimizelyId } = useOptimizely();
   const enabled = useFeatureEnabledForEntity(whichToggle, optimizelyId);
   useEffect(() => {
     

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -19,7 +19,8 @@ const ROLLOUT_DESCRIPTIONS = {
   },
 };
 const DEFAULT_DESCRIPTION = {
-  true: ['variant', '']
+  true: ['variant', 'showing the new form'],
+  false: ['control', 'showing the original form'],
 };
 
 const Context = createContext();
@@ -68,8 +69,8 @@ export const useFeatureEnabled = (whichToggle) => {
   const enabled = useFeatureEnabledForEntity(whichToggle, optimizelyId);
   const track = useTracker('Experiment Viewed');
   useEffect(() => {
-    const [variant, description] = descriptions[whichToggle][enabled];
     const config = optimizely.projectConfigManager.getConfig();
+    const [variant, description] = (ROLLOUT_DESCRIPTIONS[whichToggle] || DEFAULT_DESCRIPTION)[enabled];
     track({
       experiment_id: config.featureKeyMap[whichToggle].id,
       experiment_name: whichToggle,

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -51,6 +51,12 @@ export const useFeatureEnabled = (whichToggle) => {
   const track = useTracker('Experiment Viewed');
   useEffect(() => {
     const config = optimizely.projectConfigManager.getConfig();
+    const descriptions = {
+      analytics: {
+        true: ['analytics visible', 'analytics are shown on team pages'],
+        false: ['analytics hi']
+      }
+    };
     track({
       experiment_id: config.featureKeyMap[whichToggle].id,
       experiment_name: whichToggle,

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -70,7 +70,6 @@ export const useFeatureEnabledForEntity = (whichToggle, entityId) => {
     [whichToggle],
   );
   useEffect(() => {
-    console.log(id, whichToggle, enabled);
     const [variant, description] = (ROLLOUT_DESCRIPTIONS[whichToggle] || DEFAULT_DESCRIPTION)[enabled];
     track({
       experiment_id: id,

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -4,6 +4,24 @@ import { useTracker } from './segment-analytics';
 import { useCurrentUser } from './current-user';
 import useUserPref from './user-prefs';
 
+const ROLLOUT_DESCRIPTIONS = {
+  analytics: {
+    true: ['enabled', 'analytics are shown on team pages'],
+    false: ['disabled', 'team analytics are not shown'],
+  },
+  test_feature: {
+    true: ['yep', 'this is in fact a test'],
+    false: ['nope', 'but it is still a test'],
+  },
+  swap_index_create: {
+    true: ['swapped', 'create is shown at the index'],
+    false: ['control', 'see the existing homepage'],
+  },
+};
+const DEFAULT_DESCRIPTION = {
+  true: ['variant', '']
+};
+
 const Context = createContext();
 
 export const OptimizelyProvider = ({ optimizely, optimizelyId: initialOptimizelyId, children }) => {
@@ -50,19 +68,14 @@ export const useFeatureEnabled = (whichToggle) => {
   const enabled = useFeatureEnabledForEntity(whichToggle, optimizelyId);
   const track = useTracker('Experiment Viewed');
   useEffect(() => {
+    const [variant, description] = descriptions[whichToggle][enabled];
     const config = optimizely.projectConfigManager.getConfig();
-    const descriptions = {
-      analytics: {
-        true: ['analytics visible', 'analytics are shown on team pages'],
-        false: ['analytics hi']
-      }
-    };
     track({
       experiment_id: config.featureKeyMap[whichToggle].id,
       experiment_name: whichToggle,
       experiment_group: enabled ? 'variant' : 'control',
-      variant_type: enabled,
-      variant_description: null,
+      variant_type: variant,
+      variant_description: description,
     });
   }, [optimizely, whichToggle, optimizelyId, enabled]);
   return enabled;

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { enums } from '@optimizely/optimizely-sdk';
+import { useTracker } from './segment-analytics';
 import { useCurrentUser } from './current-user';
 import useUserPref from './user-prefs';
 
@@ -47,9 +48,9 @@ export const useFeatureEnabledForEntity = (whichToggle, entityId) => {
 export const useFeatureEnabled = (whichToggle) => {
   const { optimizely, optimizelyId } = useOptimizely();
   const enabled = useFeatureEnabledForEntity(whichToggle, optimizelyId);
+  const track = useTracker('Experiment Viewed');
   useEffect(() => {
-    
-  }, [optimizelyId, whichToggle, enabled]);
+  }, [optimizely, whichToggle, optimizelyId, enabled]);
   return enabled;
 };
 

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -46,7 +46,11 @@ export const useFeatureEnabledForEntity = (whichToggle, entityId) => {
 
 export const useFeatureEnabled = (whichToggle) => {
   const { optimizelyId } = useOptimizely();
-  return useFeatureEnabledForEntity(whichToggle, optimizelyId);
+  const enabled = useFeatureEnabledForEntity(whichToggle, optimizelyId);
+  useEffect(() => {
+    
+  }, [optimizelyId, whichToggle, enabled]);
+  return enabled;
 };
 
 export const RolloutsUserSync = () => {

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -50,6 +50,14 @@ export const useFeatureEnabled = (whichToggle) => {
   const enabled = useFeatureEnabledForEntity(whichToggle, optimizelyId);
   const track = useTracker('Experiment Viewed');
   useEffect(() => {
+    const config = optimizely.projectConfigManager.getConfig();
+    track({
+      experiment_id: config.featureKeyMap[whichToggle].id,
+      experiment_name: whichToggle,
+      experiment_group: enabled ? 'variant' : 'control',
+      variant_type: enabled,
+      variant_description: null,
+    });
   }, [optimizely, whichToggle, optimizelyId, enabled]);
   return enabled;
 };

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -65,20 +65,21 @@ export const useFeatureEnabledForEntity = (whichToggle, entityId) => {
   const enabled = overrides[whichToggle] !== undefined ? !!overrides[whichToggle] : raw;
 
   const track = useTracker('Experiment Viewed');
-  const feature = useOptimizelyValue(
+  const { id } = useOptimizelyValue(
     (optimizely) => optimizely.projectConfigManager.getConfig().featureKeyMap[whichToggle],
     [whichToggle],
   );
   useEffect(() => {
-    const [variant, description] = (ROLLOUT_DESCRIPTIONS[feature.key] || DEFAULT_DESCRIPTION)[enabled];
+    console.log(id, whichToggle, enabled);
+    const [variant, description] = (ROLLOUT_DESCRIPTIONS[whichToggle] || DEFAULT_DESCRIPTION)[enabled];
     track({
-      experiment_id: feature.id,
-      experiment_name: feature.key,
+      experiment_id: id,
+      experiment_name: whichToggle,
       experiment_group: enabled ? 'variant' : 'control',
       variant_type: variant,
       variant_description: description,
     });
-  }, [feature, enabled]);
+  }, [id, whichToggle, enabled]);
 
   return enabled;
 };

--- a/src/state/segment-analytics.js
+++ b/src/state/segment-analytics.js
@@ -40,9 +40,9 @@ AnalyticsContext.defaultProps = {
 
 export const useTracker = (name, properties, context) => {
   const inherited = React.useContext(Context);
-  return () => {
+  return (callProperties) => {
     try {
-      analytics.track(name, resolveProperties(properties, inherited.properties), resolveProperties(context, inherited.context));
+      analytics.track(name, resolveProperties(callProperties, resolveProperties(properties, inherited.properties)), resolveProperties(context, inherited.context));
     } catch (error) {
       /*
       From Segment: "We currently return a 200 response for all API requests so debugging should be done in the Segment Debugger.

--- a/src/state/segment-analytics.js
+++ b/src/state/segment-analytics.js
@@ -7,7 +7,10 @@ import { captureException } from 'Utils/sentry';
 
 const Context = React.createContext({ properties: {}, context: {} });
 
-const resolveProperties = (properties, inheritedProperties) => {
+const resolveProperties = (properties, inheritedProperties, ...moreProperties) => {
+  if (moreProperties.length > 0) {
+    return resolveProperties(properties, resolveProperties(inheritedProperties, ...moreProperties));
+  }
   if (isFunction(properties)) {
     return properties(inheritedProperties);
   }
@@ -42,7 +45,7 @@ export const useTracker = (name, properties, context) => {
   const inherited = React.useContext(Context);
   return (callProperties) => {
     try {
-      analytics.track(name, resolveProperties(callProperties, resolveProperties(properties, inherited.properties)), resolveProperties(context, inherited.context));
+      analytics.track(name, resolveProperties(callProperties, properties, inherited.properties), resolveProperties(context, inherited.context));
     } catch (error) {
       /*
       From Segment: "We currently return a 200 response for all API requests so debugging should be done in the Segment Debugger.


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/
https://app.clubhouse.io/glitch/story/4829/add-an-experiment-viewed-event-for-optimizely-rollouts
https://app.clubhouse.io/glitch/story/2956/error-securityerror-the-operation-is-insecure

## Changes:
- Checking for an optimizely value sends an 'Experiment Viewed' event to segment with info about the feature and status
- Cleaned up team analytics a very small amount so it only reads from optimizely once
- Changed the secret page so it doesn't trigger tracking events
- Block optimizely from sending yet another error message to sentry

## How To Test:
Load up a team page you are not a member of and notice that there is no track request. Load up a team page you are a member of, and there should be a request with info about whether analytics are enabled