### PR TITLE
Add jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": false,
+    "baseUrl": "./",
+    "paths": {
+      "Components/*": ["src/components/*"],
+      "Utils/*": ["src/utils/*"],
+      "Curated/*": ["src/curated/*"],
+      "Models/*": ["src/models/*"],
+      "State/*": ["src/state/*"],
+      "Hooks/*": ["src/hooks/*"],
+      "Shared/*": ["/shared/*"]
+    }
+  },
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
## Changes:
I’ve been keeping this `jsconfig.json` in the root of Glitch-Community so that I can use Cmd+Click in VS Code to navigate through the aliases (`import whatever from ‘Components/whatever’`) to where the files are.

## How To Test:
* See that you can use Cmd+Click in VS Code to navigate through aliases.
* See that VS Code is not showing errors that were not there before and are not real.

## Feedback I'm looking for:
Anything!

## Things left to do before deploying:
- [ ] It shouldn't change anything about the site.
