### PR TITLE
Fallacious slice: Redux for local storage

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,6 @@ import { HelmetProvider } from 'react-helmet-async';
 import Store from 'State/store';
 import { APIContextProvider } from 'State/api';
 import { APICacheProvider } from 'State/api-cache';
-import { LocalStorageProvider } from 'State/local-storage';
 import { ProjectContextProvider } from 'State/project';
 import { CollectionContextProvider } from 'State/collection';
 import { NotificationsProvider } from 'State/notifications';
@@ -23,22 +22,20 @@ const App = ({ apiCache, helmetContext }) => (
       <LiveAnnouncer>
         <Store>
           <NotificationsProvider>
-            <LocalStorageProvider>
-              <APIContextProvider>
-                <APICacheProvider initial={apiCache}>
-                  <ProjectContextProvider>
-                    <CollectionContextProvider>
-                      <HelmetProvider context={helmetContext}>
-                        <SuperUserBanner />
-                        <OfflineNotice />
-                        <Router />
-                        <RolloutsUserSync />
-                      </HelmetProvider>
-                    </CollectionContextProvider>
-                  </ProjectContextProvider>
-                </APICacheProvider>
-              </APIContextProvider>
-            </LocalStorageProvider>
+            <APIContextProvider>
+              <APICacheProvider initial={apiCache}>
+                <ProjectContextProvider>
+                  <CollectionContextProvider>
+                    <HelmetProvider context={helmetContext}>
+                      <SuperUserBanner />
+                      <OfflineNotice />
+                      <Router />
+                      <RolloutsUserSync />
+                    </HelmetProvider>
+                  </CollectionContextProvider>
+                </ProjectContextProvider>
+              </APICacheProvider>
+            </APIContextProvider>
           </NotificationsProvider>
         </Store>
       </LiveAnnouncer>

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -104,12 +104,9 @@ export const handlers = {
 
 const useLocalStorage = (name, defaultValue) => {
   const storage = useSelector((state) => state.localStorage.storage);
-  const { value, cached } = useSelector((state) => {
-    if (state.localStorage.cache.has(name)) {
-      return { value: state.localStorage.cache.get(name), cached: true };
-    }
-    return { value: readFromStorage(storage, name), cached: false };
-  });
+  const valueIsCached = useSelector((state) => state.localStorage.cache.has(name));
+  const cachedValue = useSelector((state) => state.localStorage.cache.get(name));
+  const storedValue = valueIsCached ? cachedValue : 
   const dispatch = useDispatch();
   const setValue = React.useCallback((newValue) => dispatch(actions.writeValue({ name, value: newValue })), [name]);
   return [value, setValue, !!storage];

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -1,22 +1,24 @@
 import React from 'react';
+import { createSlice } from '@reduxjs/toolkit';
+import { useSelector, useDispatch } from 'react-redux';
 import { captureException } from 'Utils/sentry';
+
+const testStorage = (storage) => {
+  storage.setItem('test', 'test');
+  storage.getItem('test');
+  storage.removeItem('test');
+};
 
 export const getStorage = () => {
   try {
-    const storage = window.localStorage;
-    storage.setItem('test', 'test');
-    storage.getItem('test');
-    storage.removeItem('test');
-    return storage;
+    testStorage(window.localStorage);
+    return window.localStorage;
   } catch (error) {
     console.warn('Local storage not available');
   }
   try {
-    const storage = window.sessionStorage;
-    storage.setItem('test', 'test');
-    storage.getItem('test');
-    storage.removeItem('test');
-    return storage;
+    testStorage(window.sessionStorage);
+    return window.sessionStorage;
   } catch (error) {
     console.warn('Session storage not available');
   }
@@ -50,6 +52,23 @@ export const writeToStorage = (storage, name, value) => {
     }
   }
 };
+
+export const { reducer, actions } = createSlice({
+  name: 'localStorage',
+  initialState: {
+    cache: new Map(),
+    ready: false,
+  },
+  reducers: {
+    initialized: (state) => ({
+      ...state,
+      ready: true,
+    }),
+    readValue: ({ cache }, { payload }) => {
+      cache.setValue(payload.name, payload.value);
+    }
+  },
+});
 
 const Context = React.createContext([() => undefined, () => {}]);
 

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback, useEffect } from 'react';
 import { createSlice } from '@reduxjs/toolkit';
 import { useSelector, useDispatch } from 'react-redux';
 import { captureException } from 'Utils/sentry';
@@ -107,14 +107,14 @@ const useLocalStorage = (name, defaultValue) => {
   const cachedValue = useSelector((state) => state.localStorage.cache[name]);
 
   const dispatch = useDispatch();
-  React.useEffect(() => {
+  useEffect(() => {
     if (ready && !valueIsCached) {
       dispatch(actions.readValue({ name, value: readFromStorage(storage, name) }));
     }
   }, [ready, valueIsCached, name]);
 
   const value = cachedValue !== undefined ? cachedValue : defaultValue;
-  const setValue = React.useCallback((newValue) => dispatch(actions.writeValue({ name, value: newValue })), [name]);
+  const setValue = useCallback((newValue) => dispatch(actions.writeValue({ name, value: newValue })), [name]);
   return [value, setValue, ready];
 };
 

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -61,24 +61,22 @@ export const { reducer, actions } = createSlice({
     ready: false,
   },
   reducers: {
-    storageFound: () => ({
-      cache: {},
-      ready: true,
-    }),
+    storageFound: (store) => {
+      store.cache = {};
+      store.ready = true;
+    },
     storageUpdated: ({ cache }, { payload }) => {
       delete cache[payload];
     },
-    storageCleared: (store) => ({
-      ...store,
-      cache: {},
-    }),
-    readValue: (cache, { payload }) => {
-      cache[payload.name] = payload.value },
-    }),
-    writeValue: (store, { payload }) => ({
-      ...store,
-      cache: { ...store.cache, [payload.name]: payload.value },
-    }),
+    storageCleared: (store) => {
+      store.cache = {};
+    },
+    readValue: ({ cache }, { payload }) => {
+      cache[payload.name] = payload.value;
+    },
+    writeValue: ({ cache }, { payload }) => {
+      cache[payload.name] = payload.value;
+    },
   },
 });
 
