### PR TITLE
Only project admins (aka owners) should add a project to a team

### DIFF
--- a/src/components/team/add-team-project-pop.js
+++ b/src/components/team/add-team-project-pop.js
@@ -33,7 +33,7 @@ const filterProjects = (query, projects, teamProjects) => {
 };
 
 const getProjectsWhereCurrentUserIsAdmin = (allMyProjects) =>
-  allMyProjects.filter((p) => p.permission && p.permission.accessLevel && p.permission.accessLevel === ADMIN_ACCESS_LEVEL);
+  allMyProjects.filter((p) => p.permission && p.permission.accessLevel && p.permission.accessLevel >= ADMIN_ACCESS_LEVEL);
 
 function AddTeamProjectPop({ teamProjects, addProject }) {
   const [query, setQuery] = useState('');

--- a/src/components/team/add-team-project-pop.js
+++ b/src/components/team/add-team-project-pop.js
@@ -5,6 +5,7 @@ import { Button, Icon, Info, Popover } from '@fogcreek/shared-components';
 import { PopoverSearch } from 'Components/popover';
 import ProjectResultItem from 'Components/project/project-result-item';
 import { useCurrentUser } from 'State/current-user';
+import { ADMIN_ACCESS_LEVEL } from 'Models/project';
 
 import { emoji, widePopover } from '../global.styl';
 
@@ -32,7 +33,7 @@ const filterProjects = (query, projects, teamProjects) => {
 };
 
 const getProjectsWhereCurrentUserIsAdmin = (allMyProjects) =>
-  allMyProjects.filter((p) => p.permission && p.permission.accessLevel && p.permission.accessLevel === 30);
+  allMyProjects.filter((p) => p.permission && p.permission.accessLevel && p.permission.accessLevel === ADMIN_ACCESS_LEVEL);
 
 function AddTeamProjectPop({ teamProjects, addProject }) {
   const [query, setQuery] = useState('');

--- a/src/components/team/add-team-project-pop.js
+++ b/src/components/team/add-team-project-pop.js
@@ -31,11 +31,13 @@ const filterProjects = (query, projects, teamProjects) => {
   return filteredProjects;
 };
 
+const getProjectsWhereCurrentUserIsAdmin = (allMyProjects) =>
+  allMyProjects.filter((p) => p.permission && p.permission.accessLevel && p.permission.accessLevel === 30);
+
 function AddTeamProjectPop({ teamProjects, addProject }) {
   const [query, setQuery] = useState('');
   const { currentUser } = useCurrentUser();
-  const myProjects = currentUser.projects;
-
+  const myProjects = useMemo(() => getProjectsWhereCurrentUserIsAdmin(currentUser.projects), [currentUser.projects]);
   const filteredProjects = useMemo(() => filterProjects(query, myProjects, teamProjects), [query, myProjects, teamProjects]);
 
   return (

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -104,7 +104,7 @@ export const useProjectOptions = (project, { user, team, collection, ...options 
     displayNewNote: !project.note && !project.isAddingANewNote && canAddNote && bind(projectOptions.displayNewNote, project),
     joinTeamProject: areMembersReady && !isProjectMember && !!projectTeam && bind(projectOptions.joinTeamProject, project, projectTeam),
     leaveProject: areMembersReady && isProjectMember && !isOnlyProjectAdmin && bind(projectOptions.leaveProject, project),
-    removeProjectFromTeam: isTeamMember && bind(projectOptions.removeProjectFromTeam, project),
+    removeProjectFromTeam: isTeamMember && isProjectAdmin && bind(projectOptions.removeProjectFromTeam, project),
     deleteProject: isProjectAdmin && bind(projectOptions.deleteProject, project),
     removeProjectFromCollection: isCollectionOwner && bind(projectOptions.removeProjectFromCollection, project),
     toggleBookmark: isLoggedIn && projectOptions.toggleBookmark,

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -7,7 +7,7 @@ import { useAPIHandlers, useAPI } from 'State/api';
 import useErrorHandlers from 'State/error-handlers';
 import { userOrTeamIsAuthor, useCollectionReload } from 'State/collection';
 import { useProjectReload, useProjectMembers } from 'State/project';
-import { userIsOnTeam } from 'Models/team';
+import { userIsOnTeam, userIsTeamAdmin } from 'Models/team';
 import { userIsProjectMember, userIsProjectAdmin, userIsOnlyProjectAdmin } from 'Models/project';
 import { useNotifications } from 'State/notifications';
 import { createCollection } from 'Models/collection';
@@ -92,6 +92,7 @@ export const useProjectOptions = (project, { user, team, collection, ...options 
   const isUser = user && user.id === currentUser.id;
   const isCollectionOwner = collection && userOrTeamIsAuthor({ collection, user: currentUser });
   const isTeamMember = team && userIsOnTeam({ team, user: currentUser });
+  const isTeamAdmin = team && userIsTeamAdmin({ team, user: currentUser });
   const projectTeam = currentUser.teams.find((t) => project.teamIds.includes(t.id));
   const isProfileOwner = isUser || isCollectionOwner || isTeamMember;
   const canAddNote = collection ? isCollectionOwner : isProjectAdmin;
@@ -104,7 +105,7 @@ export const useProjectOptions = (project, { user, team, collection, ...options 
     displayNewNote: !project.note && !project.isAddingANewNote && canAddNote && bind(projectOptions.displayNewNote, project),
     joinTeamProject: areMembersReady && !isProjectMember && !!projectTeam && bind(projectOptions.joinTeamProject, project, projectTeam),
     leaveProject: areMembersReady && isProjectMember && !isOnlyProjectAdmin && bind(projectOptions.leaveProject, project),
-    removeProjectFromTeam: isTeamMember && isProjectAdmin && bind(projectOptions.removeProjectFromTeam, project),
+    removeProjectFromTeam: isTeamMember && (isTeamAdmin || isProjectAdmin) && bind(projectOptions.removeProjectFromTeam, project),
     deleteProject: isProjectAdmin && bind(projectOptions.deleteProject, project),
     removeProjectFromCollection: isCollectionOwner && bind(projectOptions.removeProjectFromCollection, project),
     toggleBookmark: isLoggedIn && projectOptions.toggleBookmark,


### PR DESCRIPTION
## Links
* Remix link: https://glass-mercury.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/5713/only-project-owners-should-be-able-to-add-projects-to-teams

## Changes:
* Only project admins (aka owners) should add a project to a team. I also am proposing that project owners and team admins should be the only ones who can remove a project from a team. I believe @modernserf is working on the backend on this as well, but fixing the ui seems like a great first step.

## How To Test:
These scenarios should work as follows I believe:

| User        | Test           | Should work  |
|:------------- |:-------------|:-----|
| Project Owner/Team Admin | add project to team | yes |
| Project Owner/Team Admin | remove project from team | yes |
| Project Owner/Team Member | add project to team | yes |
| Project Owner/Team Member | remove project from team | yes |
| Project Member/Team Admin | add project to team | no |
| Project Member/Team Admin | remove project from team | yes |
| Project Member/Team Member | add project to team | no |
| Project Member/Team Member | remove project from team | no |

## Feedback I'm looking for:
think hard about this and tell me if there are undesirable consequences that we aren't thinking about? I think this is how it should work?
