### PR TITLE
Astonishing orchestra: Projects modal pane

### DIFF
--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -6,6 +6,7 @@ import { useCurrentUser } from 'State/current-user';
 
 import Link from 'Components/link';
 import ProjectResultItem from 'Components/project/project-result-item';
+import { getProjectLink } from 'Models/project';
 import MultiPage from '../layout/multi-page';
 
 import styles from './delete-account-modal.styl';
@@ -75,8 +76,8 @@ const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
       </Info>
       {singleAdminProjects.length > 0 ? (
         <ResultsList value={currentlyFocusedProject} onChange={onSelectProject} options={singleAdminProjects} scroll>
-          {({ item: project, buttonProps }) => (
-            <ProjectResultItem project={project} onClick={() => {}} buttonProps={buttonProps} profileListAsLinks={false} isALink />
+          {({ item: project }) => (
+            <ProjectResultItem project={project} onClick={() => window.open(`${getProjectLink(project)}`, '_blank')} />
           )}
         </ResultsList>
       ) : (

--- a/src/components/project/project-result-item.js
+++ b/src/components/project/project-result-item.js
@@ -24,22 +24,25 @@ const ProfileListWrap = ({ project, asLinks }) => (
   </div>
 );
 
-const ProjectResultItem = ({ project, onClick, profileListAsLinks, buttonProps }) => (
-  <ResultItem className={classnames(project.private && styles.private)} onClick={() => onClick(project)} {...buttonProps}>
-    <div>
-      <ProjectAvatar project={project} />
-    </div>
-    <ResultInfo>
-      <ResultName>{project.domain}</ResultName>
-      {project.description.length > 0 && (
-        <ResultDescription>
-          <Markdown renderAsPlaintext>{project.description}</Markdown>
-        </ResultDescription>
-      )}
-      <ProfileListWrap project={project} asLinks={profileListAsLinks} />
-    </ResultInfo>
-  </ResultItem>
-);
+const ProjectResultItem = ({ project, onClick, profileListAsLinks, buttonProps, isALink }) => {
+  const linkProps = isALink ? { as: 'a', href: `/~${project.domain}`, target: '_blank' } : {};
+  return (
+    <ResultItem className={classnames(project.private && styles.private)} onClick={() => onClick(project)} {...buttonProps} {...linkProps}>
+      <div>
+        <ProjectAvatar project={project} />
+      </div>
+      <ResultInfo>
+        <ResultName>{project.domain}</ResultName>
+        {project.description.length > 0 && (
+          <ResultDescription>
+            <Markdown renderAsPlaintext>{project.description}</Markdown>
+          </ResultDescription>
+        )}
+        <ProfileListWrap project={project} asLinks={profileListAsLinks} />
+      </ResultInfo>
+    </ResultItem>
+  );
+};
 
 ProjectResultItem.propTypes = {
   project: PropTypes.shape({
@@ -50,10 +53,12 @@ ProjectResultItem.propTypes = {
   }).isRequired,
   onClick: PropTypes.func.isRequired,
   profileListAsLinks: PropTypes.bool,
+  isALink: PropTypes.bool,
 };
 
 ProjectResultItem.defaultProps = {
   profileListAsLinks: true,
+  isALink: false,
 };
 
 export default ProjectResultItem;

--- a/src/components/project/project-result-item.js
+++ b/src/components/project/project-result-item.js
@@ -24,25 +24,22 @@ const ProfileListWrap = ({ project, asLinks }) => (
   </div>
 );
 
-const ProjectResultItem = ({ project, onClick, profileListAsLinks, buttonProps, isALink }) => {
-  const linkProps = isALink ? { as: 'a', href: `/~${project.domain}`, target: '_blank' } : {};
-  return (
-    <ResultItem className={classnames(project.private && styles.private)} onClick={() => onClick(project)} {...buttonProps} {...linkProps}>
-      <div>
-        <ProjectAvatar project={project} />
-      </div>
-      <ResultInfo>
-        <ResultName>{project.domain}</ResultName>
-        {project.description.length > 0 && (
-          <ResultDescription>
-            <Markdown renderAsPlaintext>{project.description}</Markdown>
-          </ResultDescription>
-        )}
-        <ProfileListWrap project={project} asLinks={profileListAsLinks} />
-      </ResultInfo>
-    </ResultItem>
-  );
-};
+const ProjectResultItem = ({ project, onClick, profileListAsLinks, buttonProps }) => (
+  <ResultItem className={classnames(project.private && styles.private)} onClick={() => onClick(project)} {...buttonProps}>
+    <div>
+      <ProjectAvatar project={project} />
+    </div>
+    <ResultInfo>
+      <ResultName>{project.domain}</ResultName>
+      {project.description.length > 0 && (
+        <ResultDescription>
+          <Markdown renderAsPlaintext>{project.description}</Markdown>
+        </ResultDescription>
+      )}
+      <ProfileListWrap project={project} asLinks={profileListAsLinks} />
+    </ResultInfo>
+  </ResultItem>
+);
 
 ProjectResultItem.propTypes = {
   project: PropTypes.shape({
@@ -53,12 +50,10 @@ ProjectResultItem.propTypes = {
   }).isRequired,
   onClick: PropTypes.func.isRequired,
   profileListAsLinks: PropTypes.bool,
-  isALink: PropTypes.bool,
 };
 
 ProjectResultItem.defaultProps = {
   profileListAsLinks: true,
-  isALink: false,
 };
 
 export default ProjectResultItem;

--- a/src/components/project/project-result-item.styl
+++ b/src/components/project/project-result-item.styl
@@ -1,6 +1,6 @@
 @import '../constants.styl'
 
-.private
+.private, a.private
   background-color: private
   
 .profileListWrap


### PR DESCRIPTION
## Links
* https://astonishing-orchestra.glitch.me/
* https://app.clubhouse.io/glitch/story/3864/project-ownership-transfer-highlights-and-links-out-to-which-projects-have-multiple-members-but-only-one-admin-step-2a
* https://docs.google.com/document/d/1ya5WQraU0OPXf22uCsTGhaNnFU-3XyVLHSqGHzMkTPk/edit#heading=h.3im6lap0txtw (design spec)
https://docs.google.com/document/d/17O0aLlf0znuCN4-LuVihAkGzsUtdFpv4uV7dQpouvWI/edit#heading=h.c3jzht6x35ee (tech spec)

## GIF/Screenshots:
<img width="654" alt="Screen Shot 2019-12-05 at 2 40 05 PM" src="https://user-images.githubusercontent.com/3011231/70267803-2ce06900-176d-11ea-937e-574243f0bc70.png">
<img width="655" alt="Screen Shot 2019-12-05 at 2 44 18 PM" src="https://user-images.githubusercontent.com/3011231/70268104-c3148f00-176d-11ea-8638-f2af050dba01.png">


## Changes:
* Adds "isALink" prop to project-result-item so that clicking on results will take you to the project for updating
* Looks for projects where you're the only admin and there are multiple users, and not letting you continue till they've been fixed (as deleting your account would leave these in a bad state)
* Updates list automatically when project changes are made, no need for a refresh button!

## How To Test:
* Be logged in, turn on Account Deletion and at least one other toggle
* Go to /settings, hit Delete Account, Continue to Delete Account
* See the projects you need to take action on, try changing admins and/or deleting, make sure they disappear

## Feedback I'm looking for:
whatever you've got 😄 

## Things left to do before deploying:
* not a blocker to deploying (since its behind a dev toggle) but we should have the help links go somewhere.
