### PR TITLE
separate projects into words and Title Case them

### DIFF
--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -225,7 +225,7 @@ const ProjectPage = ({ project: initialProject }) => {
   return (
     <main id="main" aria-label="Glitch Project Page">
       <GlitchHelmet
-        title={project.domain}
+        title={project.domain.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1))}
         description={seoDescription}
         image={project.suspendedReason ? SUSPENDED_AVATAR_URL : getProjectAvatarUrl(project)}
         canonicalUrl={getProjectLink(project)}


### PR DESCRIPTION
## Links
* https://cookie-ricotta.glitch.me
* https://app.clubhouse.io/glitch/story/6637/in-title-tag-for-project-pages-change-format-of-project-names

## GIF/Screenshots:
<img width="459" alt="Screen Shot 2020-01-09 at 3 01 01 PM" src="https://user-images.githubusercontent.com/3011231/72100578-e0022c00-32f0-11ea-8687-41ea02a67d26.png">

## Changes:
* Separates words in project domains (by hyphen only), converts them to Title Case

## How To Test:
* go to a project page, look at what's in the tab title

## Feedback I'm looking for:
all good?
