### PR TITLE
Show star in collections list when it's an protected collection

### DIFF
--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -14,6 +14,7 @@ import ProjectItemSmall from 'Components/project/project-item-small';
 import { BookmarkAvatar, StarAvatar } from 'Components/images/avatar';
 import VisibilityContainer from 'Components/visibility-container';
 import { PrivateBadge } from 'Components/private-badge';
+import CollectionOptions from 'Components/collection/collection-options-pop';
 
 import { isDarkColor } from 'Utils/color';
 import { CDN_URL } from 'Utils/constants';
@@ -24,8 +25,6 @@ import { useNotifications } from 'State/notifications';
 import { useCurrentUser } from 'State/current-user';
 
 import { createCollection } from 'Models/collection';
-
-import CollectionOptions from './collection-options-pop';
 
 import styles from './collection-item.styl';
 import { emoji } from '../global.styl';
@@ -171,7 +170,9 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
         {(showCurator || isAuthorized) && (
           <div className={styles.header}>
             <div className={styles.curator}>{showCurator && <CollectionCuratorLoader collection={collection} />}</div>
-            {isAuthorized && <CollectionOptions collection={collection} deleteCollection={animateAndDeleteCollection} />}
+            {isAuthorized && !collection.isProtectedCollection && (
+              <CollectionOptions collection={collection} deleteCollection={animateAndDeleteCollection} />
+            )}
           </div>
         )}
 

--- a/src/components/collection/collection-item.js
+++ b/src/components/collection/collection-item.js
@@ -11,7 +11,7 @@ import { ProfileItem } from 'Components/profile-list';
 import { CollectionLink } from 'Components/link';
 import Row from 'Components/containers/row';
 import ProjectItemSmall from 'Components/project/project-item-small';
-import { BookmarkAvatar } from 'Components/images/avatar';
+import { BookmarkAvatar, StarAvatar } from 'Components/images/avatar';
 import VisibilityContainer from 'Components/visibility-container';
 import { PrivateBadge } from 'Components/private-badge';
 
@@ -182,6 +182,7 @@ const CollectionItem = ({ collection, deleteCollection, isAuthorized, showCurato
             style={collectionColorStyles(collection)}
             label={`${collection.private ? 'private ' : ''}${collection.name}`}
           >
+            {collection.isProtectedCollection && <StarAvatar className={styles.starAvatar} />}
             <div className={styles.nameDescriptionContainer}>
               <div className={styles.itemButtonWrap}>
                 <Button textWrap as="span">

--- a/src/components/collection/collection-item.styl
+++ b/src/components/collection/collection-item.styl
@@ -274,3 +274,9 @@ svg.arrow
     left: 0
     position: absolute
     z-index: 1
+
+.starAvatar
+  height: 3.5em;
+  width: auto;
+  margin-right: 10px;
+  vertical-align: top;

--- a/src/state/collection.js
+++ b/src/state/collection.js
@@ -45,7 +45,7 @@ function loadCollectionProjects(api, collections, setResponses, withCacheBust) {
   });
 }
 
-const CollectionProjectContext = createContext();
+export const CollectionProjectContext = createContext();
 const CollectionReloadContext = createContext();
 
 // we mock out the projects for the placeholder my stuff collections

--- a/test/components/collection/collection-item.js
+++ b/test/components/collection/collection-item.js
@@ -4,6 +4,8 @@ import { expect } from 'chai';
 
 import CollectionItem from 'Components/collection/collection-item';
 import { StarAvatar } from 'Components/images/avatar';
+import CollectionOptions from 'Components/collection/collection-options-pop';
+
 import MockContext from '../../helpers/mockContext';
 
 describe('CollectionItem', function() {
@@ -16,6 +18,8 @@ describe('CollectionItem', function() {
         coverColor: '',
         fullUrl: '',
       },
+      deleteCollection: () => {},
+      isAuthorized: true,
     };
   });
 
@@ -39,6 +43,22 @@ describe('CollectionItem', function() {
 
       expect(wrapper.find(StarAvatar).length).to.equal(1);
     });
+
+    it('does not render a collection options dropdown', () => {
+      const wrapper = mount(
+        <MockContext
+          currentUser={{ id: 1 }}
+          location={'collectionPage'}
+          getCollectionProjects={() => {
+            return [];
+          }}
+        >
+          <CollectionItem {...this.props} />
+        </MockContext>,
+      );
+
+      expect(wrapper.find(CollectionOptions).length).to.equal(0);
+    });
   });
 
   context('when collection.isProtectedCollection is false', () => {
@@ -60,6 +80,22 @@ describe('CollectionItem', function() {
       );
 
       expect(wrapper.find(StarAvatar).length).to.equal(0);
+    });
+
+    it('renders a collection options dropdown', () => {
+      const wrapper = mount(
+        <MockContext
+          currentUser={{ id: 1 }}
+          location={'collectionPage'}
+          getCollectionProjects={() => {
+            return [];
+          }}
+        >
+          <CollectionItem {...this.props} />
+        </MockContext>,
+      );
+
+      expect(wrapper.find(CollectionOptions).length).to.equal(1);
     });
   });
 });

