### PR TITLE
Superb guide: Allow experiments to test against user signed in and project status

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -104,9 +104,10 @@ const render = async (url, { OPTIMIZELY_ID, ...context }) => {
 
 module.exports = async (url, context) => {
   const optimizelyClient = await getOptimizelyClient();
-  const optimizelyAttributes = { hasLogin: context.SSR_SIGNED_IN, hasProjects: false };
+  const optimizelyAttributes = { hasLogin: context.SSR_SIGNED_IN, hasProjects: context.SSR_HAS_PROJECTS };
   const key = [
     context.SSR_SIGNED_IN ? 'signed-in' : 'signed-out',
+    context.SSR_HAS_PROJECTS ? 'with-projects' : 'without-projects',
     ...Object.entries(context.AB_TESTS).map(([test, assignment]) => `${test}=${assignment}`),
     ...optimizelyClient.getEnabledFeatures(String(context.OPTIMIZELY_ID), optimizelyAttributes),
     url,

--- a/server/render.js
+++ b/server/render.js
@@ -104,10 +104,11 @@ const render = async (url, { OPTIMIZELY_ID, ...context }) => {
 
 module.exports = async (url, context) => {
   const optimizelyClient = await getOptimizelyClient();
+  const optimizelyAttributes = { hasLogin: context.SSR_SIGNED_IN, hasProjects: false };
   const key = [
     context.SSR_SIGNED_IN ? 'signed-in' : 'signed-out',
     ...Object.entries(context.AB_TESTS).map(([test, assignment]) => `${test}=${assignment}`),
-    ...optimizelyClient.getEnabledFeatures(String(context.OPTIMIZELY_ID)),
+    ...optimizelyClient.getEnabledFeatures(String(context.OPTIMIZELY_ID), optimizelyAttributes),
     url,
   ];
   return getFromCache(key.join(' '), render, url, context);

--- a/server/routes.js
+++ b/server/routes.js
@@ -83,6 +83,7 @@ module.exports = function(EXTERNAL_ROUTES) {
       OPTIMIZELY_ID: getOptimizelyId(req, res),
       PUPDATES_CONTENT: readCuratedContent('pupdates'),
       SSR_SIGNED_IN: !!req.cookies.hasLogin,
+      SSR_HAS_PROJECTS: !!req.cookies.hasProjects,
       ZINE_POSTS: getZine(),
     });
 

--- a/src/client.js
+++ b/src/client.js
@@ -74,6 +74,7 @@ window.bootstrap = async (container) => {
         HOME_CONTENT={window.HOME_CONTENT}
         PUPDATES_CONTENT={window.PUPDATES_CONTENT}
         SSR_SIGNED_IN={window.SSR_SIGNED_IN}
+        SSR_HAS_PROJECTS={window.SSR_HAS_PROJECTS}
         ZINE_POSTS={window.ZINE_POSTS}
       >
         <TestsProvider AB_TESTS={window.AB_TESTS}>

--- a/src/server.js
+++ b/src/server.js
@@ -17,7 +17,7 @@ const Page = ({
   OPTIMIZELY_ID,
   PUPDATES_CONTENT,
   SSR_SIGNED_IN,
-  SSR+
+  SSR_HAS_PROJECTS,
   ZINE_POSTS,
   optimizely,
   helmetContext,
@@ -30,6 +30,7 @@ const Page = ({
       HOME_CONTENT={HOME_CONTENT}
       PUPDATES_CONTENT={PUPDATES_CONTENT}
       SSR_SIGNED_IN={SSR_SIGNED_IN}
+      SSR_HAS_PROJECTS={SSR_HAS_PROJECTS}
       ZINE_POSTS={ZINE_POSTS}
     >
       <TestsProvider AB_TESTS={AB_TESTS}>

--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,7 @@ const Page = ({
   OPTIMIZELY_ID,
   PUPDATES_CONTENT,
   SSR_SIGNED_IN,
+  SSR+
   ZINE_POSTS,
   optimizely,
   helmetContext,

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -15,6 +15,16 @@ const getStorageMemo = memoize(getStorage);
 const getFromStorage = (key) => readFromStorage(getStorageMemo(), key);
 const setStorage = (key, value) => writeToStorage(getStorageMemo(), key, value);
 
+function setCookie(name, value) {
+  if (value) {
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+    document.cookie = `${name}=true; path=/; expires=${expires}`;
+  } else {
+    document.cookie = `${name}=; path=/; expires=${new Date()}`;
+  }
+}
+
 function identifyUser(user) {
   if (user) {
     addBreadcrumb({
@@ -27,13 +37,8 @@ function identifyUser(user) {
       message: 'logged out',
     });
   }
-  if (user && user.login) {
-    const expires = new Date();
-    expires.setFullYear(expires.getFullYear() + 1);
-    document.cookie = `hasLogin=true; path=/; expires=${expires}`;
-  } else {
-    document.cookie = `hasLogin=; path=/; expires=${new Date()}`;
-  }
+  setCookie('hasLogin', user && user.login);
+  setCookie('hasProjects', user && user.projects.length > 0);
   try {
     if (window.analytics && user && user.login) {
       const emailObj = Array.isArray(user.emails) && user.emails.find((email) => email.primary);

--- a/src/state/globals.js
+++ b/src/state/globals.js
@@ -21,6 +21,7 @@ GlobalsProvider.propTypes = {
   HOME_CONTENT: PropTypes.object.isRequired,
   PUPDATES_CONTENT: PropTypes.object.isRequired,
   SSR_SIGNED_IN: PropTypes.bool.isRequired,
+  SSR_HAS_PROJECTS: PropTypes.bool.isRequired,
   ZINE_POSTS: PropTypes.array.isRequired,
 };
 

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -88,14 +88,15 @@ export const useFeatureEnabled = (whichToggle) => {
   const { optimizelyId } = useOptimizely();
   const { currentUser } = useCurrentUser();
   const { SSR_SIGNED_IN, SSR_HAS_PROJECTS } = useGlobals();
+  console.log(SSR_SIGNED_IN, SSR_HAS_PROJECTS);
 
   const attributes = useMemo(() => {
-    const ssrState = { hasLogin: SSR_SIGNED_IN, hasProjects: SSR_HAS_PROJECTS };
     const hasLogin = !!currentUser.login;
     const hasProjects = currentUser.projects.length > 0;
     const userState = { hasLogin, hasProjects };
+    const ssrState = { hasLogin: SSR_SIGNED_IN, hasProjects: SSR_HAS_PROJECTS };
     return currentUser.id ? userState : ssrState;
-  }, [currentUser.id, currentUser.login, currentUser.projects.length, SSR_SIGNED_IN]);
+  }, [currentUser.id, currentUser.login, currentUser.projects.length, SSR_SIGNED_IN, SSR_HAS_PROJECTS]);
 
   return useFeatureEnabledForEntity(whichToggle, optimizelyId, attributes);
 };

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -87,10 +87,10 @@ export const useFeatureEnabledForEntity = (whichToggle, entityId, attributes) =>
 export const useFeatureEnabled = (whichToggle) => {
   const { optimizelyId } = useOptimizely();
   const { currentUser } = useCurrentUser();
-  const { SSR_SIGNED_IN } = useGlobals();
+  const { SSR_SIGNED_IN, SSR_HAS_PROJECTS } = useGlobals();
 
   const attributes = useMemo(() => {
-    const ssrState = { hasLogin: SSR_SIGNED_IN, hasProjects: false };
+    const ssrState = { hasLogin: SSR_SIGNED_IN, hasProjects: SSR_HAS_PROJECTS };
     const hasLogin = !!currentUser.login;
     const hasProjects = currentUser.projects.length > 0;
     const userState = { hasLogin, hasProjects };

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -42,7 +42,7 @@ export const OptimizelyProvider = ({ optimizely, optimizelyId: initialOptimizely
 const defaultOverrides = {};
 const useOptimizely = () => useContext(Context);
 const useOverrides = () => useUserPref('optimizelyOverrides', defaultOverrides);
-
+// the id+attributes combo for the current user
 const useDefaultUser = () => {
   const { optimizelyId } = useOptimizely();
   const { currentUser } = useCurrentUser();

--- a/src/state/rollouts.js
+++ b/src/state/rollouts.js
@@ -47,16 +47,15 @@ const useDefaultUser = () => {
   const { optimizelyId } = useOptimizely();
   const { currentUser } = useCurrentUser();
   const { SSR_SIGNED_IN, SSR_HAS_PROJECTS } = useGlobals();
-  const attributes = useMemo(() => currentUser.id ? {
-        hasLogin: !!currentUser.login,
-        hasProjects: currentUser.projects.length > 0,
-      };
-    }
-    return {
+  const attributes = useMemo(() => (
+    currentUser.id ? {
+      hasLogin: !!currentUser.login,
+      hasProjects: currentUser.projects.length > 0,
+    } : {
       hasLogin: SSR_SIGNED_IN,
       hasProjects: SSR_HAS_PROJECTS,
-    };
-  }, [currentUser.id, currentUser.login, currentUser.projects.length, SSR_SIGNED_IN, SSR_HAS_PROJECTS]);
+    }
+  ), [currentUser.id, currentUser.login, currentUser.projects.length, SSR_SIGNED_IN, SSR_HAS_PROJECTS]);
   return [optimizelyId, attributes];
 };
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -45,6 +45,7 @@
       var PUPDATES_CONTENT = <%- JSON.stringify(PUPDATES_CONTENT) %>;
       var API_CACHE = <%- JSON.stringify(API_CACHE) %>;
       var SSR_SIGNED_IN = <%- SSR_SIGNED_IN %>;
+      var SSR_HAS_PROJECTS = <%- SSR_HAS_PROJECTS %>;
       var AB_TESTS = <%- JSON.stringify(AB_TESTS) %>;
       var OPTIMIZELY_DATA = <%- JSON.stringify(OPTIMIZELY_DATA) %>;
       var OPTIMIZELY_ID = <%- JSON.stringify(OPTIMIZELY_ID) %>;


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/secret
https://app.clubhouse.io/glitch/story/5135/optimizely-features-that-depend-on-the-user-being-signed-out-and-not-having-projects

## Changes:
- Added a new 'user has projects' cookie to track if the user has projects for server rendering
- Send the hasLogin and hasProjects to optimizely so experiments can be made conditional on them

## How To Test:
Reload the secret page and run `window.cookie='optimizely-id='` in an incognito window until the swap test is enabled, then copy your persistent token to glitch.com and create a project. When you refresh the secret page the experiment should not be active.

## Things left to do before deploying:
- Get the hasProjects cookie whitelisted in cloudfront (not needed until the homepage/create test)