### PR TITLE
Superb guide: Expand bootstrap error messages, fix for static builds

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -46,7 +46,7 @@ const watch = (location, entry, verb) => {
   return loadClient;
 };
 
-let tempRequireClient = () => require('../src/server');
+let tempRequireClient = () => require('../build/server');
 if ((!process.env.BUILD_TYPE || process.env.BUILD_TYPE === 'memory') && process.env.NODE_ENV !== 'production') {
   const SRC = path.join(__dirname, '../src');
   const stylus = require('stylus');

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -51,6 +51,7 @@
       var OPTIMIZELY_ID = <%- JSON.stringify(OPTIMIZELY_ID) %>;
       var BUILD_COMPLETE = <%- BUILD_COMPLETE %>;
       var BUILD_TIMESTAMP = '<%= BUILD_TIMESTAMP %>';
+      var scriptLoadError = false;
     </script>
     <div id="fallback" style="display: none">
       <div class="content">
@@ -86,7 +87,7 @@
     <div id="react-root"><%- html %></div>
 
     <% for (let i = 0; i < scripts.length; ++i) { %>
-    <script src="<%= scripts[i] %>"></script>
+    <script src="<%= scripts[i] %>" onError="scriptLoadError = true"></script>
     <% } %>
     <script>
       var container = document.getElementById('react-root');
@@ -98,18 +99,24 @@
       }
       
       var isIe = /Trident\/[7]{1}/i.test(navigator.userAgent);
-      var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com"; 
+      var isCodeRunningInsideGoogleTranslateIframe = window.location.origin === "https://translate.googleusercontent.com";
+      var isCodeRunningInsideGoogleSearchCache = window.location.origin === "https://webcache.googleusercontent.com";
       
       if (isIe) {
         // ie doesn't support our css
         showFallback('ie');
       } else if (isCodeRunningInsideGoogleTranslateIframe) {
-        // only translate server rendered pages
+        // only allow translation of server rendered pages
         if (!container.hasChildNodes()) {
           showFallback('translate');
           setTimeout(function() {
             window.location.href = "https://glitch.com";      
           }, 3000);
+        }
+      } else if (isCodeRunningInsideGoogleSearchCache) {
+        // show an error if the page wasn't server rendered
+        if (!container.hasChildNodes()) {
+          
         }
       } else if (window.bootstrap) {
         window.bootstrap(container);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -66,6 +66,10 @@
               <h1>The web browser that you're using does not support Javascript</h1>
               <p>Since Glitch requires Javascript to run, please try using Glitch in a different web browser.</p>
             </div>
+            <div class="error-msg" id="fallback-loaderror" style="display: none">
+              <h1>The site couldn't load some required content</h1>
+              <p>Try refreshing in a few moments.</p>
+            </div>
             <div class="error-msg" id="fallback-notbuilt" style="display: none">
               <h1>The site isn&apos;t quite ready yet</h1>
               <p>Try refreshing in a few moments.</p>
@@ -129,7 +133,7 @@
         showFallback('notbuilt');
       } else if (scriptLoadError) {
         // network error loading js, treat it the same for now
-        showFallback('noscript');
+        showFallback('loaderror');
       } else {
         // js failed to parse, odds are the css would be broken too
         showFallback('noscript');

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -66,7 +66,7 @@
               <h1>The web browser that you're using does not support Javascript</h1>
               <p>Since Glitch requires Javascript to run, please try using Glitch in a different web browser.</p>
             </div>
-              <div class="error-msg" id="fallback-notbuilt" style="display: none">
+            <div class="error-msg" id="fallback-notbuilt" style="display: none">
               <h1>The site isn&apos;t quite ready yet</h1>
               <p>Try refreshing in a few moments.</p>
             </div>
@@ -79,6 +79,10 @@
             <div class="error-msg" id="fallback-translate" style="display: none">
               <h1>Unfortunately, Glitch does not support Google translate at this time</h1>
               <p>redirecting to glitch.com in English...</p>
+            </div>
+            <div class="error-msg" id="fallback-cache" style="display: none">
+              <h1>Unfortunately, Glitch does not support running in a cache</h1>
+              <p>Please try loading the current site</p>
             </div>
           </section>
       </div>
@@ -116,7 +120,7 @@
       } else if (isCodeRunningInsideGoogleSearchCache) {
         // show an error if the page wasn't server rendered
         if (!container.hasChildNodes()) {
-          
+          showFallback('cache');
         }
       } else if (window.bootstrap) {
         window.bootstrap(container);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -71,7 +71,7 @@
               <p>Try refreshing in a few moments.</p>
             </div>
             <div class="error-msg" id="fallback-notbuilt" style="display: none">
-              <h1>The site isn&apos;t quite ready yet</h1>
+              <h1>The site isn't quite ready yet</h1>
               <p>Try refreshing in a few moments.</p>
             </div>
             <div class="error-msg" id="fallback-ie" style="display: none">
@@ -85,7 +85,7 @@
               <p>redirecting to glitch.com in English...</p>
             </div>
             <div class="error-msg" id="fallback-cache" style="display: none">
-              <h1>Unfortunately, Glitch does not support running in a cache</h1>
+              <h1>Unfortunately, Glitch does not support running in this cache</h1>
               <p>Please try loading the current site</p>
             </div>
           </section>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -127,6 +127,9 @@
       } else if (!BUILD_COMPLETE) {
         // we can't show the server rendered page if the css is still building
         showFallback('notbuilt');
+      } else if (scriptLoadError) {
+        // network error loading js, something is wrong
+        showFallback('noscript');
       } else {
         // js failed to parse, odds are the css would be broken too
         showFallback('noscript');

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -128,7 +128,7 @@
         // we can't show the server rendered page if the css is still building
         showFallback('notbuilt');
       } else if (scriptLoadError) {
-        // network error loading js, something is wrong
+        // network error loading js, treat it the same for now
         showFallback('noscript');
       } else {
         // js failed to parse, odds are the css would be broken too

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -132,7 +132,7 @@
         // we can't show the server rendered page if the css is still building
         showFallback('notbuilt');
       } else if (scriptLoadError) {
-        // network error loading js, treat it the same for now
+        // network error loading js, can only ask to refresh
         showFallback('loaderror');
       } else {
         // js failed to parse, odds are the css would be broken too


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/
https://app.clubhouse.io/glitch/story/5246/investigate-ssr-rendering-for-google-crawler

## Changes:
- Static builds use build/server.js instead of src/server.js
- Allow no-js ssr pages when running in the google cache
- Check for network errors loading the js code, and show a unique error if that happens

## How To Test:
- Load up the site (it's in a static build right now)
- Join the project and delete build/client.hash.js, notice that the 'your browser does not support js' message does not appear, and instead it says something failed to load