### PR TITLE
create multi-page delete modal

### DIFF
--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import Pluralize from 'react-pluralize';
+import { Actions, Button, DangerZone, Icon, Info, Overlay, Title, useOverlay, mergeRefs } from '@fogcreek/shared-components';
+
+import { useCurrentUser } from 'State/current-user';
+
+import Link from 'Components/link';
+import MultiPage from '../layout/multi-page';
+
+import styles from './delete-account-modal.styl';
+import { emoji } from '../global.styl';
+
+const DeleteInfo = ({ setPage, onClose, first, focusedOnMount, last }) => (
+  <>
+    <Title onClose={onClose} onCloseRef={mergeRefs(first, focusedOnMount)}>
+      Delete Account <Icon className={emoji} icon="coffin" />
+    </Title>
+    <Actions>
+      <p>Once your account is deleted, all of your project, teams and collections will be gone forever!</p>
+      <p>If you are sharing any teams or projects, we'll walk you though transferring ownership before you delete your account.</p>
+    </Actions>
+    <Info>
+      <p>
+        You can export any of your projects but only <b>before</b> you delete your account.
+      </p>
+      <Button onClick={() => console.log('Learning more')} className={styles.modalButton} size="small" variant="secondary">
+        Learn about exporting <Icon className={emoji} icon="arrowRight" />
+      </Button>
+    </Info>
+    <DangerZone>
+      <p>For security purposes, you must confirm via email before we delete your account.</p>
+      <Button ref={last} onClick={() => setPage('projectOwnerTransfer')} className={styles.modalButton} size="small" variant="warning">
+        Continue to Delete Account
+      </Button>
+    </DangerZone>
+  </>
+);
+const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
+  <>
+    <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Transfer Team Ownership</Title>
+    <Info>
+      You must <Link to="/">pick a new team admin</Link> or <Link to="/">delete</Link> these teams before you can delete your account.
+    </Info>
+    <Actions>
+      <Button className={styles.actionButton} onClick={() => setPage('emailConfirm')}>
+        Continue to Delete Account
+      </Button>
+      <Button className={styles.actionButton} variant="secondary" ref={last} onClick={onClose}>
+        Close
+      </Button>
+    </Actions>
+  </>
+);
+
+const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
+  <>
+    <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Transfer Project Ownership</Title>
+    <Info>
+      You must <Link to="/">transfer ownership</Link> or <Link to="/">delete</Link> these projects before you can delete your account.
+    </Info>
+    <Actions>
+      <Button className={styles.actionButton} onClick={() => setPage('teamOwnerTransfer')}>
+        Continue to Delete Account
+      </Button>
+      <Button className={styles.actionButton} variant="secondary" onClick={onClose} ref={last}>
+        Close
+      </Button>
+    </Actions>
+  </>
+);
+
+const EmailConfirm = ({ onClose, first, focusedOnMount, last }) => {
+  const { currentUser } = useCurrentUser();
+  const soloProjects = currentUser.projects.filter((project) => project.permissions.length === 1);
+  const soloTeams = currentUser.teams.filter((team) => team.teamPermissions.length === 1);
+  const soloCollections = currentUser.collections; // all collections are solo, at least currently
+  return (
+    <>
+      <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Email Confirmation Sent</Title>
+      <Actions>
+        <p>For security purposes, we've sent an email confirmation.</p>
+        <p>Please click the link in the email to finish deleting your account.</p>
+        <p>
+          If you choose to delete your account,{' '}
+          <b>
+            <Pluralize count={soloProjects.length} singular="project" />, <Pluralize count={soloTeams.length} singular="team" />, and{' '}
+            <Pluralize count={soloCollections.length} singular="collection" />
+          </b>{' '}
+          will be deleted forever.
+        </p>
+      </Actions>
+      <Actions>
+        <Button onClick={onClose} ref={last}>
+          Close
+        </Button>
+      </Actions>
+    </>
+  );
+};
+
+const DeleteSettings = () => {
+  const { open, onOpen, onClose, toggleRef } = useOverlay();
+  return (
+    <>
+      <h2>Delete Account</h2>
+      <Button onClick={onOpen} ref={toggleRef}>
+        Delete Account <Icon className={emoji} icon="coffin" />
+      </Button>
+      <Overlay open={open} onClose={onClose}>
+        {({ first, last, focusedOnMount }) => (
+          <MultiPage defaultPage="info">
+            {({ page, setPage }) => (
+              <>
+                {page === 'info' ? (
+                  <DeleteInfo setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} />
+                ) : null}
+                {page === 'projectOwnerTransfer' ? <ProjectTransfer setPage={setPage} onClose={onClose} /> : null}
+                {page === 'teamOwnerTransfer' ? <TeamTransfer setPage={setPage} onClose={onClose} /> : null}
+                {page === 'emailConfirm' ? <EmailConfirm onClose={onClose} /> : null}
+              </>
+            )}
+          </MultiPage>
+        )}
+      </Overlay>
+    </>
+  );
+};
+
+export default DeleteSettings;

