### PR TITLE
Placid salto: use v0 routes for user pinned projects

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -202,7 +202,7 @@ export const useAPIHandlers = () => {
       // teams / users
       // note: users are currently using v0 routes, but teams are using v1 routes
       addPinnedProject: ({ project, team, user }) =>
-        team 
+        team
           ? api.put(`/${entityPath({ team })}/pinnedProjects/${project.id}`)
           : api.post(`/${entityPath({ user })}/pinned-projects/${project.id}`),
       removePinnedProject: ({ project, team, user }) =>

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -76,9 +76,7 @@ export function APIContextProvider({ children }) {
     if (api.persistentToken && pendingRequests.length) {
       // go back and finally make all of those requests
       pendingRequests.forEach((request) => request(api));
-      setPendingRequests((latestPendingRequests) => (
-        latestPendingRequests.filter((request) => !pendingRequests.includes(request))
-      ));
+      setPendingRequests((latestPendingRequests) => latestPendingRequests.filter((request) => !pendingRequests.includes(request)));
     }
   }, [api, pendingRequests]);
   return <Context.Provider value={api}>{children}</Context.Provider>;
@@ -183,11 +181,12 @@ export const useAPIHandlers = () => {
       removeUserFromProject: ({ project, user }) => api.delete(`/projects/${project.id}/authorization`, { data: { targetUserId: user.id } }),
       updateProjectDomain: ({ project }) => api.post(`/project/domainChanged?projectId=${project.id}`),
       undeleteProject: ({ project }) => api.post(`/projects/${project.id}/undelete`),
-      updateProjectMemberAccessLevel: ({ project, user, accessLevel }) => api.post(`/project_permissions/${project.id}`, {
-        projectId: project.id,
-        userId: user.id,
-        accessLevel,
-      }),
+      updateProjectMemberAccessLevel: ({ project, user, accessLevel }) =>
+        api.post(`/project_permissions/${project.id}`, {
+          projectId: project.id,
+          userId: user.id,
+          accessLevel,
+        }),
 
       // teams
       joinTeam: ({ team }) => api.post(`/v1/teams/${team.id}/join`),
@@ -201,8 +200,15 @@ export const useAPIHandlers = () => {
       joinTeamProject: ({ project, team }) => api.post(`/v1/teams/${team.id}/projects/${project.id}/join`),
 
       // teams / users
-      addPinnedProject: ({ project, team, user }) => api.put(`/${entityPath({ team, user })}/pinnedProjects/${project.id}`),
-      removePinnedProject: ({ project, team, user }) => api.delete(`/${entityPath({ team, user })}/pinnedProjects/${project.id}`),
+      // note: users are currently using v0 routes, but teams are using v1 routes
+      addPinnedProject: ({ project, team, user }) =>
+        team 
+          ? api.put(`/${entityPath({ team })}/pinnedProjects/${project.id}`)
+          : api.post(`/${entityPath({ user })}/pinned-projects/${project.id}`),
+      removePinnedProject: ({ project, team, user }) =>
+        team
+          ? api.delete(`/${entityPath({ team })}/pinnedProjects/${project.id}`)
+          : api.delete(`/${entityPath({ user })}/pinned-projects/${project.id}`),
     }),
     [api],
   );


### PR DESCRIPTION
## Links
* Remix link: https://placid-salto.glitch.me
* Issue-tracker link: https://app.clubhouse.io/glitch/story/6315/pinning-projects-no-longer-working

## Changes:
* use v0 routes for user pins, v1 routes for team pins

## How To Test:
* log into placid-salto.glitch.me
* visit your user page
* verify you can pin & un-pin your projects
* visit a team page you control
* verify you can pin & un-pin your team's projects
