### PR TITLE
Debonair quokka: Teams modal pane

### DIFF
--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -1,21 +1,15 @@
 import React, { useState, useEffect } from 'react';
-<<<<<<< HEAD
 import PropTypes from 'prop-types';
-=======
->>>>>>> 895988ced4dec94b70885c16b67d0d0bf5df1b5f
 import Pluralize from 'react-pluralize';
 import { Actions, Badge, Button, DangerZone, Icon, Info, Overlay, ResultsList, Title, useOverlay, mergeRefs } from '@fogcreek/shared-components';
 
 import { useCurrentUser } from 'State/current-user';
 
 import Link from 'Components/link';
-<<<<<<< HEAD
 import TeamResultItem from 'Components/team/team-result-item';
-import { getTeamLink } from 'Models/team';
-=======
 import ProjectResultItem from 'Components/project/project-result-item';
+import { getTeamLink } from 'Models/team';
 import { getProjectLink } from 'Models/project';
->>>>>>> 895988ced4dec94b70885c16b67d0d0bf5df1b5f
 import MultiPage from '../layout/multi-page';
 
 import styles from './delete-account-modal.styl';
@@ -125,24 +119,6 @@ TeamTransfer.propTypes = {
   last: PropTypes.object.isRequired,
 };
 
-<<<<<<< HEAD
-const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
-  <>
-    <Title>Transfer Project Ownership</Title>
-    <Info>
-      You must <Link ref={mergeRefs(first, focusedOnMount)} to="/">transfer ownership</Link> or <Link to="/">delete</Link> these projects before you can delete your account.
-    </Info>
-    <Actions>
-      <Button className={styles.actionButton} onClick={() => setPage('teamOwnerTransfer')}>
-        Continue to Delete Account
-      </Button>
-      <Button className={styles.actionButton} variant="secondary" onClick={onClose} ref={last}>
-        Close
-      </Button>
-    </Actions>
-  </>
-);
-=======
 const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
   const { currentUser } = useCurrentUser();
   const [currentlyFocusedProject, onSelectProject] = useState(null);
@@ -191,7 +167,6 @@ const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
     </>
   );
 };
->>>>>>> 895988ced4dec94b70885c16b67d0d0bf5df1b5f
 
 ProjectTransfer.propTypes = {
   setPage: PropTypes.func.isRequired,
@@ -253,15 +228,9 @@ const DeleteSettings = () => {
                 {page === 'info' ? (
                   <DeleteInfo setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} />
                 ) : null}
-<<<<<<< HEAD
-                {page === 'projectOwnerTransfer' ? <ProjectTransfer setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} /> : null}
-                {page === 'teamOwnerTransfer' ? <TeamTransfer setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} /> : null}
-                {page === 'emailConfirm' ? <EmailConfirm onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} /> : null}
-=======
-                {page === 'projectOwnerTransfer' && <ProjectTransfer setPage={setPage} onClose={onClose} />}
-                {page === 'teamOwnerTransfer' && <TeamTransfer setPage={setPage} onClose={onClose} />}
-                {page === 'emailConfirm' && <EmailConfirm onClose={onClose} />}
->>>>>>> 895988ced4dec94b70885c16b67d0d0bf5df1b5f
+                {page === 'projectOwnerTransfer' && <ProjectTransfer setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} />}
+                {page === 'teamOwnerTransfer' && <TeamTransfer setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} />}
+                {page === 'emailConfirm' && <EmailConfirm onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} />}
               </>
             )}
           </MultiPage>

--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -6,6 +6,7 @@ import { useCurrentUser } from 'State/current-user';
 
 import Link from 'Components/link';
 import TeamResultItem from 'Components/team/team-result-item';
+import { getTeamLink } from 'Models/team';
 import MultiPage from '../layout/multi-page';
 
 import styles from './delete-account-modal.styl';
@@ -62,7 +63,7 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
       </Info>
       {singleAdminTeams.length > 0 ? (
         <ResultsList value={selectedTeam} onChange={onTeamSelection} options={singleAdminTeams}>
-          {({ item, buttonProps }) => <TeamResultItem team={item} onClick={() => {}} buttonProps={buttonProps} profileListAsLinks={false} isALink />}
+          {({ item: team }) => <TeamResultItem team={team} onClick={() => window.open(`${getTeamLink(team)}`, '_blank')} />}
         </ResultsList>
       ) : (
         <Actions>
@@ -72,7 +73,7 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
       )}
       <Info className={styles.remaining}>
         <p>
-          <Badge>{singleAdminTeams.length}</Badge> teams to update
+          <Badge>{singleAdminTeams.length}</Badge> <Pluralize count={singleAdminTeams.length} showCount={false} singular="team" /> to update
         </p>
       </Info>
       <Info>