--- a/test/components/collection/collection-item.js
+++ b/test/components/collection/collection-item.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import CollectionItem from 'Components/collection/collection-item';
+import { StarAvatar } from 'Components/images/avatar';
+import MockContext from '../../helpers/mockContext';
+
+describe('CollectionItem', function() {
+  beforeEach(() => {
+    this.props = {
+      collection: {
+        id: 1,
+        name: '',
+        description: '',
+        coverColor: '',
+        fullUrl: '',
+      },
+    };
+  });
+
+  context('when collection.isProtectedCollection is true', () => {
+    beforeEach(() => {
+      this.props.collection.isProtectedCollection = true;
+    });
+
+    it('shows a star avatar', () => {
+      const wrapper = mount(
+        <MockContext
+          currentUser={{ id: 1 }}
+          location={'collectionPage'}
+          getCollectionProjects={() => {
+            return [];
+          }}
+        >
+          <CollectionItem {...this.props} />
+        </MockContext>,
+      );
+
+      expect(wrapper.find(StarAvatar).length).to.equal(1);
+    });
+  });
+
+  context('when collection.isProtectedCollection is false', () => {
+    beforeEach(() => {
+      this.props.collection.isProtectedCollection = false;
+    });
+
+    it('does not show a star avatar', () => {
+      const wrapper = mount(
+        <MockContext
+          currentUser={{ id: 1 }}
+          location={'collectionPage'}
+          getCollectionProjects={() => {
+            return [];
+          }}
+        >
+          <CollectionItem {...this.props} />
+        </MockContext>,
+      );
+
+      expect(wrapper.find(StarAvatar).length).to.equal(0);
+    });
+  });
+});

--- a/test/helpers/mockContext.js
+++ b/test/helpers/mockContext.js
@@ -3,7 +3,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { Context as GlobalsContext } from 'State/globals';
 import { MemoryRouter } from 'react-router-dom';
 import { context as NotificationContext } from 'State/notifications';
-
+import { CollectionProjectContext } from 'State/collection'
 import Location from '@jedmao/location';
 
 import configureStore from 'redux-mock-store';
@@ -12,7 +12,7 @@ import configureStore from 'redux-mock-store';
 const middlewares = [];
 const mockStore = configureStore(middlewares);
 
-export default ({ children, currentUser, location }) => {
+export default ({ children, currentUser, location, getCollectionProjects }) => {
   const reduxStore = mockStore({ currentUser });
 
   return (
@@ -20,7 +20,9 @@ export default ({ children, currentUser, location }) => {
       <MemoryRouter initialEntries={[location]} initialIndex={0}>
         <GlobalsContext.Provider value={{ location: new Location(`https://glitch.com/${location}`), EXTERNAL_ROUTES: [] }}>
           <ReduxProvider store={reduxStore}>
-            {children}
+            <CollectionProjectContext.Provider value={getCollectionProjects}>
+              {children}
+            </CollectionProjectContext.Provider>
           </ReduxProvider>
         </GlobalsContext.Provider>
       </MemoryRouter>

--- a/test/helpers/mockContext.js
+++ b/test/helpers/mockContext.js
@@ -3,11 +3,10 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { Context as GlobalsContext } from 'State/globals';
 import { MemoryRouter } from 'react-router-dom';
 import { context as NotificationContext } from 'State/notifications';
-import { CollectionProjectContext } from 'State/collection'
+import { CollectionProjectContext } from 'State/collection';
 import Location from '@jedmao/location';
 
 import configureStore from 'redux-mock-store';
-
 
 const middlewares = [];
 const mockStore = configureStore(middlewares);
@@ -20,12 +19,10 @@ export default ({ children, currentUser, location, getCollectionProjects }) => {
       <MemoryRouter initialEntries={[location]} initialIndex={0}>
         <GlobalsContext.Provider value={{ location: new Location(`https://glitch.com/${location}`), EXTERNAL_ROUTES: [] }}>
           <ReduxProvider store={reduxStore}>
-            <CollectionProjectContext.Provider value={getCollectionProjects}>
-              {children}
-            </CollectionProjectContext.Provider>
+            <CollectionProjectContext.Provider value={getCollectionProjects}>{children}</CollectionProjectContext.Provider>
           </ReduxProvider>
         </GlobalsContext.Provider>
       </MemoryRouter>
     </NotificationContext.Provider>
-  )
-}
+  );
+};


### PR DESCRIPTION
## Links
* Remix link: https://sarah-staging.glitch.me/
* Issue-tracker link:
    - https://app.clubhouse.io/glitch/story/6407/render-the-extra-memory-collection-in-a-collectionslist-on-user-profile-pages
    - https://app.clubhouse.io/glitch/story/7187/extra-memory-should-not-have-delete-menu
* Specs/doc links

## GIF/Screenshots:
<img width="1178" alt="Screen Shot 2020-01-17 at 2 21 49 PM" src="https://user-images.githubusercontent.com/6620164/72639925-ba9aa100-3934-11ea-927d-92cccd6a6ce4.png">

## Changes:
* adds a star avatar for to a collections list
* hides delete dropdown if it's a special collection

## How To Test:
* join the testing team, enable pufferfish, go pro, check out on your user page, double check that the rest of the collections lists look good

## Feedback I'm looking for:
anything!

