### PR TITLE
move build assets to a subpath for better expiration

### DIFF
--- a/ci/local-deploy.sh
+++ b/ci/local-deploy.sh
@@ -34,7 +34,7 @@ npm i && npm run stop && wait
 find . -type f | grep -v -e "${CIRCLE_SHA}.tar.gz" -e "ci" | xargs rm -rf
 
 # go get the build file. we assume it is there; this scripts only caller deposits it. then deploy.
-aws s3 cp --quiet "s3://${COMMUNITY_BOOTSTRAP_BUCKET}/${CIRCLE_SHA}.tar.gz" .
+aws s3 cp --quiet "s3://${COMMUNITY_BOOTSTRAP_BUCKET}/builds/${CIRCLE_SHA}.tar.gz" .
 tar -xz --overwrite -f "${CIRCLE_SHA}.tar.gz"
 rm "${CIRCLE_SHA}.tar.gz"
 

--- a/ci/publish-build-asset.sh
+++ b/ci/publish-build-asset.sh
@@ -28,15 +28,15 @@ export AWS_SECRET_ACCESS_KEY=${COMMUNITY_AWS_BOOTSTRAP_SECRET}
 if [[ -f "/home/circleci/$CIRCLE_SHA.tar.gz" ]]; then
 
   # maybe upload
-  if aws s3api head-object --bucket "$COMMUNITY_BOOTSTRAP_BUCKET" --key "$CIRCLE_SHA.tar.gz" > /dev/null 2>&1; then
+  if aws s3api head-object --bucket "$COMMUNITY_BOOTSTRAP_BUCKET" --key "builds/$CIRCLE_SHA.tar.gz" > /dev/null 2>&1; then
     code=$?
     echo "$CIRCLE_SHA.tar.gz exists in S3"
   else
     #   this build is not in s3
-    aws s3 cp --quiet "/home/circleci/$CIRCLE_SHA.tar.gz" "s3://$COMMUNITY_BOOTSTRAP_BUCKET"; code=$?
+    aws s3 cp --quiet "/home/circleci/$CIRCLE_SHA.tar.gz" "s3://$COMMUNITY_BOOTSTRAP_BUCKET/builds"; code=$?
   fi
 
-  #update
+  #update last_deployed_sha
   if [[ "$code" -eq 0 ]]; then
     echo "$CIRCLE_SHA" > /home/circleci/LAST_DEPLOYED_SHA
     aws s3 cp --quiet /home/circleci/LAST_DEPLOYED_SHA "s3://$COMMUNITY_BOOTSTRAP_BUCKET"; code=$?


### PR DESCRIPTION
## Changes:
* move the build assets to a subpath so we can properly expire them

## How To Test:
* merging into staging should kick off a build to test the changes

## Feedback I'm looking for:
* I'm going to go ahead and merge this into staging - I just wanted a branch to point to
