### PR TITLE
Fix settings page flicker

### DIFF
--- a/src/presenters/pages/settings.js
+++ b/src/presenters/pages/settings.js
@@ -14,13 +14,17 @@ import { emoji } from '../../components/global.styl';
 
 const Settings = () => {
   const tagline = 'Account Settings';
-  const { currentUser } = useCurrentUser();
+  const { currentUser, fetched } = useCurrentUser();
   const { persistentToken, login } = currentUser;
   const userPasswordEnabled = useDevToggle('User Passwords');
   const tfaEnabled = useDevToggle('Two Factor Auth');
   const isSignedIn = persistentToken && login;
   const showAccountSettingsTab = userPasswordEnabled || tfaEnabled;
   const showSubscriptionTab = useFeatureEnabled('pufferfish');
+
+  if (!fetched) {
+    return null;
+  }
 
   if (!isSignedIn || !(showAccountSettingsTab || showSubscriptionTab)) {
     return <NotFoundPage />;


### PR DESCRIPTION
## Links
* Remix link: https://sarah-staging.glitch.me/settings

## GIF/Screenshots:
![](http://g.recordit.co/ryFKfggnBO.gif)

## Changes:
* Don't show not found page until user has been fetched

## How To Test:
* go to /secret and enable various features like user deletion and auth stuff, see how the /settings page works when features are enabled/disabled and when you're logged in/not logged in etc. 