--- a/src/components/delete-account/delete-account-modal.styl
+++ b/src/components/delete-account/delete-account-modal.styl
@@ -1,0 +1,16 @@
+[data-module="Button"].modalButton
+  margin-bottom: 10px
+
+[data-module="Info"].remaining
+  display: flex
+  justify-content: space-between
+  p
+    margin: 0
+  [data-module="Badge"]
+    vertical-align: baseline
+
+[data-module="Button"].actionButton
+  display: block
+  + [data-module="Button"].actionButton
+    margin-top: 8px 
+    

--- a/src/presenters/pages/settings.js
+++ b/src/presenters/pages/settings.js
@@ -1,46 +1,18 @@
 import React from 'react';
-import { Actions, Button, DangerZone, Icon, Info, Overlay, Title, useOverlay, mergeRefs } from '@fogcreek/shared-components';
+import { Button, Icon } from '@fogcreek/shared-components';
 
 import Layout from 'Components/layout';
 import GlitchHelmet from 'Components/glitch-helmet';
 import Heading from 'Components/text/heading';
 import PasswordSettings from 'Components/account-settings-overlay/password-settings';
 import TwoFactorSettings from 'Components/account-settings-overlay/two-factor-settings';
+import DeleteSettings from 'Components/delete-account/delete-account-modal';
 import useDevToggle from 'State/dev-toggles';
 import { useCurrentUser } from 'State/current-user';
 import { NotFoundPage } from './error';
 
 import styles from './settings.styl';
 import { emoji } from '../../components/global.styl';
-
-const DeleteSettings = () => {
-  const { open, onOpen, onClose, toggleRef } = useOverlay();
-
-  return (
-    <>
-      <Button onClick={onOpen} ref={toggleRef}>Delete Account <Icon className={emoji} icon="coffin" /></Button>
-      <Overlay open={open} onClose={onClose}>
-        {({ first, last, focusedOnMount }) => (
-          <>
-            <Title onClose={onClose} onCloseRef={mergeRefs(first, focusedOnMount)}>Delete Account <Icon className={emoji} icon="coffin" /></Title>
-            <Actions>
-              <p>Once your account is deleted, all of your project, teams and collections will be gone forever!</p>
-              <p>If you are sharing any teams or projects, we'll walk you though transferring ownership before you delete your account.</p>
-            </Actions>
-            <Info>
-              <p>You can export any of your projects but only <b>before</b> you delete your account.</p>
-              <Button onClick={() => console.log('Learning more')} className={styles.modalButton} size="small" variant="secondary">Learn about exporting <Icon className={emoji} icon="arrowRight" /></Button>
-            </Info>
-            <DangerZone>
-              <p>For security purposes, you must confirm via email before we delete your account.</p>
-              <Button ref={last} onClick={() => console.log("I'm a scary button!")} className={styles.modalButton} size="small" variant="warning">Continue to Delete Account</Button>
-            </DangerZone>
-          </>
-        )}
-      </Overlay>
-    </>
-  );
-};
 
 const Settings = () => {
   const tagline = 'Account Settings';

--- a/src/presenters/pages/settings.styl
+++ b/src/presenters/pages/settings.styl
@@ -15,6 +15,3 @@
   padding-left: 10px
   .contentSection
     padding-bottom: 100px
-
-[data-module="Button"].modalButton
-  margin-bottom: 10px


### PR DESCRIPTION
## Links
* https://breezy-ocelot.glitch.me/
* https://app.clubhouse.io/glitch/story/3863/team-ownership-transfer-highlights-and-links-out-to-which-teams-have-multiple-members-but-only-one-admin-step-2a
* https://app.clubhouse.io/glitch/story/3864/project-ownership-transfer-highlights-and-links-out-to-which-projects-have-multiple-members-but-only-one-admin-step-2a
* https://app.clubhouse.io/glitch/story/3865/email-confirmation-sent-explains-to-the-user-that-they-should-have-received-an-email-with-a-link-to-truly-delete-their-account
* https://docs.google.com/document/d/1ya5WQraU0OPXf22uCsTGhaNnFU-3XyVLHSqGHzMkTPk/edit#heading=h.3im6lap0txtw (design spec)
* https://docs.google.com/document/d/17O0aLlf0znuCN4-LuVihAkGzsUtdFpv4uV7dQpouvWI/edit#heading=h.c3jzht6x35ee (tech spec)

## Changes:
* Moves delete-modal into its own file, creates a multi-pane view to click through the deletion steps

## How To Test:
* turn on user passwords and account deletion in `/secret`
* go to `/settings`
* click through the modal! It shouldn't really *do* anything, but you can see the different panes

## Feedback I'm looking for:
whatever you've got!

## Things left to do before deploying:

