### PR TITLE
Nova-chance: Fix a regression when creating anon users

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -54,21 +54,24 @@ export const getAPIForToken = memoize((persistentToken) => {
 
 export function APIContextProvider({ children }) {
   const { persistentToken } = useCurrentUser();
-  const api = getAPIForToken(persistentToken);
-
   const [pendingRequests, setPendingRequests] = useState([]);
 
-  if (!api.persistentToken) {
+  const api = useMemo(() => {
+    const rawApi = getAPIForToken(persistentToken);
+    if (rawApi.persistentToken) return rawApi;
     // stall requests until we have a persistentToken
+    const overrides = {};
     ['get', 'post', 'put', 'patch', 'delete'].forEach((method) => {
-      api[method] = async (...args) => {
+      overrides[method] = async (...args) => {
         const apiWithToken = await new Promise((resolve) => {
           setPendingRequests((latestPendingRequests) => [...latestPendingRequests, resolve]);
         });
         return apiWithToken[method](...args);
       };
     });
-  }
+    return { ...rawApi, ...overrides };
+  }, [persistentToken]);
+
   useEffect(() => {
     if (api.persistentToken && pendingRequests.length) {
       // go back and finally make all of those requests


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me/
https://app.clubhouse.io/glitch/story/4471/edge-case-anonymous-account-persists
https://app.clubhouse.io/glitch/story/5076/signing-out-of-the-community-site-gives-me-an-anonymous-user-that-can-sign-out-i-e-there-s-no-sign-in-button-until-i-refresh

## Changes:
The APIContextProvider does not modify the api object returned from getAPIForToken. Its modification stalls requests until the token is ready, once the user is loaded from localStorage or an anon user is created. Since it modified the actual api object, this affected the call to create the anon user, so depending on init order the site would never create an anon user because it was waiting for the anon user to be created.

## How To Test:
Sign out (delete `cachedUser` and `community-cachedUser` from localStorage) and make sure the sign in button appears after refreshing. Try it a few times to be sure.