### PR TITLE
Remove global overflow to fix drag and drop

### DIFF
--- a/src/components/containers/grid.styl
+++ b/src/components/containers/grid.styl
@@ -6,7 +6,6 @@
   list-style-type: none
   margin: 0
   padding: 0
-  overflow: auto // this might look unimportant but it is very necesary for now! https://github.com/clauderic/react-sortable-hoc/issues/617
 
 .item
   list-style: none

--- a/src/components/global.styl
+++ b/src/components/global.styl
@@ -8,7 +8,6 @@ body
   font-family: sansserif
   color: primary
   margin: 0
-  overflow-x: hidden
 
 h1
   font-weight: bold


### PR DESCRIPTION
## Links
* Remix link: https://olive-staircase.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/5783/overflow-auto-breaks-grids-with-one-row-in-it

## GIF/Screenshots:
yuckyuckyuck:
<img width="299" alt="Screen Shot 2019-12-16 at 2 20 50 PM" src="https://user-images.githubusercontent.com/6620164/70935926-4ad08800-200f-11ea-8450-71ae0e59f733.png">

## Changes:
* [not that long ago](https://github.com/FogCreek/Glitch-Community/pull/1114) I added `overflow: auto` to our grid containers to fix an issue with our drag and drop. Unfortunately in doing so I caused another bug see screenshot above ^ you can see that things that overflow from that container are clipped. So I removed it.
* I then realized that if we removed `overflow-x: hidden` from our global styles, the overflow bug we had our with our drag and drop library goes away. If you're interested in why this is I'm happy to walk you through it! I'm debating making a change directly to the lib to handle this situation, but I don't know when that would get approved and am a bit concerned there might be some reasoning for why it was written that way that I just haven't picked up yet. To go back to the glitch codebase for a moment, it's not clear to me why we have `overflow-x: hidden` on our body in general, but maybe this is a preventative measure to handle bugs? Seems to me like we can safely remove it, but feel free to disagree and I can try to find a better solution. 
* I did try to dynamically add/remove `overflow: auto` for when we're dragging/dropping stuff, but that does not appear to work to solve this issue.

## How To Test:
* Open dropdowns and tooltips on grid containers (collections, projects lists, etc) make sure they all open correctly and do not get cut off like they do in prod right now
* Reorder a collection on a wide screen (bigger than 1400px) ensure that collection items move to the next line as expected. 

## Feedback I'm looking for:
anything, mostly curious to unexpected  consequences of removing overflow-x:hidden from body to look out for/test for

