### PR TITLE
Nova chance: Swap button text using media queries instead of react

### DIFF
--- a/src/components/buttons/responsive-button.js
+++ b/src/components/buttons/responsive-button.js
@@ -5,15 +5,22 @@ import { Button, Icon } from '@fogcreek/shared-components';
 
 import styles from './responsive-button.styl';
 
-const ResponsiveButton = ({ baseText, extraText, icon, ...props }) => (
+const ResponsiveButton = ({ children, shortText, icon, ...props }) => (
   <Button {...props}>
-    {baseText} <span clasName={styles.extraText}>{extraText}</span> {!!icon && <Icon icon={icon} />}
+    <span clasName={styles.fullText}>{children}</span>
+    <span className={styles.shortText}>{shortText}</span>
+    {icon}
   </Button>
 );
 
 ResponsiveButton.propTypes = {
-  baseText: PropTypes.node.isRequired,
-  extraText: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+  shortText: PropTypes.node.isRequired,
+  icon: PropTypes.node,
+};
+
+ResponsiveButton.defaultProps = {
+  icon: null,
 };
 
 export default ResponsiveButton;

--- a/src/components/buttons/responsive-button.js
+++ b/src/components/buttons/responsive-button.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Icon } from '@fogcreek/shared-components';
+import { Button } from '@fogcreek/shared-components';
 
 import styles from './responsive-button.styl';
 
 const ResponsiveButton = ({ children, shortText, icon, ...props }) => (
   <Button {...props}>
-    <span clasName={styles.fullText}>{children}</span>
+    <span className={styles.fullText}>{children}</span>
     <span className={styles.shortText}>{shortText}</span>
     {icon}
   </Button>

--- a/src/components/buttons/responsive-button.js
+++ b/src/components/buttons/responsive-button.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button, Icon } from '@fogcreek/shared-components';
+
+import styles from './responsive-button.styl';
+
+const ResponsiveButton = ({ baseText, extraText, icon, ...props }) => (
+  <Button {...props}>
+    {baseText} <span clasName={styles.extraText}>{extraText}</span> {!!icon && <Icon icon={icon} />}
+  </Button>
+);
+
+ResponsiveButton.propTypes = {
+  baseText: PropTypes.node.isRequired,
+  extraText: PropTypes.node.isRequired,
+};
+
+export default ResponsiveButton;

--- a/src/components/buttons/responsive-button.styl
+++ b/src/components/buttons/responsive-button.styl
@@ -1,0 +1,5 @@
+@require '../constants'
+
+@media (max-width: mediumSmallViewport)
+ .extraText
+   display: none

--- a/src/components/buttons/responsive-button.styl
+++ b/src/components/buttons/responsive-button.styl
@@ -1,12 +1,9 @@
 @require '../constants'
 
-@media screen
-  @media not (max-width: mediumSmallViewport)
-    .shortText
-      display: none
-  @media (max-width: mediumSmallViewport)
-    .fullText
-      display: unset
+@media screen and (max-width: mediumSmallViewport)
+  .fullText
+    display: none
 
-@media not screen
-  
+@media not screen and (max-width: mediumSmallViewport)
+  .shortText
+    display: none

--- a/src/components/buttons/responsive-button.styl
+++ b/src/components/buttons/responsive-button.styl
@@ -1,5 +1,12 @@
 @require '../constants'
 
-@media (max-width: mediumSmallViewport)
- .extraText
-   display: none
+@media screen
+  @media not (max-width: mediumSmallViewport)
+    .shortText
+      display: none
+  @media (max-width: mediumSmallViewport)
+    .fullText
+      display: unset
+
+@media not screen
+  

--- a/src/components/project/add-project-to-collection-pop.js
+++ b/src/components/project/add-project-to-collection-pop.js
@@ -3,12 +3,12 @@ import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Pluralize from 'react-pluralize';
 import { partition } from 'lodash';
-import { mediumSmallViewport, useWindowSize } from 'Hooks/use-window-size';
 import { Actions, Badge, Button, Icon, Info, Popover, SegmentedButton, Title } from '@fogcreek/shared-components';
 
 import Link from 'Components/link';
 import { PopoverSearch } from 'Components/popover';
 import { ProjectAvatar } from 'Components/images/avatar';
+import ResponsiveButton from 'Components/buttons/responsive-button';
 import CollectionResultItem from 'Components/collection/collection-result-item';
 import { CreateCollectionWithProject } from 'Components/collection/create-collection-pop';
 import { AddProjectToCollectionMsg } from 'Components/notification';
@@ -196,52 +196,42 @@ AddProjectToCollectionBase.propTypes = {
   createCollectionPopover: PropTypes.func.isRequired,
 };
 