@@ -111,10 +109,10 @@ const useLocalStorage = (name, defaultValue) => {
 
   const dispatch = useDispatch();
   React.useEffect(() => {
-    if (!valueIsCached) {
+    if (ready && !valueIsCached) {
       dispatch(actions.readValue({ name, value: readFromStorage(storage, name) }));
     }
-  }, [valueIsCached, name]);
+  }, [ready, valueIsCached, name]);
 
   const value = cachedValue !== undefined ? cachedValue : defaultValue;
   const setValue = React.useCallback((newValue) => dispatch(actions.writeValue({ name, value: newValue })), [name]);

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -8,18 +8,17 @@ const testStorage = (storage) => {
   storage.setItem('test', 'test');
   storage.getItem('test');
   storage.removeItem('test');
+  return storage;
 };
 
 export const getStorage = () => {
   try {
-    testStorage(window.localStorage);
-    return window.localStorage;
+    return testStorage(window.localStorage);
   } catch (error) {
     console.warn('Local storage not available');
   }
   try {
-    testStorage(window.sessionStorage);
-    return window.sessionStorage;
+    return testStorage(window.sessionStorage);
   } catch (error) {
     console.warn('Session storage not available');
   }

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -74,6 +74,9 @@ export const { reducer, actions } = createSlice({
     clearCache: ({ cache }) => {
       cache.clear();
     },
+    readValue: ({ storage, cache }, { payload }) => {
+      if (!cache.has())
+    }
   },
 });
 
@@ -95,7 +98,14 @@ export const handlers = {
 };
 
 const useLocalStorage = (name, defaultValue) => {
-  const value = useSelector((state) => state.localStorage.cache[name]);
+  const storage = useSelector((state) => state.localStorage.storage);
+  const { value, cached } = useSelector((state) => {
+    if (state.localStorage.cache.has(name)) {
+      return { value: state.localStorage.cache.get(name), cached: true };
+    }
+    return { value: readFromStorage(storage, name), cached: false };
+  });
+  const dispatch = useDispatch();
 };
 
 /*

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -65,24 +65,40 @@ export const { reducer, actions } = createSlice({
       storage: payload,
       cache: new Map(),
     }),
-    setValue: ({ cache }, { payload }) => {
+    addToCache: ({ cache }, { payload }) => {
       cache.set(payload.name, payload.value);
     },
-    readValue: () => {},
-    writeValue: () => {},
+    removeFromCache: ({ cache }, { payload }) => {
+      cache.delete(payload);
+    },
+    clearCache: ({ cache }) => {
+      cache.clear();
+    },
   },
 });
 
 export const handlers = {
   [appMounted]: (_, store) => {
+    const storage = getStorage();
     const onStorage = (event) => {
-      
+      if (event.storageArea === storage) {
+        if (event.key) {
+          store.dispatch(actions.removeFromCache(event.key));
+        } else {
+          store.dispatch(actions.clearCache());
+        }
+      }
     };
     window.addEventListener('storage', onStorage, { passive: true });
     store.dispatch(actions.setStorage(storage));
   },
 };
 
+const useLocalStorage = (name, defaultValue) => {
+  const value = useSelector((state) => state.localStorage.cache[name]);
+};
+
+/*
 const Context = React.createContext([() => undefined, () => {}]);
 
 const LocalStorageProvider = ({ children }) => {
@@ -143,7 +159,7 @@ const LocalStorageProvider = ({ children }) => {
   );
 };
 
-const useLocalStorage = (name, defaultValue) => {
+const useOldLocalStorage = (name, defaultValue) => {
   const [getRawValue, setRawValue, ready] = React.useContext(Context);
   const rawValue = getRawValue(name);
 
@@ -154,4 +170,4 @@ const useLocalStorage = (name, defaultValue) => {
 };
 
 export default useLocalStorage;
-export { LocalStorageProvider };
+export { LocalStorageProvider };*/

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { createSlice } from '@reduxjs/toolkit';
 import { useSelector, useDispatch } from 'react-redux';
 import { captureException } from 'Utils/sentry';
