### PR TITLE
update API route to PUT for joining team project

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -192,7 +192,7 @@ export const useAPIHandlers = () => {
       removeUserFromTeam: ({ user, team }) => api.delete(`/v1/teams/${team.id}/users/${user.id}`),
       addProjectToTeam: ({ project, team }) => api.put(`/v1/teams/${team.id}/projects/${project.id}`),
       removeProjectFromTeam: ({ project, team }) => api.delete(`/v1/teams/${team.id}/projects/${project.id}`),
-      joinTeamProject: ({ project, team }) => api.post(`/v1/teams/${team.id}/projects/${project.id}/join`),
+      joinTeamProject: ({ project, team }) => api.put(`/v1/teams/${team.id}/projects/${project.id}/join`),
 
       // teams / users
       addPinnedProject: ({ project, team, user }) => api.put(`/${entityPath({ team, user })}/pinnedProjects/${project.id}`),

--- a/src/state/current-user.js
+++ b/src/state/current-user.js
@@ -201,6 +201,9 @@ export const { reducer, actions } = createSlice({
     leftProject: (state, { payload }) => {
       state.projects = state.projects.filter((p) => p.id !== payload.id);
     },
+    joinedProject: (state, { payload }) => {
+      state.projects.push(payload);
+    },
   },
 });
 

--- a/src/state/project-options.js
+++ b/src/state/project-options.js
@@ -38,6 +38,7 @@ const useDefaultProjectOptions = () => {
     joinTeamProject: withErrorHandler(async (project, team) => {
       await joinTeamProject({ team, project });
       reloadProjectMembers([project.id]);
+      dispatch(currentUserActions.joinedProject(project));
     }, handleError),
     leaveProject: withErrorHandler(async (project) => {
       await removeUserFromProject({ project, user: currentUser });


### PR DESCRIPTION
## Links
* breezy-ocelot.glitch.me
* https://app.clubhouse.io/glitch/story/6898/join-team-project-from-project-page-doesn-t-work

## Changes:
* changes the API call to a PUT, as needed for the new route

## How To Test:
* Go to a project page for a project that is in a team you're on, click the "join team project" button under the embed. You should join the project, not get an error

## Feedback I'm looking for:
* is the change in current-user necessary? it seems like we ought to have it

## Things left to do before deploying:
- Not really a TODO, but note that the button doesn't update properly if you're joining a project on the glitch team (see ch6956). Isaac's looking into that further, he thinks its a timeout when we update the search index (but still not sure why it only happens for glitch team projects)