-const AddProjectToCollection = ({ project, addProjectToCollection }) => {
-  const [width] = useWindowSize();
-  let buttonText = null;
-  if (width && width < mediumSmallViewport) {
-    buttonText = 'Add';
-  } else {
-    buttonText = 'Add to Collection';
-  }
-
-  return (
-    <Popover
-      className={widePopover}
-      align="right"
-      renderLabel={({ onClick, ref }) => (
-        <Button size="small" onClick={onClick} ref={ref}>
-          {buttonText} <Icon className={emoji} icon="framedPicture" />
-        </Button>
-      )}
-      views={{
-        createCollectionPopover: ({ onClose, onBack }) => (
-          <CreateCollectionWithProject
-            onBack={onBack}
-            onClose={onClose}
-            addProjectToCollection={(...args) => {
-              addProjectToCollection(...args);
-            }}
-            project={project}
-          />
-        ),
-      }}
-    >
-      {({ onClose, onBack, setActiveView }) => (
-        <AddProjectToCollectionBase
+const AddProjectToCollection = ({ project, addProjectToCollection }) => (
+  <Popover
+    className={widePopover}
+    align="right"
+    renderLabel={({ onClick, ref }) => (
+      <ResponsiveButton size="small" onClick={onClick} ref={ref} shortText="Add" icon={<Icon className={emoji} icon="framedPicture" />}>
+        Add to Collection
+      </ResponsiveButton>
+    )}
+    views={{
+      createCollectionPopover: ({ onClose, onBack }) => (
+        <CreateCollectionWithProject
           onBack={onBack}
-          addProjectToCollection={addProjectToCollection}
-          fromProject={false}
-          project={project}
-          togglePopover={onClose}
-          createCollectionPopover={() => {
-            setActiveView('createCollectionPopover');
+          onClose={onClose}
+          addProjectToCollection={(...args) => {
+            addProjectToCollection(...args);
           }}
+          project={project}
         />
-      )}
-    </Popover>
-  );
-};
+      ),
+    }}
+  >
+    {({ onClose, onBack, setActiveView }) => (
+      <AddProjectToCollectionBase
+        onBack={onBack}
+        addProjectToCollection={addProjectToCollection}
+        fromProject={false}
+        project={project}
+        togglePopover={onClose}
+        createCollectionPopover={() => {
+          setActiveView('createCollectionPopover');
+        }}
+      />
+    )}
+  </Popover>
+);
 
 AddProjectToCollection.propTypes = {
   addProjectToCollection: PropTypes.func.isRequired,

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -36,20 +36,15 @@ EditButtonCta.defaultProps = {
 };
 
 // the Edit Button that appears below the embed
-export const EditButton = ({ name, isMember, size }) => {
-  const [width] = useWindowSize();
-  let editButtonText = null;
-  if (width && width < mediumSmallViewport) {
-    editButtonText = isMember ? 'Edit' : 'View';
-  } else {
-    editButtonText = isMember ? 'Edit Project' : 'View Source';
-  }
-  return (
-    <Button as="a" href={getEditorUrl(name)} size={size}>
-      {editButtonText}
-    </Button>
-  );
-};
+export const EditButton = ({ name, isMember, size }) => (
+  <Button as="a" href={getEditorUrl(name)} size={size}>
+    {isMember ? (
+      <>Edit <span className={styles.hideIfSmallViewport}>Project</span></>
+    ) : (
+      <>View <span className={styles.hideIfSmallViewport}>Source</span></>
+    )}
+  </Button>
+);
 
 EditButton.propTypes = {
   name: PropTypes.string.isRequired,
@@ -62,9 +57,7 @@ EditButton.defaultProps = {
 
 export const RemixButton = ({ name, isMember, onClick }) => (
   <Button as="a" href={getRemixUrl(name)} size="small" onClick={onClick}>
-    Remix
-    <span className={styles.hideIfSmallViewport}>{isMember ? 'This' : 'Your Own'}</span>
-    <Icon className={emoji} icon="microphone" />
+    Remix <span className={styles.hideIfSmallViewport}>{isMember ? 'This' : 'Your Own'}</span> <Icon className={emoji} icon="microphone" />
   </Button>
 );
 
@@ -83,11 +76,6 @@ export const MembershipButton = ({ project, isMember, isTeamProject, leaveProjec
   const [width] = useWindowSize();
 
   if (!isMember && joinProject) {
-    let joinProjectBtnText = 'Join Team Project';
-
-    if (width && width < mediumSmallViewport) {
-      joinProjectBtnText = 'Join';
-    }
     return isTeamProject ? (
       <Button
         size="small"
@@ -96,18 +84,13 @@ export const MembershipButton = ({ project, isMember, isTeamProject, leaveProjec
           refreshEmbed();
         }}
       >
-        {joinProjectBtnText} <Icon icon="rainbow" />
+        Join <span className={styles.hideIfSmallViewport}>Team Project</span> <Icon icon="rainbow" />
       </Button>
     ) : null;
   }
 
   // let team members leave directly, warn non team members
   if (isTeamProject && leaveProject) {
-    let leaveProjectBtnText = 'Leave Project';
-    if (width && width < mediumSmallViewport) {
-      leaveProjectBtnText = 'Leave';
-    }
-
     return (
       <Button
         size="small"
@@ -116,7 +99,7 @@ export const MembershipButton = ({ project, isMember, isTeamProject, leaveProjec
           refreshEmbed();
         }}
       >
-        {leaveProjectBtnText} <Icon icon="wave" />
+        Leave <span className={styles.hideIfSmallViewport}>Project</span> <Icon icon="wave" />
       </Button>
     );
   }

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -56,8 +56,8 @@ EditButton.defaultProps = {
 };
 
 export const RemixButton = ({ name, isMember, onClick }) => (
-  <ResponsiveButton as="a" href={getRemixUrl(name)} size="small" onClick={onClick}>
-    Remix <span className={styles.hideIfSmallViewport}>{isMember ? 'This' : 'Your Own'}</span> <Icon className={emoji} icon="microphone" />
+  <ResponsiveButton as="a" href={getRemixUrl(name)} size="small" onClick={onClick} shortText="Remix" icon={<Icon className={emoji} icon="microphone" />}>
+    {isMember ? 'Remix This' : 'Remix Your Own'}
   </ResponsiveButton>
 );
 
@@ -75,30 +75,34 @@ RemixButton.defaultProps = {
 export const MembershipButton = ({ project, isMember, isTeamProject, leaveProject, joinProject, refreshEmbed }) => {
   if (!isMember && joinProject) {
     return isTeamProject ? (
-      <Button
+      <ResponsiveButton
         size="small"
         onClick={() => {
           joinProject();
           refreshEmbed();
         }}
+        shortText="Join"
+        icon={<Icon icon="rainbow" />}
       >
-        Join <span className={styles.hideIfSmallViewport}>Team Project</span> <Icon icon="rainbow" />
-      </Button>
+        Join Team Project
+      </ResponsiveButton>
     ) : null;
   }
 
   // let team members leave directly, warn non team members
   if (isTeamProject && leaveProject) {
     return (
-      <Button
+      <ResponsiveButton
         size="small"
         onClick={() => {
           leaveProject(project);
           refreshEmbed();
         }}
+        shortText="Leave"
+        icon={<Icon icon="wave" />}
       >
-        Leave <span className={styles.hideIfSmallViewport}>Project</span> <Icon icon="wave" />
-      </Button>
+        Leave Project
+      </ResponsiveButton>
     );
   }
   return (

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Button, Icon, Popover } from '@fogcreek/shared-components';
 
 import { getShowUrl, getEditorUrl, getRemixUrl } from 'Models/project';
-import { mediumSmallViewport, useWindowSize } from 'Hooks/use-window-size';
 import LeaveProjectPopover from './leave-project-pop';
 
 import { emoji } from '../global.styl';
@@ -73,8 +72,6 @@ RemixButton.defaultProps = {
 };
 
 export const MembershipButton = ({ project, isMember, isTeamProject, leaveProject, joinProject, refreshEmbed }) => {
-  const [width] = useWindowSize();
-
   if (!isMember && joinProject) {
     return isTeamProject ? (
       <Button

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon, Popover } from '@fogcreek/shared-components';
 
+import ResponsiveButton from 'Components/buttons/responsive-button';
 import { getShowUrl, getEditorUrl, getRemixUrl } from 'Models/project';
 import LeaveProjectPopover from './leave-project-pop';
 
@@ -36,13 +37,19 @@ EditButtonCta.defaultProps = {
 
 // the Edit Button that appears below the embed
 export const EditButton = ({ name, isMember, size }) => (
-  <Button as="a" href={getEditorUrl(name)} size={size}>
+  <ResponsiveButton
+    as="a"
+    href={getEditorUrl(name)}
+    size={size}
+    baseText={isMember ? 'Edit' : 'View'}
+    extraText={isMember ? ''}
+  />
     {isMember ? (
       <>Edit <span className={styles.hideIfSmallViewport}>Project</span></>
     ) : (
       <>View <span className={styles.hideIfSmallViewport}>Source</span></>
     )}
-  </Button>
+  </ResponsiveButton>
 );
 
 EditButton.propTypes = {

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -7,6 +7,7 @@ import { mediumSmallViewport, useWindowSize } from 'Hooks/use-window-size';
 import LeaveProjectPopover from './leave-project-pop';
 
 import { emoji } from '../global.styl';
+import styles from './project-actions.styl';
 
 export const ShowButton = ({ name, size }) => (
   <Button as="a" href={getShowUrl(name)} size={size}>
@@ -59,20 +60,13 @@ EditButton.defaultProps = {
   isMember: false,
 };
 
-export const RemixButton = ({ name, isMember, onClick }) => {
-  const [width] = useWindowSize();
-
-  let remixButtonText = 'Remix';
-  if (!width || width > mediumSmallViewport) {
-    remixButtonText = isMember ? `${remixButtonText} This` : `${remixButtonText} Your Own`;
-  }
-
-  return (
-    <Button as="a" href={getRemixUrl(name)} size="small" onClick={onClick}>
-      {remixButtonText} <Icon className={emoji} icon="microphone" />
-    </Button>
-  );
-};
+export const RemixButton = ({ name, isMember, onClick }) => (
+  <Button as="a" href={getRemixUrl(name)} size="small" onClick={onClick}>
+    Remix
+    <span className={styles.hideIfSmallViewport}>{isMember ? 'This' : 'Your Own'}</span>
+    <Icon className={emoji} icon="microphone" />
+  </Button>
+);
 
 RemixButton.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -36,12 +36,7 @@ EditButtonCta.defaultProps = {
 
 // the Edit Button that appears below the embed
 export const EditButton = ({ name, isMember, size }) => (
-  <ResponsiveButton
-    as="a"
-    href={getEditorUrl(name)}
-    size={size}
-    shortText={isMember ? 'Edit' : 'View'}
-  >
+  <ResponsiveButton as="a" href={getEditorUrl(name)} size={size} shortText={isMember ? 'Edit' : 'View'}>
     {isMember ? 'Edit Project' : 'View Source'}
   </ResponsiveButton>
 );

--- a/src/components/project/project-actions.js
+++ b/src/components/project/project-actions.js
@@ -7,7 +7,6 @@ import { getShowUrl, getEditorUrl, getRemixUrl } from 'Models/project';
 import LeaveProjectPopover from './leave-project-pop';
 
 import { emoji } from '../global.styl';
-import styles from './project-actions.styl';
 
 export const ShowButton = ({ name, size }) => (
   <Button as="a" href={getShowUrl(name)} size={size}>
@@ -41,14 +40,9 @@ export const EditButton = ({ name, isMember, size }) => (
     as="a"
     href={getEditorUrl(name)}
     size={size}
-    baseText={isMember ? 'Edit' : 'View'}
-    extraText={isMember ? ''}
-  />
-    {isMember ? (
-      <>Edit <span className={styles.hideIfSmallViewport}>Project</span></>
-    ) : (
-      <>View <span className={styles.hideIfSmallViewport}>Source</span></>
-    )}
+    shortText={isMember ? 'Edit' : 'View'}
+  >
+    {isMember ? 'Edit Project' : 'View Source'}
   </ResponsiveButton>
 );
 
@@ -62,9 +56,9 @@ EditButton.defaultProps = {
 };
 
 export const RemixButton = ({ name, isMember, onClick }) => (
-  <Button as="a" href={getRemixUrl(name)} size="small" onClick={onClick}>
+  <ResponsiveButton as="a" href={getRemixUrl(name)} size="small" onClick={onClick}>
     Remix <span className={styles.hideIfSmallViewport}>{isMember ? 'This' : 'Your Own'}</span> <Icon className={emoji} icon="microphone" />
-  </Button>
+  </ResponsiveButton>
 );
 
 RemixButton.propTypes = {

--- a/src/components/project/project-actions.styl
+++ b/src/components/project/project-actions.styl
@@ -1,0 +1,5 @@
+@require '../constants'
+
+@media (max-width: mediumSmallViewport)
+ .hideIfSmallViewport
+   display: none

--- a/src/components/project/project-actions.styl
+++ b/src/components/project/project-actions.styl
@@ -1,5 +1,0 @@
-@require '../constants'
-
-@media (max-width: mediumSmallViewport)
- .hideIfSmallViewport
-   display: none


### PR DESCRIPTION
## Links
https://nova-chance.glitch.me/
https://app.clubhouse.io/glitch/story/3489/replace-usewindowsize-with-css-media-queries

## Changes:
Added ResponsiveButton, which shows either `children` or `shortText` based on the window width

## How To Test:
- Resize the window on a project page and see how it does