### PR TITLE
Add project/collection popover fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/register": "7.5.5",
     "@babel/runtime": "^7.5.4",
     "@babel/runtime-corejs3": "^7.5.5",
-    "@fogcreek/shared-components": "^0.13.5",
+    "@fogcreek/shared-components": "^0.13.9",
     "@jedmao/location": "^2.0.4",
     "@optimizely/optimizely-sdk": "^3.3.0",
     "@percy/cypress": "^1.0.9",
@@ -107,6 +107,7 @@
     "mini-css-extract-plugin": "^0.8.0",
     "module-alias": "^2.2.0",
     "nodemon": "^1.19.3",
+    "pm2": "^3.5.1",
     "prop-types": "^15.7.2",
     "punycode": "^2.1.1",
     "qrcode": "^1.4.0",
@@ -142,8 +143,7 @@
     "webpack-cli": "^3.3.10",
     "webpack-dev-middleware": "^3.7.0",
     "webpack-node-externals": "^1.7.2",
-    "winston": "^3.2.1",
-    "pm2": "^3.5.1"
+    "winston": "^3.2.1"
   },
   "engines": {
     "node": "10.x"

--- a/src/components/collection/collection-result-item.js
+++ b/src/components/collection/collection-result-item.js
@@ -33,27 +33,24 @@ const CollectionResultItem = ({ onClick, collection, buttonProps }) => {
   const collectionIsMyStuff = collection.isMyStuff;
 
   return (
-    <div className={classnames(collection.private && styles.private)}>
-      <ResultItem {...buttonProps} onClick={onClick} href={`/@${collection.fullUrl}`}>
-        {collectionIsMyStuff && (
-          <div className={styles.avatarWrap}>
-            <BookmarkAvatar />
-          </div>
+    <ResultItem isPrivate={collection.private} {...buttonProps} onClick={onClick} href={`/@${collection.fullUrl}`}>
+      {collectionIsMyStuff && (
+        <div className={styles.avatarWrap}>
+          <BookmarkAvatar />
+        </div>
+      )}
+      <ResultInfo>
+        <VisuallyHidden>Add to collection</VisuallyHidden>
+        <ResultName isPrivate={collection.private}>{collection.name}</ResultName>
+        {collection.description.length > 0 && (
+          <ResultDescription>
+            <VisuallyHidden>with description</VisuallyHidden>
+            <Markdown renderAsPlaintext>{collection.description}</Markdown>
+          </ResultDescription>
         )}
-        <ResultInfo>
-          <VisuallyHidden>Add to collection</VisuallyHidden>
-          <ResultName>{collection.name}</ResultName>
-          {collection.description.length > 0 && (
-            <ResultDescription>
-              <VisuallyHidden>with description</VisuallyHidden>
-              <Markdown renderAsPlaintext>{collection.description}</Markdown>
-            </ResultDescription>
-          )}
-          {collection.teamId && collection.teamId !== -1 && <ProfileItemWrap collection={collection} asLinks={false} />}
-        </ResultInfo>
-      </ResultItem>
-
-    </div>
+        {collection.teamId && collection.teamId !== -1 && <ProfileItemWrap collection={collection} asLinks={false} />}
+      </ResultInfo>
+    </ResultItem>
   );
 };
 

--- a/src/components/collection/collection-result-item.js
+++ b/src/components/collection/collection-result-item.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { ResultItem, ResultInfo, ResultName, ResultDescription, VisuallyHidden } from '@fogcreek/shared-components';
 
 import Markdown from 'Components/text/markdown';

--- a/src/components/collection/collection-result-item.styl
+++ b/src/components/collection/collection-result-item.styl
@@ -11,9 +11,3 @@
   position: relative
   padding-top: 6px
   z-index: 1
-
-.private
-  > div
-    background-color: private
-  > div:hover
-      background-color: general-link

--- a/src/components/project/project-result-item.js
+++ b/src/components/project/project-result-item.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import Markdown from 'Components/text/markdown';
 import ProfileList from 'Components/profile-list';
@@ -25,12 +24,12 @@ const ProfileListWrap = ({ project, asLinks }) => (
 );
 
 const ProjectResultItem = ({ project, onClick, profileListAsLinks, buttonProps }) => (
-  <ResultItem className={classnames(project.private && styles.private)} onClick={() => onClick(project)} {...buttonProps}>
+  <ResultItem isPrivate={project.private} onClick={() => onClick(project)} {...buttonProps}>
     <div>
       <ProjectAvatar project={project} />
     </div>
     <ResultInfo>
-      <ResultName>{project.domain}</ResultName>
+      <ResultName isPrivate={project.private}>{project.domain}</ResultName>
       {project.description.length > 0 && (
         <ResultDescription>
           <Markdown renderAsPlaintext>{project.description}</Markdown>

--- a/src/components/project/project-result-item.styl
+++ b/src/components/project/project-result-item.styl
@@ -1,7 +1,4 @@
 @import '../constants.styl'
-
-.private
-  background-color: private
   
 .profileListWrap
   position: relative

--- a/src/state/collection.js
+++ b/src/state/collection.js
@@ -217,10 +217,11 @@ export function useCollectionEditor(initialCollection) {
         setCollection((oldCollection) => ({
           ...oldCollection,
           projects: oldCollection.projects.map((p) => {
-            if (p.id === project.id) {
-              p.authUserHasBookmarked = true;
+            const newProject = { ...p };
+            if (newProject.id === project.id) {
+              newProject.authUserHasBookmarked = true;
             }
-            return p;
+            return newProject;
           }),
         }));
       }


### PR DESCRIPTION
## Links
* Remix link: https://honored-cantaloupe.glitch.me/
* Issue-tracker link: 
- https://app.clubhouse.io/glitch/story/5041/dividers-on-results-lists-have-gone-missing
- https://app.clubhouse.io/glitch/story/5469/console-error-when-adding-a-project-to-my-stuff-collection-when-running-locally

## GIF/Screenshots:
![Screen Shot 2019-12-09 at 11 36 09 AM](https://user-images.githubusercontent.com/6620164/70455021-84d2e480-1a79-11ea-81cc-99a9c2a33290.png)
![Screen Shot 2019-12-09 at 11 36 20 AM](https://user-images.githubusercontent.com/6620164/70455022-84d2e480-1a79-11ea-9aea-a762c7eadcc1.png)

## Changes:
* upgrade to latest version of shared components
* use new privacy props: https://github.com/FogCreek/shared-components/pull/69
* fix a console.log error 

## How To Test:
* add projects to a collection on the collections page
* add projects to a collection on the project-item pages
* filter a project in a team analytics page

## Feedback I'm looking for:
bugz?