+import { appMounted } from './app-mounted';
 
 const testStorage = (storage) => {
   storage.setItem('test', 'test');
@@ -56,19 +57,31 @@ export const writeToStorage = (storage, name, value) => {
 export const { reducer, actions } = createSlice({
   name: 'localStorage',
   initialState: {
+    storage: null,
     cache: new Map(),
-    ready: false,
   },
   reducers: {
-    initialized: (state) => ({
-      ...state,
-      ready: true,
+    setStorage: (state, { payload }) => ({
+      storage: payload,
+      cache: new Map(),
     }),
-    readValue: ({ cache }, { payload }) => {
-      cache.setValue(payload.name, payload.value);
-    }
+    setValue: ({ cache }, { payload }) => {
+      cache.set(payload.name, payload.value);
+    },
+    readValue: () => {},
+    writeValue: () => {},
   },
 });
+
+export const handlers = {
+  [appMounted]: (_, store) => {
+    const onStorage = (event) => {
+      
+    };
+    window.addEventListener('storage', onStorage, { passive: true });
+    store.dispatch(actions.setStorage(storage));
+  },
+};
 
 const Context = React.createContext([() => undefined, () => {}]);
 

--- a/src/state/local-storage.js
+++ b/src/state/local-storage.js
@@ -57,26 +57,28 @@ export const writeToStorage = (storage, name, value) => {
 export const { reducer, actions } = createSlice({
   name: 'localStorage',
   initialState: {
-    cache: new Map(),
+    cache: {},
     ready: false,
   },
   reducers: {
     storageFound: () => ({
-      cache: new Map(),
+      cache: {},
       ready: true,
     }),
     storageUpdated: ({ cache }, { payload }) => {
-      cache.delete(payload);
+      delete cache[payload];
     },
-    storageCleared: ({ cache }) => {
-      cache.clear();
-    },
-    readValue: ({ cache }, { payload }) => {
-      cache.set(payload.name, payload.value);
-    },
-    writeValue: ({ cache }, { payload }) => {
-      cache.set(payload.name, payload.value);
-    },
+    storageCleared: (store) => ({
+      ...store,
+      cache: {},
+    }),
+    readValue: (cache, { payload }) => {
+      cache[payload.name] = payload.value },
+    }),
+    writeValue: (store, { payload }) => ({
+      ...store,
+      cache: { ...store.cache, [payload.name]: payload.value },
+    }),
   },
 });
 
@@ -104,8 +106,8 @@ export const handlers = {
 
 const useLocalStorage = (name, defaultValue) => {
   const ready = useSelector((state) => state.localStorage.ready);
-  const valueIsCached = useSelector((state) => state.localStorage.cache.has(name));
-  const cachedValue = useSelector((state) => state.localStorage.cache.get(name));
+  const valueIsCached = useSelector((state) => name in state.localStorage.cache);
+  const cachedValue = useSelector((state) => state.localStorage.cache[name]);
 
   const dispatch = useDispatch();
   React.useEffect(() => {

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -3,14 +3,20 @@ import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { isBrowser } from 'Utils/constants';
 import createHandlerMiddleware from './handler-middleware';
+import * as localStorage from './local-storage';
 import * as currentUser from './current-user';
 
 const createStore = () =>
   configureStore({
     reducer: {
       currentUser: currentUser.reducer,
+      localStorage: localStorage.reducer,
     },
-    middleware: [...getDefaultMiddleware(), createHandlerMiddleware(currentUser.handlers)],
+    middleware: [
+      ...getDefaultMiddleware(),
+      createHandlerMiddleware(currentUser.handlers),
+      createHandlerMiddleware(localStorage.handlers),
+    ],
     devTools: isBrowser && window.ENVIRONMENT === 'dev',
   });
 

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -9,13 +9,13 @@ import * as currentUser from './current-user';
 const createStore = () =>
   configureStore({
     reducer: {
-      currentUser: currentUser.reducer,
       localStorage: localStorage.reducer,
+      currentUser: currentUser.reducer,
     },
     middleware: [
       ...getDefaultMiddleware(),
-      createHandlerMiddleware(currentUser.handlers),
       createHandlerMiddleware(localStorage.handlers),
+      createHandlerMiddleware(currentUser.handlers),
     ],
     devTools: isBrowser && window.ENVIRONMENT === 'dev',
   });


### PR DESCRIPTION
## Links
https://fallacious-slice.glitch.me/
https://app.clubhouse.io/glitch/story/6671/convert-local-storage-to-use-redux

## Changes:
- Local storage is in the redux store, rather than having its own context
- Small behavioral change: components used to read from storage in their first render (excluding the initial full page render) but now the hook never reads from storage outside of redux handlers or useEffect calls

## How To Test:
Browse around the site and make sure things that use storage still work (and sync across tabs)
- Signing in and out
- Updating your name
- Dev toggles
- Optimizely overrides
- Pupdates

## Feedback I'm looking for:
It's apparently bad form to store dynamic stuff such as the local storage object in the redux state (it shows a warning). The getStorage function isn't node compatible, so I've opted to have a root level var the gets set by the appMounted handler