### PR TITLE
State updates for user deletion

### DIFF
--- a/src/components/team/delete-team-pop.js
+++ b/src/components/team/delete-team-pop.js
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { Actions, Button, DangerZone, Icon, Loader, Popover, Title } from '@fogcreek/shared-components';
 
 import Image from 'Components/images/image';
-import { useAPIHandlers } from 'State/api';
+import { useTeamEditor } from 'State/team';
 import { useNotifications } from 'State/notifications';
 // import { teamAdmins } from 'Models/team';
 
@@ -12,9 +12,9 @@ import { emoji } from '../global.styl';
 
 const illustration = 'https://cdn.glitch.com/c53fd895-ee00-4295-b111-7e024967a033%2Fdelete-team.svg?1531267699621';
 
-const DeleteTeamPop = ({ team }) => {
+const DeleteTeamPop = ({ team: initialTeam }) => {
   const history = useHistory();
-  const { deleteItem } = useAPIHandlers();
+  const [team, funcs] = useTeamEditor(initialTeam);
   const { createNotification } = useNotifications();
   const [teamIsDeleting, setTeamIsDeleting] = useState(false);
 
@@ -22,7 +22,7 @@ const DeleteTeamPop = ({ team }) => {
     if (teamIsDeleting) return;
     setTeamIsDeleting(true);
     try {
-      await deleteItem({ team });
+      await funcs.deleteItem({ team });
       history.push('/');
     } catch (error) {
       console.error('deleteTeam', error, error.response);

--- a/src/components/team/delete-team-pop.js
+++ b/src/components/team/delete-team-pop.js
@@ -22,7 +22,7 @@ const DeleteTeamPop = ({ team: initialTeam }) => {
     if (teamIsDeleting) return;
     setTeamIsDeleting(true);
     try {
-      await funcs.deleteItem({ team });
+      await funcs.deleteTeam({ team });
       history.push('/');
     } catch (error) {
       console.error('deleteTeam', error, error.response);

--- a/src/components/team/team-item.js
+++ b/src/components/team/team-item.js
@@ -11,27 +11,16 @@ import VerifiedBadge from 'Components/verified-badge';
 import ProfileList from 'Components/profile-list';
 import { TeamLink, WrappingLink } from 'Components/link';
 import { getTeamLink, getTeamAvatarUrl, DEFAULT_TEAM_AVATAR } from 'Models/team';
-import { createAPIHook } from 'State/api';
-import { captureException } from 'Utils/sentry';
+import { useTeamMembers } from 'State/team';
 
 import styles from './team-item.styl';
-
-const useTeamUsers = createAPIHook(async (api, teamID) => {
-  try {
-    const res = await api.get(`/v1/teams/by/id/users?id=${teamID}&limit=10`);
-    return res.data.items;
-  } catch (e) {
-    captureException(e);
-    return [];
-  }
-});
 
 const ProfileAvatar = ({ team }) => <Image className={styles.avatar} src={getTeamAvatarUrl(team)} defaultSrc={DEFAULT_TEAM_AVATAR} alt="" />;
 
 const getTeamThanksCount = (team) => sumBy(team.users, (user) => user.thanksCount);
 
 const TeamItem = ({ team }) => {
-  const { value: users } = useTeamUsers(team.id);
+  const { value: users } = useTeamMembers(team.id);
   return (
     <WrappingLink className={styles.container} href={getTeamLink(team)}>
       <Cover type="team" item={team} size="medium" />

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -5,6 +5,7 @@ import { useAPI, useAPIHandlers } from 'State/api';
 import useErrorHandlers from 'State/error-handlers';
 import * as assets from 'Utils/assets';
 import { getAllPages } from 'Shared/api';
+import { useCurrentUser } from 'State/current-user';
 import { MEMBER_ACCESS_LEVEL, ADMIN_ACCESS_LEVEL } from 'Models/project';
 
 async function getMembers(api, projectId, withCacheBust) {
@@ -93,6 +94,7 @@ export function useProjectReload() {
 }
 
 export function useProjectEditor(initialProject) {
+  const { currentUser, update: updateCurrentUser } = useCurrentUser();
   const [project, setProject] = useState(initialProject);
   const { uploadAsset } = useUploader();
   const { handleError, handleErrorForInput, handleImageUploadError } = useErrorHandlers();
@@ -106,14 +108,26 @@ export function useProjectEditor(initialProject) {
       ...prev,
       ...changes,
     }));
+    updateCurrentUser({
+      projects: currentUser.projects.map((p) => {
+        if (p.id === project.id) {
+          return { ...p, ...changes };
+        }
+        return p;
+      }),
+    });
   }
 
   const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler);
 
   const funcs = {
-    deleteProject: () => deleteItem({ project }).catch(handleError),
+    deleteProject: () => {
+      const projects = currentUser.projects.filter((p) => p.id !== project.id);
+      updateCurrentUser({ projects });
+      return deleteItem({ project }).catch(handleError);
+    },
     updateDomainBackend: withErrorHandler(async (domain) => {
-      await updateItem({ project }, { domain });
+      await updateFields({ domain });
       // don't await this because the project domain has already changed and I don't want to delay other things updating
       updateProjectDomain({ project });
     }, handleErrorForInput),
@@ -140,7 +154,7 @@ export function useProjectEditor(initialProject) {
           }));
         }, handleImageUploadError),
       ),
-    reassignAdmin: async ({ currentUser, user }) => {
+    reassignAdmin: async ({ user }) => {
       await updateProjectMemberAccessLevel({ project, user, accessLevel: ADMIN_ACCESS_LEVEL });
       await updateProjectMemberAccessLevel({ project, user: currentUser, accessLevel: MEMBER_ACCESS_LEVEL });
       const newPermissions = [...project.permissions].map((permission) => {
@@ -162,6 +176,15 @@ export function useProjectEditor(initialProject) {
         return { ...oldUser };
       });
       setProject((prev) => ({ ...prev, permissions: newPermissions, users: newUsers }));
+      updateCurrentUser({
+        projects: currentUser.projects.map((p) => {
+          if (p.id === project.id) {
+            p = { ...p, permissions: newPermissions, users: newUsers };
+            p.permission = { ...p.permission, accessLevel: MEMBER_ACCESS_LEVEL };
+          }
+          return p;
+        }),
+      });
     },
   };
 

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -121,17 +121,11 @@ export function useProjectEditor(initialProject) {
   const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler);
 
   const funcs = {
-    deleteProject: () => {
+    deleteProject: withErrorHandler(async() => {
+      await deleteItem({ project });
       const projects = currentUser.projects.filter((p) => p.id !== project.id);
-      const deleteStatus = deleteItem({ project }).catch(handleError).then(
-        (res) => {
-          if (res.data === 'OK') {
-            updateCurrentUser({ projects });
-          }
-        },
-      );
-      return deleteStatus;
-    },
+      updateCurrentUser({ projects });
+      },handleError),
     updateDomainBackend: withErrorHandler(async (domain) => {
       updateItem({ project }, { domain });
       // don't await this because the project domain has already changed and I don't want to delay other things updating

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -127,7 +127,7 @@ export function useProjectEditor(initialProject) {
       updateCurrentUser({ projects });
     }, handleError),
     updateDomainBackend: withErrorHandler(async (domain) => {
-      updateItem({ project }, { domain });
+      await updateItem({ project }, { domain });
       // don't await this because the project domain has already changed and I don't want to delay other things updating
       updateProjectDomain({ project });
     }, handleErrorForInput),

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -121,11 +121,11 @@ export function useProjectEditor(initialProject) {
   const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler);
 
   const funcs = {
-    deleteProject: withErrorHandler(async() => {
+    deleteProject: withErrorHandler(async () => {
       await deleteItem({ project });
       const projects = currentUser.projects.filter((p) => p.id !== project.id);
       updateCurrentUser({ projects });
-      },handleError),
+    }, handleError),
     updateDomainBackend: withErrorHandler(async (domain) => {
       updateItem({ project }, { domain });
       // don't await this because the project domain has already changed and I don't want to delay other things updating

--- a/src/state/project.js
+++ b/src/state/project.js
@@ -123,11 +123,17 @@ export function useProjectEditor(initialProject) {
   const funcs = {
     deleteProject: () => {
       const projects = currentUser.projects.filter((p) => p.id !== project.id);
-      updateCurrentUser({ projects });
-      return deleteItem({ project }).catch(handleError);
+      const deleteStatus = deleteItem({ project }).catch(handleError).then(
+        (res) => {
+          if (res.data === 'OK') {
+            updateCurrentUser({ projects });
+          }
+        },
+      );
+      return deleteStatus;
     },
     updateDomainBackend: withErrorHandler(async (domain) => {
-      await updateFields({ domain });
+      updateItem({ project }, { domain });
       // don't await this because the project domain has already changed and I don't want to delay other things updating
       updateProjectDomain({ project });
     }, handleErrorForInput),

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -93,17 +93,11 @@ export function useTeamEditor(initialTeam) {
   const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler);
 
   const funcs = {
-    deleteTeam: () => {
+    deleteTeam: withErrorHandler(async() => {
+      await deleteItem({ team });
       const teams = currentUser.teams.filter((t) => t.id !== team.id);
-      const deleteStatus = deleteItem({ team }).catch(handleError).then(
-        (res) => {
-          if (res.data === 'OK') {
-            updateCurrentUser({ teams });
-          }
-        },
-      );
-      return deleteStatus;
-    },
+      updateCurrentUser({ teams });
+      },handleError),
     updateName: (name) => updateFields({ name }).catch(handleErrorForInput),
     updateUrl: (url) => updateFields({ url }).catch(handleErrorForInput),
     updateDescription: (description) => updateFields({ description }).catch(handleErrorForInput),

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -93,11 +93,11 @@ export function useTeamEditor(initialTeam) {
   const withErrorHandler = (fn, handler) => (...args) => fn(...args).catch(handler);
 
   const funcs = {
-    deleteTeam: withErrorHandler(async() => {
+    deleteTeam: withErrorHandler(async () => {
       await deleteItem({ team });
       const teams = currentUser.teams.filter((t) => t.id !== team.id);
       updateCurrentUser({ teams });
-      },handleError),
+    }, handleError),
     updateName: (name) => updateFields({ name }).catch(handleErrorForInput),
     updateUrl: (url) => updateFields({ url }).catch(handleErrorForInput),
     updateDescription: (description) => updateFields({ description }).catch(handleErrorForInput),

--- a/src/state/team.js
+++ b/src/state/team.js
@@ -95,8 +95,14 @@ export function useTeamEditor(initialTeam) {
   const funcs = {
     deleteTeam: () => {
       const teams = currentUser.teams.filter((t) => t.id !== team.id);
-      updateCurrentUser({ teams });
-      return deleteItem({ team }).catch(handleError);
+      const deleteStatus = deleteItem({ team }).catch(handleError).then(
+        (res) => {
+          if (res.data === 'OK') {
+            updateCurrentUser({ teams });
+          }
+        },
+      );
+      return deleteStatus;
     },
     updateName: (name) => updateFields({ name }).catch(handleErrorForInput),
     updateUrl: (url) => updateFields({ url }).catch(handleErrorForInput),

--- a/src/state/user.js
+++ b/src/state/user.js
@@ -125,15 +125,20 @@ export function useUserEditor(initialUser) {
         projects: prev.projects.filter((p) => p.id !== project.id),
         _deletedProjects: [deletedProjectWithPermission, ...prev._deletedProjects], // eslint-disable-line no-underscore-dangle
       }));
+      updateCurrentUser({
+        projects: currentUser.projects.filter((p) => p.id !== project.id),
+      });
     }, handleError),
     undeleteProject: withErrorHandler(async (project) => {
       await undeleteProject({ project });
       const data = await getProject({ project });
       // temp set undeleted project updatedAt to now, while it's actually updating behind the scenes
       data.updatedAt = Date.now();
+      const permission = data.permissions.find((p) => p.userId === currentUser.id);
+      const undeletedProjectWithPermission = { ...data, permission };
       setUser((prev) => ({
         ...prev,
-        projects: [data, ...prev.projects],
+        projects: [undeletedProjectWithPermission, ...prev.projects],
         _deletedProjects: prev._deletedProjects.filter((p) => p.id !== project.id), // eslint-disable-line no-underscore-dangle
       }));
     }, handleError),


### PR DESCRIPTION
## Links
* https://cookie-ricotta.glitch.me/
* https://app.clubhouse.io/glitch/story/3863/team-ownership-transfer-highlights-and-links-out-to-which-teams-have-multiple-members-but-only-one-admin-step-2a
* https://app.clubhouse.io/glitch/story/3864/project-ownership-transfer-highlights-and-links-out-to-which-projects-have-multiple-members-but-only-one-admin-step-2a
* https://docs.google.com/document/d/1ya5WQraU0OPXf22uCsTGhaNnFU-3XyVLHSqGHzMkTPk/edit#heading=h.3im6lap0txtw (design spec)
* https://docs.google.com/document/d/17O0aLlf0znuCN4-LuVihAkGzsUtdFpv4uV7dQpouvWI/edit#heading=h.c3jzht6x35ee (tech spec)

## Changes:
* In order to have the delete account modal properly know what projects and teams are preventing account deletion, we need to update currentUser when changes happen. Now we do!

## How To Test:
* throw some `console.log`s in to make sure the currentUser updates with the proper info on a project or team delete, or a admin change. 
* make sure that the project/team has properly deleted or the admin has changed

things that have changed (but should still work the same from a user POV):
  * Changing the admin of a project
  * Deleting a project
  * Changing the admin status of another person on a team
  * Changing the admin status of yourself on a team (only possible if there are other admins left)
  * Deleting a team

## Feedback I'm looking for:
um, anything you've got! 
if you'd like to reference it, #1069 is the oversized "everything in once place" WIP PR that this is pulled from