--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -76,7 +76,7 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
         </p>
       </Info>
       <Info>
-        If you delete your account, you will automatically be removed from these teams:
+        If you delete your account, you will automatically be removed from these teams:{' '}
         {otherTeams
           .map((team) => (
             <Link key={team.id} to={`@${team.name}`}>

--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import Pluralize from 'react-pluralize';
 import { Actions, Badge, Button, DangerZone, Icon, Info, Overlay, ResultsList, Title, useOverlay, mergeRefs } from '@fogcreek/shared-components';
 
@@ -37,6 +38,14 @@ const DeleteInfo = ({ setPage, onClose, first, focusedOnMount, last }) => (
     </DangerZone>
   </>
 );
+
+DeleteInfo.propTypes = {
+  setPage: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  first: PropTypes.object.isRequired,
+  focusedOnMount: PropTypes.object.isRequired,
+  last: PropTypes.object.isRequired,
+};
 
 const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
   const { currentUser } = useCurrentUser();
@@ -98,6 +107,14 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
   );
 };
 
+TeamTransfer.propTypes = {
+  setPage: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  first: PropTypes.object.isRequired,
+  focusedOnMount: PropTypes.object.isRequired,
+  last: PropTypes.object.isRequired,
+};
+
 const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
   <>
     <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Transfer Project Ownership</Title>
@@ -114,6 +131,14 @@ const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
     </Actions>
   </>
 );
