### PR TITLE
docs updated for https://github.com/FogCreek/Glitch-Community/pull/1121

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,24 +1,27 @@
 # Glitch.com Continuous Integration Configuration
 
-## Overall Process
+## Overall Development Process
 
-1. local dev
-2. push to `staging`
-   i. CircleCI picks up the commit
-      a. lints, builds, runs tests, just like it does right now
-      b. queries s3 to determine if the build archive is already present [remotely executed on a worker]
-      c. if not, sends asset for upload [remotely executed on a worker]
-      d. sends `deploy` command, which gets the asset from S3 and deploys it to the local box [remotely executed on each worker]
+1. Do your development work locally on a branch (nothing here changes, I think)
+1. merge and push to `staging`
+      1. CircleCI picks up the commit
+            1. lints, builds, runs tests, just like it does right now
+            1. `deploy.sh`
+                  1. queries s3 to determine if the current commit's build archive is already present
+                  1. if not, sends asset for upload
+                  1. sends `deploy` command to each community worker, which runs `local-deploy.sh`, gets the asset from S3 and deploys it to the local box [remotely executed on each worker]
 3. merge to `master`
-   i. CircleCI picks up the commit
-      a. same process as for staging @ 2.i.a above, but deploying to the production boxes
-      b. there's nothing in this process that indicates that staging has to be involved. If you want to have folks PR directly against / merge directly into `master` that should also work just as well.
+      1. CircleCI picks up the commit
+            1. same process as for staging @ 2.1 above, but deploying to the production boxes
 
 ## Details
 
 ### No secrets in the Glitch-Community repo
 
-A central tenet to the community CI work is that the community repo shouldn't house any secrets (even encrypted ones). This means that any information we need to get from somewhere else (AWS, primarily) needs to be proxied through something that has the appropriate permissions. To avoid additional complexity, we're relying on the built-in access that the community host machines already have by virtue of them living in our infrastructure and already having the Glitch repo in place. The downside to this is that this CI process is tightly tied to the Glitch CI process in a number of ways, so when that process changes this process will have to undergo corresponding changes. There are a few touchpoints in the Glitch code that represent this link, so I don't think there'll be major changes to the Glitch deploy process without some attention paid here, but it's worth noting.
+No secrets, encrypted or not, are stored in the Glitch-Community repo. CircleCI needs a few things configured to be able to do this work:
+
+1. The environment-specific (production, staging) bootstrap secret that gives CircleCI access to our AWS environment for finding / uploading the build asset, configured in the CircleCI environment variables for the project (https://circleci.com/gh/FogCreek/Glitch-Community/edit#env-vars).
+1. An ssh certificate to authenticate to the Glitch network, configured in the CircleCI SSH Permissions page at https://circleci.com/gh/FogCreek/Glitch-Community/edit#ssh. The appropriate certificate is stored in the Glitch repo.
 
 ### Resulting project structure
 
@@ -29,31 +32,11 @@ The overall structure, therefore, is this:
 In the Glitch-Community repo
 
 - .circleci
-  |
   - config.yaml - CircleCI configuration file, enhanced with the deploy job
 - ci
-  |
-  - deploy.sh - script run on the CircleCI executor; marshalls the deploy behavior that takes place on the community hosts themselves
-  |
-  - (these files all run on the hosts in the Glitch Infrastructure)
-  - check-deploy-source.sh - checks to see if the asset for the current sha is in S3
-  - upload-asset.sh - handles uploading the provided asset to the appropriate bucket and marking the correct sha
-  - local-deploy.sh - does the deploy work - stops the running site, cleans up the old code, pulls and unzips the new code, npm installs and runs the site
+  - deploy.sh - script run on the CircleCI executor that marshalls all the CircleCI-hosted deploy work
+  - publish-build-asset.sh - script run on the CircleCI executor that checks for and uploads (if indicated) the SHA1-identified tarball of the build result for the matching commit 
+  - local-deploy.sh - does the _local_ deploy work - stops the running site, cleans up the old code, pulls and unzips the new code, npm installs and runs the site. Executed on each community worker in turn via an ssh session started from the CircleCI executor.
 
-In the Glitch repo there is a bootstrap script that helps new community hosts get the right code as well as the terraform code that manages these devices.
-
-In S3 there is a bucket for bootstrapping in each environment (staging / production). This bucket contains the community project's `.env` file (downloaded during deploy) and the build assets from any released commit. We'll eventually want to clean up these assets. We could potentially use this bucket or something like it for storing the static assets from [ch4794](https://app.clubhouse.io/glitch/story/4797/plan-how-to-host-static-assets-outside-of-a-glitch-project).
-
-### (Some of the) Remaining work
-
-* I think it might be worthwhile to add some level of tracing to this process in the future
-* finish production infra (s3 bootstrapping bucket and the like)
-* connect `master` to prod infra and test some deploys
-* flip to prod infra
-
-### Things I chose _not_ to do
-
-* prevent overlapping CircleCI deploys
-  * there are so few boxes, deploys should happen so quickly, and the number of simulatneous deploys is so low this didn't seem worth any effort right now
-* implement `no-deploy` or `no-test` flags
-  * again this didn't seem needed right away; we can implement them later if we care to
+## New hosts
+The Glitch repo's bootstrap process handles spinning up new community workers and contains a bootstrap script that checks out the Glitch-Community repo (to gain access to the appropriate scripts), gets the tagged build asset from S3, and executes `local-deploy.sh` to set up new hosts. The terraform code that manages this infrastructure also exists there. Additionally, there is an S3 bucket for bootstrapping in each environment (staging / production) which contains the community project's `.env` file (downloaded during deploy) and the build assets from any released commit.


### PR DESCRIPTION
## Changes:

* updated to match the changes in the [referenced PR](https://github.com/FogCreek/Glitch-Community/pull/1121), primarily the interaction between the various 3rd party services. Linked-to diagram is also correspondingly updated.
* I switched back to Markdown style numbering because GitHub-flavored Markdown (and possibly others) did not like my attempt at numbering it manually. My apologies, but please view the preview (not the diff) for the numbering.


## Feedback I'm looking for:

* is this sufficiently clear?
* should any additional guidance or information be included?
* is any of it extraneous?

## Things left to do before deploying (pulled from README.md for posterity):

* I think it might be worthwhile to add some level of tracing to this process in the future
* ~finish production infra (s3 bootstrapping bucket and the like)~ (in https://github.com/FogCreek/Glitch/pull/2444)
* connect `master` to prod infra and test some deploys
* flip to prod infra
* ~clean up expired assets~ (in https://github.com/FogCreek/Glitch/pull/2444)

### Things I chose _not_ to do (also pulled from README.md)

* prevent overlapping CircleCI deploys
  * there are so few boxes, deploys should happen so quickly, and the number of simultaneous deploys is so low this didn't seem worth any effort right now
* implement `no-deploy` or `no-test` flags
  * again this didn't seem needed right away; we can implement them later if we care to
