### PR TITLE
Quixotic rocket: Consistent webpack output in all build modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cy:remix": "npx cypress open --config baseUrl=https://$1.glitch.me",
     "cy:run": "npx cypress run",
     "lint": "npm run lint:server && npm run lint:src",
-    "lint:server": "eslint --config server/.eslintrc.server.js server shared webpack.config.js",
+    "lint:server": "eslint --config server/.eslintrc.server.js server shared webpack.config.js aliases.js",
     "lint:src": "eslint --config src/.eslintrc.js src",
     "prestart": "npm run watch:lint:server & \n if if-env BUILD_TYPE=watcher; then \n npm run watch:webpack & \n fi",
     "start": "pm2-runtime start ecosystem.config.js",

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -4,7 +4,7 @@ module.exports = function webpackExpressMiddleware() {
   const compiler = webpack(webpackConfig);
 
   const webpackMiddleware = require('webpack-dev-middleware');
-  const stats = { children: false, errors: true, errorDetails: true };
+  const stats = { children: false };
   const middleware = webpackMiddleware(compiler, { stats, writeToDisk: true });
 
   let ready = false;

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -4,8 +4,8 @@ module.exports = function webpackExpressMiddleware() {
   const compiler = webpack(webpackConfig);
 
   const webpackMiddleware = require('webpack-dev-middleware');
-  const stats = { children: false };
-  const middleware = webpackMiddleware(compiler, { stats:{}, writeToDisk: true });
+  const stats = { children: webpackConfig.map((config) => config.stats) };
+  const middleware = webpackMiddleware(compiler, { stats, writeToDisk: true });
 
   let ready = false;
   middleware.waitUntilValid(() => {

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -4,7 +4,7 @@ module.exports = function webpackExpressMiddleware() {
   const compiler = webpack(webpackConfig);
 
   const webpackMiddleware = require('webpack-dev-middleware');
-  const stats = { children: false };
+  const stats = { children: false, errors: true, errorDetails: true };
   const middleware = webpackMiddleware(compiler, { stats, writeToDisk: true });
 
   let ready = false;

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -5,7 +5,7 @@ module.exports = function webpackExpressMiddleware() {
 
   const webpackMiddleware = require('webpack-dev-middleware');
   const stats = { children: false };
-  const middleware = webpackMiddleware(compiler, { stats, writeToDisk: true });
+  const middleware = webpackMiddleware(compiler, { stats:{}, writeToDisk: true });
 
   let ready = false;
   middleware.waitUntilValid(() => {

--- a/src/app.js
+++ b/src/app.js
@@ -49,4 +49,6 @@ const App = ({ apiCache, helmetContext }) => (
   </LocalStyle>
 );
 
+this is a bad issue with my code
+
 export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,4 @@ const App = ({ apiCache, helmetContext }) => (
   </LocalStyle>
 );
 
-this is obviously broken code and webpack should report an error
-
 export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -49,4 +49,6 @@ const App = ({ apiCache, helmetContext }) => (
   </LocalStyle>
 );
 
+this is obviously broken code and webpack should report an error
+
 export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,4 @@ const App = ({ apiCache, helmetContext }) => (
   </LocalStyle>
 );
 
-this
-
 export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,6 @@ const App = ({ apiCache, helmetContext }) => (
   </LocalStyle>
 );
 
-this is a bad issue with my code
+this
 
 export default App;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -233,4 +233,4 @@ const nodeConfig = {
 };
 
 const smp = new SpeedMeasurePlugin({ outputFormat: 'humanVerbose' });
-module.exports = smp.wrap(browserConfig);
+module.exports = smp.wrap([browserConfig, nodeConfig]);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -172,6 +172,8 @@ const browserConfig = {
   },
   stats: {
     children: false,
+    errors: true,
+    errorDetails: true,
   },
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,8 @@ try {
   // Don't worry about it, there's probably just no stats.json
 }
 
+const stats = { modules: false };
+
 const browserConfig = {
   mode,
   entry: {
@@ -170,9 +172,7 @@ const browserConfig = {
   watchOptions: {
     ignored: /node_modules/,
   },
-  stats: {
-    children: false,
-  },
+  stats,
 };
 
 const nodeConfig = {
@@ -230,6 +230,7 @@ const nodeConfig = {
     NodeExternals(),
     (context, request, callback) => /^Shared[\\/]/.test(request) ? callback(null, `commonjs ${request}`) : callback(),
   ],
+  stats,
 };
 
 const smp = new SpeedMeasurePlugin({ outputFormat: 'humanVerbose' });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -172,8 +172,6 @@ const browserConfig = {
   },
   stats: {
     children: false,
-    errors: true,
-    errorDetails: true,
   },
 };
 
@@ -235,4 +233,4 @@ const nodeConfig = {
 };
 
 const smp = new SpeedMeasurePlugin({ outputFormat: 'humanVerbose' });
-module.exports = smp.wrap([browserConfig, nodeConfig]);
+module.exports = smp.wrap(browserConfig);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,8 +31,6 @@ try {
   // Don't worry about it, there's probably just no stats.json
 }
 
-const stats = { children: false, modules: false };
-
 const browserConfig = {
   mode,
   entry: {
@@ -172,7 +170,7 @@ const browserConfig = {
   watchOptions: {
     ignored: /node_modules/,
   },
-  stats,
+  stats: { children: false, modules: false },
 };
 
 const nodeConfig = {
@@ -230,7 +228,7 @@ const nodeConfig = {
     NodeExternals(),
     (context, request, callback) => /^Shared[\\/]/.test(request) ? callback(null, `commonjs ${request}`) : callback(),
   ],
-  stats: { ...stats, assets: false },
+  stats: { assets: false, children: false, modules: false },
 };
 
 const smp = new SpeedMeasurePlugin({ outputFormat: 'humanVerbose' });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ try {
   // Don't worry about it, there's probably just no stats.json
 }
 
-const stats = { modules: false };
+const stats = { children: false, modules: false };
 
 const browserConfig = {
   mode,
@@ -230,7 +230,7 @@ const nodeConfig = {
     NodeExternals(),
     (context, request, callback) => /^Shared[\\/]/.test(request) ? callback(null, `commonjs ${request}`) : callback(),
   ],
-  stats,
+  stats: { ...stats, assets: false },
 };
 
 const smp = new SpeedMeasurePlugin({ outputFormat: 'humanVerbose' });


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/ (nothing surprising there)
https://app.clubhouse.io/glitch/story/4458/linting-doesn-t-run-locally-on-npm-start-anymore

## Changes:
- Tell the webpack middleware to use the same stats config as the watcher does
- Hide modules from compiler output because it's largely noise
- Lint the aliases file for full coverage

## How To Test:
- Type some gibberish into a src/ file and see if webpack prints the error
- Do it again but swapping BUILD_TYPE between watcher/memory

## Why Did It Break:
The webpack express middleware ignores the stats field in the webpack config, and has a separate argument to specify it. The stats.children field determines if child modules get printed out, but when using multiple webpack configs it controls the stats object per config. Since children was set to false, it did not print anything from any of the configs.