+
+ProjectTransfer.propTypes = {
+  setPage: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  first: PropTypes.object.isRequired,
+  focusedOnMount: PropTypes.object.isRequired,
+  last: PropTypes.object.isRequired,
+};
 
 const EmailConfirm = ({ onClose, first, focusedOnMount, last }) => {
   const { currentUser } = useCurrentUser();
@@ -142,6 +167,13 @@ const EmailConfirm = ({ onClose, first, focusedOnMount, last }) => {
       </Actions>
     </>
   );
+};
+
+EmailConfirm.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  first: PropTypes.object.isRequired,
+  focusedOnMount: PropTypes.object.isRequired,
+  last: PropTypes.object.isRequired,
 };
 
 const DeleteSettings = () => {

--- a/src/components/delete-account/delete-account-modal.js
+++ b/src/components/delete-account/delete-account-modal.js
@@ -40,7 +40,7 @@ const DeleteInfo = ({ setPage, onClose, first, focusedOnMount, last }) => (
 );
 
 DeleteInfo.propTypes = {
-  setPage: PropTypes.string.isRequired,
+  setPage: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   first: PropTypes.object.isRequired,
   focusedOnMount: PropTypes.object.isRequired,
@@ -66,9 +66,9 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
   }, [singleAdminTeams]);
   return (
     <>
-      <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Transfer Team Ownership</Title>
+      <Title>Transfer Team Ownership</Title>
       <Info>
-        You must <Link to="/">pick a new team admin</Link> or <Link to="/">delete</Link> these teams before you can delete your account.
+        You must <Link ref={mergeRefs(first, focusedOnMount)} to="/">pick a new team admin</Link> or <Link to="/">delete</Link> these teams before you can delete your account.
       </Info>
       {singleAdminTeams.length > 0 ? (
         <ResultsList value={selectedTeam} onChange={onTeamSelection} options={singleAdminTeams}>
@@ -85,16 +85,18 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
           <Badge>{singleAdminTeams.length}</Badge> <Pluralize count={singleAdminTeams.length} showCount={false} singular="team" /> to update
         </p>
       </Info>
-      <Info>
-        If you delete your account, you will automatically be removed from these teams:{' '}
-        {otherTeams
-          .map((team) => (
-            <Link key={team.id} to={`@${team.name}`}>
-              {team.name}
-            </Link>
-          )).reduce((prev, curr) => [prev, ', ', curr])
-        }
-      </Info>
+      {otherTeams.length > 0 && (
+        <Info>
+          If you delete your account, you will automatically be removed from these teams:{' '}
+          {otherTeams
+            .map((team) => (
+              <Link key={team.id} to={`@${team.name}`}>
+                {team.name}
+              </Link>
+            )).reduce((prev, curr) => [prev, ', ', curr])
+          }
+        </Info>
+      )}
       <Actions>
         <Button disabled={singleAdminTeams.length > 0} className={styles.actionButton} onClick={() => setPage('emailConfirm')}>
           Continue to Delete Account
@@ -108,7 +110,7 @@ const TeamTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => {
 };
 
 TeamTransfer.propTypes = {
-  setPage: PropTypes.string.isRequired,
+  setPage: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   first: PropTypes.object.isRequired,
   focusedOnMount: PropTypes.object.isRequired,
@@ -117,9 +119,9 @@ TeamTransfer.propTypes = {
 
 const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
   <>
-    <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Transfer Project Ownership</Title>
+    <Title>Transfer Project Ownership</Title>
     <Info>
-      You must <Link to="/">transfer ownership</Link> or <Link to="/">delete</Link> these projects before you can delete your account.
+      You must <Link ref={mergeRefs(first, focusedOnMount)} to="/">transfer ownership</Link> or <Link to="/">delete</Link> these projects before you can delete your account.
     </Info>
     <Actions>
       <Button className={styles.actionButton} onClick={() => setPage('teamOwnerTransfer')}>
@@ -133,7 +135,7 @@ const ProjectTransfer = ({ setPage, onClose, first, focusedOnMount, last }) => (
 );
 
 ProjectTransfer.propTypes = {
-  setPage: PropTypes.string.isRequired,
+  setPage: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   first: PropTypes.object.isRequired,
   focusedOnMount: PropTypes.object.isRequired,
@@ -147,7 +149,7 @@ const EmailConfirm = ({ onClose, first, focusedOnMount, last }) => {
   const soloCollections = currentUser.collections; // all collections are solo, at least currently
   return (
     <>
-      <Title onCloseRef={mergeRefs(first, focusedOnMount)}>Email Confirmation Sent</Title>
+      <Title>Email Confirmation Sent</Title>
       <Actions>
         <p>For security purposes, we've sent an email confirmation.</p>
         <p>Please click the link in the email to finish deleting your account.</p>
@@ -161,7 +163,7 @@ const EmailConfirm = ({ onClose, first, focusedOnMount, last }) => {
         </p>
       </Actions>
       <Actions>
-        <Button onClick={onClose} ref={last}>
+        <Button onClick={onClose} ref={mergeRefs(first, last, focusedOnMount)}>
           Close
         </Button>
       </Actions>
@@ -192,9 +194,9 @@ const DeleteSettings = () => {
                 {page === 'info' ? (
                   <DeleteInfo setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} />
                 ) : null}
-                {page === 'projectOwnerTransfer' ? <ProjectTransfer setPage={setPage} onClose={onClose} /> : null}
-                {page === 'teamOwnerTransfer' ? <TeamTransfer setPage={setPage} onClose={onClose} /> : null}
-                {page === 'emailConfirm' ? <EmailConfirm onClose={onClose} /> : null}
+                {page === 'projectOwnerTransfer' ? <ProjectTransfer setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} /> : null}
+                {page === 'teamOwnerTransfer' ? <TeamTransfer setPage={setPage} onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} /> : null}
+                {page === 'emailConfirm' ? <EmailConfirm onClose={onClose} first={first} focusedOnMount={focusedOnMount} last={last} /> : null}
               </>
             )}
           </MultiPage>

--- a/src/components/team/team-result-item.js
+++ b/src/components/team/team-result-item.js
@@ -6,7 +6,6 @@ import { TeamAvatar } from 'Components/images/avatar';
 import ProfileList from 'Components/profile-list';
 import VisibilityContainer from 'Components/visibility-container';
 import { ResultItem, ResultInfo, ResultName, ResultDescription } from '@fogcreek/shared-components';
-import { getTeamLink } from 'Models/team';
 import { useTeamMembers } from 'State/team';
 
 const ProfileListWithData = ({ team, asLinks }) => {
@@ -24,26 +23,22 @@ const ProfileListWrap = ({ team, asLinks }) => (
   </div>
 );
 
-const TeamResultItem = ({ team, onClick, buttonProps, profileListAsLinks, isALink }) => {
-  const linkProps = isALink ? { as: 'a', href: getTeamLink(team), target: '_blank' } : {};
-
-  return (
-    <ResultItem onClick={() => onClick(team)} {...buttonProps} {...linkProps}>
-      <div>
-        <TeamAvatar team={team} />
-      </div>
-      <ResultInfo>
-        <ResultName>{team.name}</ResultName>
-        {team.description.length > 0 && (
-          <ResultDescription>
-            <Markdown renderAsPlaintext>{team.description}</Markdown>
-          </ResultDescription>
-        )}
-        <ProfileListWrap team={team} asLinks={profileListAsLinks} />
-      </ResultInfo>
-    </ResultItem>
-  );
-};
+const TeamResultItem = ({ team, onClick, buttonProps, profileListAsLinks }) => (
+  <ResultItem onClick={() => onClick(team)} {...buttonProps}>
+    <div>
+      <TeamAvatar team={team} />
+    </div>
+    <ResultInfo>
+      <ResultName>{team.name}</ResultName>
+      {team.description.length > 0 && (
+        <ResultDescription>
+          <Markdown renderAsPlaintext>{team.description}</Markdown>
+        </ResultDescription>
+      )}
+      <ProfileListWrap team={team} asLinks={profileListAsLinks} />
+    </ResultInfo>
+  </ResultItem>
+);
 
 TeamResultItem.propTypes = {
   team: PropTypes.shape({
@@ -52,6 +47,11 @@ TeamResultItem.propTypes = {
     description: PropTypes.string.isRequired,
   }).isRequired,
   onClick: PropTypes.func.isRequired,
+  profileListAsLinks: PropTypes.bool,
+};
+
+TeamResultItem.defaultProps = {
+  profileListAsLinks: true,
 };
 
 export default TeamResultItem;

--- a/src/components/team/team-result-item.js
+++ b/src/components/team/team-result-item.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Markdown from 'Components/text/markdown';
+import { TeamAvatar } from 'Components/images/avatar';
+import ProfileList from 'Components/profile-list';
+import VisibilityContainer from 'Components/visibility-container';
+import { ResultItem, ResultInfo, ResultName, ResultDescription } from '@fogcreek/shared-components';
+import { getTeamLink } from 'Models/team';
+import { useTeamMembers } from 'State/team';
+
+const ProfileListWithData = ({ team, asLinks }) => {
+  const { value: members } = useTeamMembers(team.id);
+  return <ProfileList users={members} layout="row" size="small" asLinks={asLinks} />;
+};
+
+const ProfileListWrap = ({ team, asLinks }) => (
+  <div>
+    <VisibilityContainer>
+      {({ wasEverVisible }) =>
+        wasEverVisible ? <ProfileListWithData team={team} asLinks={asLinks} /> : <ProfileList layout="row" size="small" asLinks={asLinks} />
+      }
+    </VisibilityContainer>
+  </div>
+);
+
+const TeamResultItem = ({ team, onClick, buttonProps, profileListAsLinks, isALink }) => {
+  const linkProps = isALink ? { as: 'a', href: getTeamLink(team), target: '_blank' } : {};
+
+  return (
+    <ResultItem onClick={() => onClick(team)} {...buttonProps} {...linkProps}>
+      <div>
+        <TeamAvatar team={team} />
+      </div>
+      <ResultInfo>
+        <ResultName>{team.name}</ResultName>
+        {team.description.length > 0 && (
+          <ResultDescription>
+            <Markdown renderAsPlaintext>{team.description}</Markdown>
+          </ResultDescription>
+        )}
+        <ProfileListWrap team={team} asLinks={profileListAsLinks} />
+      </ResultInfo>
+    </ResultItem>
+  );
+};
+
+TeamResultItem.propTypes = {
+  team: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+  }).isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default TeamResultItem;


### PR DESCRIPTION
## Links
* https://debonair-quokka.glitch.me/
* https://app.clubhouse.io/glitch/story/3863/team-ownership-transfer-highlights-and-links-out-to-which-teams-have-multiple-members-but-only-one-admin-step-2a
* https://docs.google.com/document/d/1ya5WQraU0OPXf22uCsTGhaNnFU-3XyVLHSqGHzMkTPk/edit#heading=h.3im6lap0txtw (design spec)
https://docs.google.com/document/d/17O0aLlf0znuCN4-LuVihAkGzsUtdFpv4uV7dQpouvWI/edit#heading=h.c3jzht6x35ee (tech spec)

## GIF/Screenshots:
<img width="656" alt="Screen Shot 2019-12-05 at 3 01 01 PM" src="https://user-images.githubusercontent.com/3011231/70269758-fefd2380-1770-11ea-8f85-04eeed2a77c2.png">
<img width="659" alt="Screen Shot 2019-12-05 at 3 01 27 PM" src="https://user-images.githubusercontent.com/3011231/70269764-0290aa80-1771-11ea-9bfb-d3676a5486e3.png">

## Changes:
* Creates a team-result-item component so that teams can be shown in a ResultsList
* Looks for teams where you're the only admin and there are multiple users, and not letting you continue till they've been fixed (as deleting your account would leave these in a bad state)
* Updates list automatically when project changes are made, no need for a refresh button!

## How To Test:
* Be logged in, turn on Account Deletion and at least one other toggle
* Go to /settings, hit Delete Account, Continue to Delete Account, Continue to Delete Account (again)
* See the teams you need to take action on, try changing admins and/or deleting, make sure they disappear

## Feedback I'm looking for:
whatever you've got 😄

## Things left to do before deploying:
* not a blocker to deploying (since its behind a dev toggle) but we should have the help links go somewhere.
