### PR TITLE
Discovered seashore: Glitch PRO link in navigation

### DIFF
--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { Button } from '@fogcreek/shared-components';
+import Link from 'Components/link'
+
+import { useFeatureEnabled } from 'State/rollouts';
+
+const GlitchProCTA = () => {
+//   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
+
+//   if (!userHasPufferfishEnabled) {
+//     return null;
+//   }
+  
+  return (
+    <Button size="small" as={Link} to="/pricing">Glitch PRO</Button>
+  )
+};
+
+export default GlitchProCTA;

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -1,45 +1,14 @@
 import React from 'react';
-import styled from 'styled-components';
 import { Button } from '@fogcreek/shared-components';
 import Link from 'Components/link';
 import { useFeatureEnabled } from 'State/rollouts';
 import useSubscriptionStatus from 'State/subscription-status';
 import { CDN_URL } from 'Utils/constants';
+import styles from './styles.styl';
 
-const GlitchProBadge = styled.span`
-  font-weight: bold;
-  font-size: var(--fontSizes-small);
-  display: inline-block;
-  color: #2800FF;
-  padding-top: 2px;
-  margin-right: var(--space-1);
-`;
-
-const PricingPageButton = styled(Button)`
-  position: relative;
-  padding: 2px;
-  border: none;
-  line-height: 1.3;
-  background: linear-gradient(12deg, #C454FF, #2800FF, #FA8A7C, #FE7DAB);
-  color: #2800FF;
-`;
-
-const PricingPageButtonContent = styled.span`
-  padding: 0 0.5em 0.1em;
-  display: inline-block;
-  border-radius: var(--rounded);
-  background-color: white;
-`;
-
-const ImgBase = styled.img`
-  display: inline-block;
-  height: 1.5em;
-  width: auto;
-  color: inherit;
-  vertical-align: bottom;
-`;
-
-const BoostMarkImg = (props) => <ImgBase src={`${CDN_URL}/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2FBoost%20Mark%20for%20Export.svg`} {...props} />;
+const BoostMark = () => (
+  <img alt="" className={styles.boostMark} src={`${CDN_URL}/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2FBoost%20Mark%20for%20Export.svg`} />
+);
 
 const GlitchProCTA = () => {
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
@@ -51,18 +20,18 @@ const GlitchProCTA = () => {
 
   if (!isActive) {
     return (
-      <PricingPageButton size="small" as={Link} to="/pricing">
-        <PricingPageButtonContent>
-          Get PRO <BoostMarkImg />
-        </PricingPageButtonContent>
-      </PricingPageButton>
+      <Button className={styles.pricingPageButton} size="small" as={Link} to="/pricing">
+        <span className={styles.pricingPageButtonContent}>
+          Get PRO <BoostMark />
+        </span>
+      </Button>
     );
   }
 
   return (
-    <GlitchProBadge>
-      <BoostMarkImg /> PRO
-    </GlitchProBadge>
+    <span className={styles.glitchProBadge}>
+      <BoostMark /> PRO
+    </span>
   );
 };
 

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -4,10 +4,15 @@ import { Button } from '@fogcreek/shared-components';
 import Link from 'Components/link';
 import { useFeatureEnabled } from 'State/rollouts';
 import useSubscriptionStatus from 'State/subscription-status';
+import { CDN_URL } from 'Utils/constants';
 
-const SettingsPageLink = styled(Link)`
+const GlitchProBadge = styled.span`
   font-weight: bold;
+  font-size: var(--fontSizes-small);
   display: inline-block;
+  color: #2800FF;
+  padding-top: 2px;
+  margin-right: var(--space-1);
 `;
 
 const PricingPageButton = styled(Button)`
@@ -26,7 +31,7 @@ const PricingPageButtonContent = styled.span`
   background-color: white;
 `;
 
-const SVGBase = styled.svg`
+const ImgBase = styled.img`
   display: inline-block;
   height: 1.5em;
   width: auto;
@@ -34,28 +39,8 @@ const SVGBase = styled.svg`
   vertical-align: bottom;
 `;
 
-const BoostMark = ({ ...props }) => (
-  <SVGBase viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-    <path
-      d="M29.0658 7.43758C30.1482 6.61867 31.711 7.28202 31.8738 8.6295L33.0431 18.3059C33.1032 18.8032 33.3725 19.2513 33.7834 19.5379L41.7781 25.113C42.8915 25.8894 42.7435 27.5807 41.5123 28.1519L32.6708 32.2541C32.2164 32.465 31.8734 32.8595 31.7279 33.3389L28.8961 42.6652C28.5018 43.9639 26.8475 44.3458 25.9238 43.3514L19.2902 36.2103C18.9493 35.8433 18.468 35.639 17.9672 35.6487L8.22225 35.8375C6.86523 35.8638 5.99083 34.4086 6.65113 33.2228L11.3928 24.7071C11.6365 24.2695 11.6821 23.7487 11.5181 23.2753L8.32716 14.0657C7.88281 12.7832 8.99662 11.5019 10.3285 11.7634L19.8926 13.6416C20.3841 13.7381 20.8935 13.6205 21.293 13.3182L29.0658 7.43758Z"
-      fill="#FFAABF"
-    />
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M28.7479 12.0902L23.4159 16.1242C22.2174 17.0309 20.6892 17.3837 19.2146 17.0941L12.6538 15.8058L14.8427 22.1234C15.3347 23.5434 15.198 25.1058 14.4669 26.4188L11.2142 32.2604L17.899 32.1309C19.4016 32.1018 20.8453 32.7146 21.8681 33.8156L26.4186 38.7143L28.3612 32.3166C28.7978 30.8786 29.8267 29.6949 31.19 29.0624L37.255 26.2484L31.7708 22.4239C30.5381 21.5643 29.7303 20.2199 29.55 18.728L28.7479 12.0902ZM31.8738 8.6295C31.711 7.28202 30.1482 6.61867 29.0658 7.43758L21.293 13.3182C20.8935 13.6205 20.3841 13.7381 19.8926 13.6416L10.3285 11.7634C8.99662 11.5019 7.88281 12.7832 8.32716 14.0657L11.5181 23.2753C11.6821 23.7487 11.6365 24.2695 11.3928 24.7071L6.65113 33.2228C5.99083 34.4086 6.86523 35.8638 8.22225 35.8375L17.9672 35.6487C18.468 35.639 18.9493 35.8433 19.2902 36.2103L25.9238 43.3514C26.8475 44.3458 28.5018 43.9639 28.8961 42.6652L31.7279 33.3389C31.8734 32.8595 32.2164 32.465 32.6708 32.2541L41.5123 28.1519C42.7435 27.5807 42.8915 25.8894 41.7781 25.113L33.7834 19.5379C33.3725 19.2513 33.1032 18.8032 33.0431 18.3059L31.8738 8.6295Z"
-      fill="url(#paint0_linear)"
-    />
-    <defs>
-      <linearGradient id="paint0_linear" x1="33.8995" y1="14.1957" x2="12.6162" y2="35.8519" gradientUnits="userSpaceOnUse">
-        <stop stopColor="#C454FF" />
-        <stop offset="0.333333" stopColor="#2800FF" />
-        <stop offset="0.651042" stopColor="#FA8A7C" />
-        <stop offset="1" stopColor="#FE7DAB" />
-      </linearGradient>
-    </defs>
-  </SVGBase>
-);
+
+const BoostMarkImg = (props) => <ImgBase src={`${CDN_URL}/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2FBoost%20Mark%20for%20Export.svg`} {...props} />
 
 const GlitchProCTA = () => {
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
@@ -69,16 +54,16 @@ const GlitchProCTA = () => {
     return (
       <PricingPageButton size="small" as={Link} to="/pricing">
         <PricingPageButtonContent>
-          Get PRO <BoostMark />
+          Get PRO <BoostMarkImg />
         </PricingPageButtonContent>
       </PricingPageButton>
     );
   }
 
   return (
-    <SettingsPageLink to="/settings">
-      <BoostMark /> PRO
-    </SettingsPageLink>
+    <GlitchProBadge>
+      <BoostMarkImg /> PRO
+    </GlitchProBadge>
   );
 };
 

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -48,10 +48,10 @@ const BoostMark = ({ ...props }) => (
     />
     <defs>
       <linearGradient id="paint0_linear" x1="33.8995" y1="14.1957" x2="12.6162" y2="35.8519" gradientUnits="userSpaceOnUse">
-        <stop stop-color="#C454FF" />
-        <stop offset="0.333333" stop-color="#2800FF" />
-        <stop offset="0.651042" stop-color="#FA8A7C" />
-        <stop offset="1" stop-color="#FE7DAB" />
+        <stop stopColor="#C454FF" />
+        <stop offset="0.333333" stopColor="#2800FF" />
+        <stop offset="0.651042" stopColor="#FA8A7C" />
+        <stop offset="1" stopColor="#FE7DAB" />
       </linearGradient>
     </defs>
   </SVGBase>

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -1,19 +1,85 @@
+import React from 'react';
 import styled from 'styled-components';
 import { Button } from '@fogcreek/shared-components';
-import Link from 'Components/link'
-
+import Link from 'Components/link';
 import { useFeatureEnabled } from 'State/rollouts';
+import useSubscriptionStatus from 'State/subscription-status';
+
+const SettingsPageLink = styled(Link)`
+  font-weight: bold;
+  display: inline-block;
+`;
+
+const PricingPageButton = styled(Button)`
+  position: relative;
+  padding: 2px;
+  border: none;
+  line-height: 1.3;
+  background: linear-gradient(12deg, #C454FF, #2800FF, #FA8A7C, #FE7DAB);
+  color: #2800FF;
+`;
+
+const PricingPageButtonContent = styled.span`
+  padding: 0 0.5em 0.1em;
+  display: inline-block;
+  border-radius: var(--rounded);
+  background-color: white;
+`;
+
+const SVGBase = styled.svg`
+  display: inline-block;
+  height: 1.5em;
+  width: auto;
+  color: inherit;
+  vertical-align: bottom;
+`;
+
+const BoostMark = ({ ...props }) => (
+  <SVGBase viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M29.0658 7.43758C30.1482 6.61867 31.711 7.28202 31.8738 8.6295L33.0431 18.3059C33.1032 18.8032 33.3725 19.2513 33.7834 19.5379L41.7781 25.113C42.8915 25.8894 42.7435 27.5807 41.5123 28.1519L32.6708 32.2541C32.2164 32.465 31.8734 32.8595 31.7279 33.3389L28.8961 42.6652C28.5018 43.9639 26.8475 44.3458 25.9238 43.3514L19.2902 36.2103C18.9493 35.8433 18.468 35.639 17.9672 35.6487L8.22225 35.8375C6.86523 35.8638 5.99083 34.4086 6.65113 33.2228L11.3928 24.7071C11.6365 24.2695 11.6821 23.7487 11.5181 23.2753L8.32716 14.0657C7.88281 12.7832 8.99662 11.5019 10.3285 11.7634L19.8926 13.6416C20.3841 13.7381 20.8935 13.6205 21.293 13.3182L29.0658 7.43758Z"
+      fill="#FFAABF"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M28.7479 12.0902L23.4159 16.1242C22.2174 17.0309 20.6892 17.3837 19.2146 17.0941L12.6538 15.8058L14.8427 22.1234C15.3347 23.5434 15.198 25.1058 14.4669 26.4188L11.2142 32.2604L17.899 32.1309C19.4016 32.1018 20.8453 32.7146 21.8681 33.8156L26.4186 38.7143L28.3612 32.3166C28.7978 30.8786 29.8267 29.6949 31.19 29.0624L37.255 26.2484L31.7708 22.4239C30.5381 21.5643 29.7303 20.2199 29.55 18.728L28.7479 12.0902ZM31.8738 8.6295C31.711 7.28202 30.1482 6.61867 29.0658 7.43758L21.293 13.3182C20.8935 13.6205 20.3841 13.7381 19.8926 13.6416L10.3285 11.7634C8.99662 11.5019 7.88281 12.7832 8.32716 14.0657L11.5181 23.2753C11.6821 23.7487 11.6365 24.2695 11.3928 24.7071L6.65113 33.2228C5.99083 34.4086 6.86523 35.8638 8.22225 35.8375L17.9672 35.6487C18.468 35.639 18.9493 35.8433 19.2902 36.2103L25.9238 43.3514C26.8475 44.3458 28.5018 43.9639 28.8961 42.6652L31.7279 33.3389C31.8734 32.8595 32.2164 32.465 32.6708 32.2541L41.5123 28.1519C42.7435 27.5807 42.8915 25.8894 41.7781 25.113L33.7834 19.5379C33.3725 19.2513 33.1032 18.8032 33.0431 18.3059L31.8738 8.6295Z"
+      fill="url(#paint0_linear)"
+    />
+    <defs>
+      <linearGradient id="paint0_linear" x1="33.8995" y1="14.1957" x2="12.6162" y2="35.8519" gradientUnits="userSpaceOnUse">
+        <stop stop-color="#C454FF" />
+        <stop offset="0.333333" stop-color="#2800FF" />
+        <stop offset="0.651042" stop-color="#FA8A7C" />
+        <stop offset="1" stop-color="#FE7DAB" />
+      </linearGradient>
+    </defs>
+  </SVGBase>
+);
 
 const GlitchProCTA = () => {
-//   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
+  const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
+  const hasGlitchProEnabled = useSubscriptionStatus();
 
-//   if (!userHasPufferfishEnabled) {
-//     return null;
-//   }
-  
+  if (!userHasPufferfishEnabled) {
+    return null;
+  }
+
+  if (!hasGlitchProEnabled) {
+    return (
+      <PricingPageButton size="small" as={Link} to="/pricing">
+        <PricingPageButtonContent>
+          Get PRO <BoostMark width />
+        </PricingPageButtonContent>
+      </PricingPageButton>
+    );
+  }
+
   return (
-    <Button size="small" as={Link} to="/pricing">Glitch PRO</Button>
-  )
+    <SettingsPageLink to="/settings">
+      <BoostMark /> PRO
+    </SettingsPageLink>
+  );
 };
 
 export default GlitchProCTA;

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -59,13 +59,13 @@ const BoostMark = ({ ...props }) => (
 
 const GlitchProCTA = () => {
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
-  const hasGlitchProEnabled = useSubscriptionStatus();
+  const { fetched, isActive } = useSubscriptionStatus();
 
-  if (!userHasPufferfishEnabled) {
+  if (!userHasPufferfishEnabled || !fetched) {
     return null;
   }
 
-  if (!hasGlitchProEnabled) {
+  if (!isActive) {
     return (
       <PricingPageButton size="small" as={Link} to="/pricing">
         <PricingPageButtonContent>

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -69,7 +69,7 @@ const GlitchProCTA = () => {
     return (
       <PricingPageButton size="small" as={Link} to="/pricing">
         <PricingPageButtonContent>
-          Get PRO <BoostMark width />
+          Get PRO <BoostMark />
         </PricingPageButtonContent>
       </PricingPageButton>
     );

--- a/src/components/glitch-pro-cta/index.js
+++ b/src/components/glitch-pro-cta/index.js
@@ -39,8 +39,7 @@ const ImgBase = styled.img`
   vertical-align: bottom;
 `;
 
-
-const BoostMarkImg = (props) => <ImgBase src={`${CDN_URL}/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2FBoost%20Mark%20for%20Export.svg`} {...props} />
+const BoostMarkImg = (props) => <ImgBase src={`${CDN_URL}/0aa2fffe-82eb-4b72-a5e9-444d4b7ce805%2FBoost%20Mark%20for%20Export.svg`} {...props} />;
 
 const GlitchProCTA = () => {
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');

--- a/src/components/glitch-pro-cta/styles.styl
+++ b/src/components/glitch-pro-cta/styles.styl
@@ -1,0 +1,29 @@
+.glitchProBadge
+  font-weight: bold
+  font-size: var(--fontSizes-small)
+  display: inline-block
+  color: #2800FF
+  padding-top: 2px
+  margin-right: var(--space-1)
+
+
+.pricingPageButton
+  position: relative
+  padding: 2px
+  border: none
+  line-height: 1.3
+  background: linear-gradient(12deg, #C454FF, #2800FF, #FA8A7C, #FE7DAB)
+  color: #2800FF
+
+.pricingPageButtonContent
+  padding: 0 0.5em 0.1em
+  display: inline-block
+  border-radius: var(--rounded)
+  background-color: white
+
+.boostMark
+  display: inline-block
+  height: 1.5em
+  width: auto
+  color: inherit
+  vertical-align: bottom

--- a/src/components/header/header.styl
+++ b/src/components/header/header.styl
@@ -22,15 +22,17 @@
   
 .buttons
   padding: 0
-  margin: 8px 0 0
+  margin: 0
   list-style-type: none
   display: flex
   flex-direction: row
+  flex-wrap: wrap
   align-items: flex-start
   justify-content: flex-end
   
 .buttonWrap
-  margin-left: 10px 
+  margin-left: 10px
+  margin-top: 8px
 
 .visibleOnFocus
   position: absolute !important

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled';
+import styled from 'styled-components';
 import classnames from 'classnames';
 
 import { Button, Icon } from '@fogcreek/shared-components';
@@ -25,15 +25,60 @@ const ResumeCoding = () => (
 
 const ProLink = styled(Link)`
   font-weight: bold;
+  display: flex;
+  align-items: center;
+`;
 
-`
+const BoostMark = ({ ...props }) => (
+  <svg width="24" height="24" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M29.0658 7.43758C30.1482 6.61867 31.711 7.28202 31.8738 8.6295L33.0431 18.3059C33.1032 18.8032 33.3725 19.2513 33.7834 19.5379L41.7781 25.113C42.8915 25.8894 42.7435 27.5807 41.5123 28.1519L32.6708 32.2541C32.2164 32.465 31.8734 32.8595 31.7279 33.3389L28.8961 42.6652C28.5018 43.9639 26.8475 44.3458 25.9238 43.3514L19.2902 36.2103C18.9493 35.8433 18.468 35.639 17.9672 35.6487L8.22225 35.8375C6.86523 35.8638 5.99083 34.4086 6.65113 33.2228L11.3928 24.7071C11.6365 24.2695 11.6821 23.7487 11.5181 23.2753L8.32716 14.0657C7.88281 12.7832 8.99662 11.5019 10.3285 11.7634L19.8926 13.6416C20.3841 13.7381 20.8935 13.6205 21.293 13.3182L29.0658 7.43758Z"
+      fill="#FFAABF"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M28.7479 12.0902L23.4159 16.1242C22.2174 17.0309 20.6892 17.3837 19.2146 17.0941L12.6538 15.8058L14.8427 22.1234C15.3347 23.5434 15.198 25.1058 14.4669 26.4188L11.2142 32.2604L17.899 32.1309C19.4016 32.1018 20.8453 32.7146 21.8681 33.8156L26.4186 38.7143L28.3612 32.3166C28.7978 30.8786 29.8267 29.6949 31.19 29.0624L37.255 26.2484L31.7708 22.4239C30.5381 21.5643 29.7303 20.2199 29.55 18.728L28.7479 12.0902ZM31.8738 8.6295C31.711 7.28202 30.1482 6.61867 29.0658 7.43758L21.293 13.3182C20.8935 13.6205 20.3841 13.7381 19.8926 13.6416L10.3285 11.7634C8.99662 11.5019 7.88281 12.7832 8.32716 14.0657L11.5181 23.2753C11.6821 23.7487 11.6365 24.2695 11.3928 24.7071L6.65113 33.2228C5.99083 34.4086 6.86523 35.8638 8.22225 35.8375L17.9672 35.6487C18.468 35.639 18.9493 35.8433 19.2902 36.2103L25.9238 43.3514C26.8475 44.3458 28.5018 43.9639 28.8961 42.6652L31.7279 33.3389C31.8734 32.8595 32.2164 32.465 32.6708 32.2541L41.5123 28.1519C42.7435 27.5807 42.8915 25.8894 41.7781 25.113L33.7834 19.5379C33.3725 19.2513 33.1032 18.8032 33.0431 18.3059L31.8738 8.6295Z"
+      fill="url(#paint0_linear)"
+    />
+    <defs>
+      <linearGradient id="paint0_linear" x1="33.8995" y1="14.1957" x2="12.6162" y2="35.8519" gradientUnits="userSpaceOnUse">
+        <stop stop-color="#C454FF" />
+        <stop offset="0.333333" stop-color="#2800FF" />
+        <stop offset="0.651042" stop-color="#FA8A7C" />
+        <stop offset="1" stop-color="#FE7DAB" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+
+const ProLinkWrap = () => {
+  const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
+  const hasGlitchProEnabled = useSubscriptionStatus();
+  
+  if (!userHasPufferfishEnabled) { return null }
+  
+  {userHasPufferfishEnabled && !hasGlitchProEnabled && (
+              <li className={styles.buttonWrap}>
+                <Button size="small" as={Link} to="/pricing">
+                  Get PRO <BoostMark />
+                </Button>
+              </li>
+            )}
+            {userHasPufferfishEnabled && hasGlitchProEnabled && (
+              <li className={styles.buttonWrap}>
+                <ProLink to="/settings">
+                  <BoostMark /> PRO
+                </ProLink>
+              </li>
+            )}
+}
+
 
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, showNav }) => {
   const { currentUser } = useCurrentUser();
   const { SSR_SIGNED_IN } = useGlobals();
-  const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
-  const hasGlitchProEnabled = useSubscriptionStatus();
-  
+
   // signedIn and signedOut are both false on the server so the sign in button doesn't render
   const fakeSignedIn = !currentUser.id && SSR_SIGNED_IN;
   const signedIn = !!currentUser.login || fakeSignedIn;
@@ -54,20 +99,7 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, 
             <SearchForm defaultValue={searchQuery} />
           </div>
           <ul className={styles.buttons}>
-            {userHasPufferfishEnabled && !hasGlitchProEnabled && (
-              <li className={styles.buttonWrap}>
-                <Button size="small" as={Link} to="/pricing">
-                  Get PRO <Icon icon="sparkles" />
-                </Button>
-              </li>
-            )}
-            {userHasPufferfishEnabled && hasGlitchProEnabled && (
-              <li className={styles.buttonWrap}>
-                <ProLink to="/settings">
-                  <Icon icon="sparkles" /> PRO
-                </ProLink>
-              </li>
-            )}
+            
             <li className={classnames(styles.buttonWrap, !ssrHasHappened && styles.hiddenHack)}>
               <NewProjectPop />
             </li>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -8,9 +8,8 @@ import SearchForm from 'Components/search-form';
 import UserOptionsPop from 'Components/user-options-pop';
 import NewProjectPop from 'Components/new-project-pop';
 import Link from 'Components/link';
+import GlitchProCTA from 'Components/glitch-pro-cta';
 import { useCurrentUser } from 'State/current-user';
-import { useFeatureEnabled } from 'State/rollouts';
-import useSubscriptionStatus from 'State/subscription-status';
 import { useGlobals } from 'State/globals';
 import { EDITOR_URL } from 'Utils/constants';
 
@@ -22,72 +21,6 @@ const ResumeCoding = () => (
     Resume Coding
   </Button>
 );
-
-const SettingsPageLink = styled(Link)`
-  font-weight: bold;
-  display: inline-block;
-`;
-
-const PricingPageButton = styled(Button)`
-  padding-top: 0;
-  padding-bottom: 0.1em;
-  line-height: 1.3;
-  border-image: linear-gradient(#C454FF, #2800FF, #FA8A7C, #FE7DAB);
-`
-
-const SVGBase = styled.svg`
-  display: inline-block;
-  height: 1.5em;
-  width: auto;
-  color: inherit;
-  vertical-align: bottom;
-`;
-
-const BoostMark = ({ ...props }) => (
-  <SVGBase viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-    <path
-      d="M29.0658 7.43758C30.1482 6.61867 31.711 7.28202 31.8738 8.6295L33.0431 18.3059C33.1032 18.8032 33.3725 19.2513 33.7834 19.5379L41.7781 25.113C42.8915 25.8894 42.7435 27.5807 41.5123 28.1519L32.6708 32.2541C32.2164 32.465 31.8734 32.8595 31.7279 33.3389L28.8961 42.6652C28.5018 43.9639 26.8475 44.3458 25.9238 43.3514L19.2902 36.2103C18.9493 35.8433 18.468 35.639 17.9672 35.6487L8.22225 35.8375C6.86523 35.8638 5.99083 34.4086 6.65113 33.2228L11.3928 24.7071C11.6365 24.2695 11.6821 23.7487 11.5181 23.2753L8.32716 14.0657C7.88281 12.7832 8.99662 11.5019 10.3285 11.7634L19.8926 13.6416C20.3841 13.7381 20.8935 13.6205 21.293 13.3182L29.0658 7.43758Z"
-      fill="#FFAABF"
-    />
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M28.7479 12.0902L23.4159 16.1242C22.2174 17.0309 20.6892 17.3837 19.2146 17.0941L12.6538 15.8058L14.8427 22.1234C15.3347 23.5434 15.198 25.1058 14.4669 26.4188L11.2142 32.2604L17.899 32.1309C19.4016 32.1018 20.8453 32.7146 21.8681 33.8156L26.4186 38.7143L28.3612 32.3166C28.7978 30.8786 29.8267 29.6949 31.19 29.0624L37.255 26.2484L31.7708 22.4239C30.5381 21.5643 29.7303 20.2199 29.55 18.728L28.7479 12.0902ZM31.8738 8.6295C31.711 7.28202 30.1482 6.61867 29.0658 7.43758L21.293 13.3182C20.8935 13.6205 20.3841 13.7381 19.8926 13.6416L10.3285 11.7634C8.99662 11.5019 7.88281 12.7832 8.32716 14.0657L11.5181 23.2753C11.6821 23.7487 11.6365 24.2695 11.3928 24.7071L6.65113 33.2228C5.99083 34.4086 6.86523 35.8638 8.22225 35.8375L17.9672 35.6487C18.468 35.639 18.9493 35.8433 19.2902 36.2103L25.9238 43.3514C26.8475 44.3458 28.5018 43.9639 28.8961 42.6652L31.7279 33.3389C31.8734 32.8595 32.2164 32.465 32.6708 32.2541L41.5123 28.1519C42.7435 27.5807 42.8915 25.8894 41.7781 25.113L33.7834 19.5379C33.3725 19.2513 33.1032 18.8032 33.0431 18.3059L31.8738 8.6295Z"
-      fill="url(#paint0_linear)"
-    />
-    <defs>
-      <linearGradient id="paint0_linear" x1="33.8995" y1="14.1957" x2="12.6162" y2="35.8519" gradientUnits="userSpaceOnUse">
-        <stop stop-color="#C454FF" />
-        <stop offset="0.333333" stop-color="#2800FF" />
-        <stop offset="0.651042" stop-color="#FA8A7C" />
-        <stop offset="1" stop-color="#FE7DAB" />
-      </linearGradient>
-    </defs>
-  </SVGBase>
-);
-
-const ProLinkWrap = () => {
-  const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
-  const hasGlitchProEnabled = false; // useSubscriptionStatus();
-
-  if (!userHasPufferfishEnabled) {
-    return null;
-  }
-
-  if (!hasGlitchProEnabled) {
-    return (
-      <PricingPageButton size="small" as={Link} to="/pricing">
-        Get PRO <BoostMark width />
-      </PricingPageButton>
-    );
-  }
-
-  return (
-    <SettingsPageLink to="/settings">
-      <BoostMark /> PRO
-    </SettingsPageLink>
-  );
-};
 
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, showNav }) => {
   const { currentUser } = useCurrentUser();
@@ -114,7 +47,7 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, 
           </div>
           <ul className={styles.buttons}>
             <li className={styles.buttonWrap}>
-              <ProLinkWrap />
+              <GlitchProCTA />
             </li>
             <li className={classnames(styles.buttonWrap, !ssrHasHappened && styles.hiddenHack)}>
               <NewProjectPop />

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -8,6 +8,7 @@ import UserOptionsPop from 'Components/user-options-pop';
 import NewProjectPop from 'Components/new-project-pop';
 import Link from 'Components/link';
 import { useCurrentUser } from 'State/current-user';
+import { useFeatureEnabled } from 'State/rollouts';
 import { useGlobals } from 'State/globals';
 import { EDITOR_URL } from 'Utils/constants';
 
@@ -23,6 +24,7 @@ const ResumeCoding = () => (
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, showNav }) => {
   const { currentUser } = useCurrentUser();
   const { SSR_SIGNED_IN } = useGlobals();
+  const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
   // signedIn and signedOut are both false on the server so the sign in button doesn't render
   const fakeSignedIn = !currentUser.id && SSR_SIGNED_IN;
   const signedIn = !!currentUser.login || fakeSignedIn;
@@ -43,6 +45,13 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, 
             <SearchForm defaultValue={searchQuery} />
           </div>
           <ul className={styles.buttons}>
+            {userHasPufferfishEnabled && (
+              <li className={styles.buttonWrap}>
+                <Button size="small" as={Link} to="/pricing">
+                  Glitch PRO
+                </Button>
+              </li>
+            )}
             <li className={classnames(styles.buttonWrap, !ssrHasHappened && styles.hiddenHack)}>
               <NewProjectPop />
             </li>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -25,16 +25,22 @@ const ResumeCoding = () => (
 
 const SettingsPageLink = styled(Link)`
   font-weight: bold;
-  display: flex;
-  align-items: center;
+  display: inline-block;
 `;
+
+const PricingPageButton = styled(Button)`
+  padding-top: 0;
+  padding-bottom: 0.1em;
+  line-height: 1.3;
+  border-image: linear-gradient(#C454FF, #2800FF, #FA8A7C, #FE7DAB);
+`
 
 const SVGBase = styled.svg`
   display: inline-block;
-  height: 1em;
+  height: 1.5em;
   width: auto;
   color: inherit;
-  vertical-align: top;
+  vertical-align: bottom;
 `;
 
 const BoostMark = ({ ...props }) => (
@@ -62,7 +68,7 @@ const BoostMark = ({ ...props }) => (
 
 const ProLinkWrap = () => {
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
-  const hasGlitchProEnabled = true; // useSubscriptionStatus();
+  const hasGlitchProEnabled = false; // useSubscriptionStatus();
 
   if (!userHasPufferfishEnabled) {
     return null;
@@ -70,9 +76,9 @@ const ProLinkWrap = () => {
 
   if (!hasGlitchProEnabled) {
     return (
-      <Button size="small" as={Link} to="/pricing">
+      <PricingPageButton size="small" as={Link} to="/pricing">
         Get PRO <BoostMark width />
-      </Button>
+      </PricingPageButton>
     );
   }
 

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import classnames from 'classnames';
 
 import { Button } from '@fogcreek/shared-components';

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled';
 import classnames from 'classnames';
 
-import { Button } from '@fogcreek/shared-components';
+import { Button, Icon } from '@fogcreek/shared-components';
 import SearchForm from 'Components/search-form';
 import UserOptionsPop from 'Components/user-options-pop';
 import NewProjectPop from 'Components/new-project-pop';
 import Link from 'Components/link';
 import { useCurrentUser } from 'State/current-user';
 import { useFeatureEnabled } from 'State/rollouts';
+import useSubscriptionStatus from 'State/subscription-status';
 import { useGlobals } from 'State/globals';
 import { EDITOR_URL } from 'Utils/constants';
 
@@ -21,10 +23,17 @@ const ResumeCoding = () => (
   </Button>
 );
 
+const ProLink = styled(Link)`
+  font-weight: bold;
+
+`
+
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, showNav }) => {
   const { currentUser } = useCurrentUser();
   const { SSR_SIGNED_IN } = useGlobals();
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
+  const hasGlitchProEnabled = useSubscriptionStatus();
+  
   // signedIn and signedOut are both false on the server so the sign in button doesn't render
   const fakeSignedIn = !currentUser.id && SSR_SIGNED_IN;
   const signedIn = !!currentUser.login || fakeSignedIn;
@@ -45,11 +54,18 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, 
             <SearchForm defaultValue={searchQuery} />
           </div>
           <ul className={styles.buttons}>
-            {userHasPufferfishEnabled && (
+            {userHasPufferfishEnabled && !hasGlitchProEnabled && (
               <li className={styles.buttonWrap}>
                 <Button size="small" as={Link} to="/pricing">
-                  Glitch PRO
+                  Get PRO <Icon icon="sparkles" />
                 </Button>
+              </li>
+            )}
+            {userHasPufferfishEnabled && hasGlitchProEnabled && (
+              <li className={styles.buttonWrap}>
+                <ProLink to="/settings">
+                  <Icon icon="sparkles" /> PRO
+                </ProLink>
               </li>
             )}
             <li className={classnames(styles.buttonWrap, !ssrHasHappened && styles.hiddenHack)}>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classnames from 'classnames';
 
-import { Button, Icon } from '@fogcreek/shared-components';
+import { Button } from '@fogcreek/shared-components';
 import SearchForm from 'Components/search-form';
 import UserOptionsPop from 'Components/user-options-pop';
 import NewProjectPop from 'Components/new-project-pop';
@@ -23,14 +23,22 @@ const ResumeCoding = () => (
   </Button>
 );
 
-const ProLink = styled(Link)`
+const SettingsPageLink = styled(Link)`
   font-weight: bold;
   display: flex;
   align-items: center;
 `;
 
+const SVGBase = styled.svg`
+  display: inline-block;
+  height: 1em;
+  width: auto;
+  color: inherit;
+  vertical-align: top;
+`;
+
 const BoostMark = ({ ...props }) => (
-  <svg width="24" height="24" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+  <SVGBase viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
       d="M29.0658 7.43758C30.1482 6.61867 31.711 7.28202 31.8738 8.6295L33.0431 18.3059C33.1032 18.8032 33.3725 19.2513 33.7834 19.5379L41.7781 25.113C42.8915 25.8894 42.7435 27.5807 41.5123 28.1519L32.6708 32.2541C32.2164 32.465 31.8734 32.8595 31.7279 33.3389L28.8961 42.6652C28.5018 43.9639 26.8475 44.3458 25.9238 43.3514L19.2902 36.2103C18.9493 35.8433 18.468 35.639 17.9672 35.6487L8.22225 35.8375C6.86523 35.8638 5.99083 34.4086 6.65113 33.2228L11.3928 24.7071C11.6365 24.2695 11.6821 23.7487 11.5181 23.2753L8.32716 14.0657C7.88281 12.7832 8.99662 11.5019 10.3285 11.7634L19.8926 13.6416C20.3841 13.7381 20.8935 13.6205 21.293 13.3182L29.0658 7.43758Z"
       fill="#FFAABF"
@@ -49,31 +57,31 @@ const BoostMark = ({ ...props }) => (
         <stop offset="1" stop-color="#FE7DAB" />
       </linearGradient>
     </defs>
-  </svg>
+  </SVGBase>
 );
 
 const ProLinkWrap = () => {
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
-  const hasGlitchProEnabled = useSubscriptionStatus();
-  
-  if (!userHasPufferfishEnabled) { return null }
-  
-  {userHasPufferfishEnabled && !hasGlitchProEnabled && (
-              <li className={styles.buttonWrap}>
-                <Button size="small" as={Link} to="/pricing">
-                  Get PRO <BoostMark />
-                </Button>
-              </li>
-            )}
-            {userHasPufferfishEnabled && hasGlitchProEnabled && (
-              <li className={styles.buttonWrap}>
-                <ProLink to="/settings">
-                  <BoostMark /> PRO
-                </ProLink>
-              </li>
-            )}
-}
+  const hasGlitchProEnabled = true; // useSubscriptionStatus();
 
+  if (!userHasPufferfishEnabled) {
+    return null;
+  }
+
+  if (!hasGlitchProEnabled) {
+    return (
+      <Button size="small" as={Link} to="/pricing">
+        Get PRO <BoostMark width />
+      </Button>
+    );
+  }
+
+  return (
+    <SettingsPageLink to="/settings">
+      <BoostMark /> PRO
+    </SettingsPageLink>
+  );
+};
 
 const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, showNav }) => {
   const { currentUser } = useCurrentUser();
@@ -99,7 +107,9 @@ const Header = ({ searchQuery, showAccountSettingsOverlay, showNewStuffOverlay, 
             <SearchForm defaultValue={searchQuery} />
           </div>
           <ul className={styles.buttons}>
-            
+            <li className={styles.buttonWrap}>
+              <ProLinkWrap />
+            </li>
             <li className={classnames(styles.buttonWrap, !ssrHasHappened && styles.hiddenHack)}>
               <NewProjectPop />
             </li>

--- a/src/presenters/pages/about/pricing.js
+++ b/src/presenters/pages/about/pricing.js
@@ -26,8 +26,8 @@ const PricingPage = () => {
   async function subscribe() {
     try {
       const { data } = await createSubscriptionSession({
-        successUrl: `${APP_URL}${getUserLink(currentUser)}`,
-        cancelUrl: `${APP_URL}/settings`,
+        successUrl: `${window.location.origin}${getUserLink(currentUser)}`,
+        cancelUrl: `${window.location.origin}/settings`,
       });
       const { id: sessionId } = data;
       stripe.redirectToCheckout({ sessionId });

--- a/src/presenters/pages/about/pricing.js
+++ b/src/presenters/pages/about/pricing.js
@@ -10,7 +10,6 @@ import useStripe from 'State/stripe';
 import useSubscriptionStatus from 'State/subscription-status';
 import { useFeatureEnabled } from 'State/rollouts';
 import { getUserLink } from 'Models/user';
-import { APP_URL } from 'Utils/constants';
 
 import AboutLayout from './about-layout';
 import { NotFoundPage } from '../error';


### PR DESCRIPTION
## Links
* Remix link: https://discovered-seashore.glitch.me/
* Issue-tracker link: https://app.clubhouse.io/glitch/story/6405/add-a-cta-in-the-nav-bar

## GIF/Screenshots:

![Screen Shot 2020-01-15 at 10 20 17 AM](https://user-images.githubusercontent.com/938722/72446005-b4fc5a00-3780-11ea-8db8-b3cc7037952f.png)
![Screen Shot 2020-01-15 at 10 19 58 AM](https://user-images.githubusercontent.com/938722/72446006-b4fc5a00-3780-11ea-87fc-a5a832591030.png)

## Changes:
* add Glitch Pro link/button to nav bar
* use `window.location.origin` for redirect urls, so it redirects to the current remix

## How To Test:
- visit https://discovered-seashore.glitch.me/
  + the PRO link should not be visible to logged-out users
- log in with a new Glitch email address (you can add a "+" label to your existing glitch.com email, eg `justin+test1@glitch.com`)
  + the PRO link should not be visible to users not in the feature flag group
- visit https://discovered-seashore.glitch.me/@testing-team and click "Join Team"
- visit https://discovered-seashore.glitch.me/secret and set "Pufferfish" to "Enable"
- go back to https://discovered-seashore.glitch.me
  + there should be a button with bisexual lighting labeled "Get PRO ⭐️"
- click the Get PRO button
  + this should take you to https://discovered-seashore.glitch.me/pricing
- click Sign Up
  + this should take you to a Stripe checkout page
- submit the form
  + this should take you to your profile page
  + you will now have a private Extra Memory collection
  + you will now have a link in the nav bar labeled "⭐️ PRO"

## Feedback I'm looking for:
- mostly design feedback, I think -- ~I pulled the icon directly from Figma~, but I mostly just eyeballed the button and proportions
