### PR TITLE
add production settings (prep for merging to master and starting prod deploys)

### DIFF
--- a/ci/env
+++ b/ci/env
@@ -24,14 +24,14 @@ fi
 # set the COMMUNITY_BOOTSTRAP_BUCKET, JUMP_DOMAIN, and key id appropriately
 case "${ENVIRONMENT}" in
   production)
-    export COMMUNITY_BOOTSTRAP_BUCKET=
+    export COMMUNITY_BOOTSTRAP_BUCKET=community-bootstrap-bucket20200103210320258500000002
     export JUMP_DOMAIN=jump.glitch.com
-    export COMMUNITY_AWS_BOOTSTRAP_KEY=
+    export COMMUNITY_AWS_BOOTSTRAP_KEY=AKIAWT5PUNCVYJCBDB6W
     ;;
   staging)
     export COMMUNITY_BOOTSTRAP_BUCKET=community-bootstrap-bucket20191205165831056600000001
     export JUMP_DOMAIN=jump.staging.glitch.com
-    export COMMUNITY_AWS_BOOTSTRAP_KEY=AKIA6O2CCK6XTDYMEAM4
+    export COMMUNITY_AWS_BOOTSTRAP_KEY=AKIA6O2CCK6XWDBCK7M5
     ;;
   *)
     echo "Unknown environment ${ENVIRONMENT}"


### PR DESCRIPTION
## Changes:
* adds the production S3 bucket and access key ids
* updates the staging access key to one already managed by terraform - this requires some CircleCI changes to match. future deploys will test that the key works as expected.

## How To Test:
* merge and deploy

## Feedback I'm looking for:
* sanity check
* timeline for getting these changes into prod so Circle can start using them.

## Things left to do before deploying:
- i'll merge this to staging to get the production info and the corrected staging key there. Once this is in staging, when we are ready to start deploys to the prod infra just merging staging to master (and adding the proper env var to CircleCI) should get things running. 