### PR TITLE
Fix bug of projects spilling over out of a collection

### DIFF
--- a/src/components/containers/grid.styl
+++ b/src/components/containers/grid.styl
@@ -6,6 +6,7 @@
   list-style-type: none
   margin: 0
   padding: 0
+  overflow: auto // this might look unimportant but it is very necesary for now! https://github.com/clauderic/react-sortable-hoc/issues/617
 
 .item
   list-style: none


### PR DESCRIPTION
## Links
* Remix link: https://pool-rodent.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/1634/collection-items-overflow-horizontally-while-dragging

## GIF/Screenshots:
before and after: 
![](http://g.recordit.co/QzZ2xjJHLN.gif)


## Changes:
What a journey! TLDR: react-sortable-hoc needs the container to have `overflow: auto` set. For a more detailed explanation of what's going on you can check out https://github.com/clauderic/react-sortable-hoc/issues/617 

## How To Test:
As far as I can tell the bug only happens when your browser window reaches a width of `1370px` or bigger.

## Feedback I'm looking for:
anything! 

## Things left to do before deploying:
- [ ] probably a good idea to test this on multiple browsers I've only been working in chrome for the most part.
